### PR TITLE
feat(rs): replace strip-ansi with vt100 virtual terminal emulator

### DIFF
--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -48,6 +48,7 @@ serde_yaml = "0.9"
 # Terminal handling
 crossterm = "0.27"
 strip-ansi-escapes = "0.2"
+vt100-ctt = "0.17"
 
 # Directories
 dirs = "5"

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -196,6 +196,10 @@ impl AgentContext {
         if let Err(e) = pty.resize(initial_size.0, initial_size.1) {
             warn!("Initial PTY resize to {}x{} failed: {}", initial_size.0, initial_size.1, e);
         }
+        // Keep vterm in sync with the same initial size, otherwise vterm
+        // could remain stuck at AgentContext::new() dimensions until the
+        // first SIGWINCH fires.
+        self.vterm.resize(initial_size.1, initial_size.0);
 
         // Suppress unused-variable warning on non-unix where resize_tx is never moved
         #[cfg(not(unix))]
@@ -405,10 +409,14 @@ impl AgentContext {
         // Feed raw output to virtual terminal emulator for accurate screen state
         self.vterm.process(output.as_bytes());
 
-        // Write back any terminal query responses (DSR, DA) to child process
-        for response in self.vterm.take_responses() {
+        // Write back any terminal query responses (DSR, DA) to child process.
+        // Lock once and batch all responses to keep them atomic w.r.t. other writers.
+        let responses = self.vterm.take_responses();
+        if !responses.is_empty() {
             let mut w = msg_ctx.writer.lock().map_err(|e| anyhow::anyhow!("Lock: {}", e))?;
-            w.write_all(&response)?;
+            for response in responses {
+                w.write_all(&response)?;
+            }
             w.flush()?;
         }
 
@@ -467,9 +475,11 @@ impl AgentContext {
                     self.last_idle_scan_at = Some(Instant::now());
                     let buffer = self.vterm.contents();
                     let buffer_hash = hash_str(&buffer);
-                    // Skip if screen hasn't changed since last action — prevents
-                    // resurrecting an already-handled prompt during idle.
-                    if Some(buffer_hash) != self.last_action_screen_hash {
+                    // Skip if screen still equals the last handled action.
+                    // If it diverges, clear the suppression so identical
+                    // prompts can be re-handled after intervening output.
+                    if self.last_action_screen_hash != Some(buffer_hash) {
+                        self.last_action_screen_hash = None;
                         for pattern in &self.cli_config.enter {
                             if pattern.is_match(&buffer) {
                                 debug!("Idle scan: enter pattern matched after {}ms idle", idle_ms);
@@ -603,9 +613,13 @@ impl AgentContext {
         // this, vterm.contents() persists matched prompts and would
         // re-trigger every time check_patterns() runs.
         let current_hash = hash_str(&buffer);
-        if Some(current_hash) == self.last_action_screen_hash {
+        if self.last_action_screen_hash == Some(current_hash) {
             return Ok(());
         }
+        // Screen has diverged from the last handled action — clear the
+        // suppression so that if an identical prompt later reappears (after
+        // any intervening output), one-shot patterns can fire again.
+        self.last_action_screen_hash = None;
 
         // Check typing response patterns
         for (response, patterns) in &self.cli_config.typing_respond {

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -46,6 +46,11 @@ pub struct AgentContext {
     vterm: VTermProxy,
     start_time: Instant,
 
+    // Hash of vterm screen contents at the last typing_respond/enter match.
+    // Suppresses re-trigger of one-shot patterns until the screen actually
+    // changes (vterm contents() persists, unlike the old append-only buffer).
+    last_action_screen_hash: Option<u64>,
+
     // Enter key scheduling
     pending_enter: bool,
     pending_enter_detected_at: Option<Instant>,
@@ -109,6 +114,7 @@ impl AgentContext {
             cwd,
             stdin_line_buffer: String::new(),
             codex_session_found: false,
+            last_action_screen_hash: None,
         }
     }
 
@@ -460,14 +466,20 @@ impl AgentContext {
                 if should_scan {
                     self.last_idle_scan_at = Some(Instant::now());
                     let buffer = self.vterm.contents();
-                    for pattern in &self.cli_config.enter {
-                        if pattern.is_match(&buffer) {
-                            debug!("Idle scan: enter pattern matched after {}ms idle", idle_ms);
-                            self.pending_enter = true;
-                            self.pending_enter_detected_at = Some(Instant::now());
-                            self.enter_sent_at = None;
-                            self.enter_retry_count = 0;
-                            break;
+                    let buffer_hash = hash_str(&buffer);
+                    // Skip if screen hasn't changed since last action — prevents
+                    // resurrecting an already-handled prompt during idle.
+                    if Some(buffer_hash) != self.last_action_screen_hash {
+                        for pattern in &self.cli_config.enter {
+                            if pattern.is_match(&buffer) {
+                                debug!("Idle scan: enter pattern matched after {}ms idle", idle_ms);
+                                self.pending_enter = true;
+                                self.pending_enter_detected_at = Some(Instant::now());
+                                self.enter_sent_at = None;
+                                self.enter_retry_count = 0;
+                                self.last_action_screen_hash = Some(buffer_hash);
+                                break;
+                            }
                         }
                     }
                 }
@@ -586,15 +598,23 @@ impl AgentContext {
             return Ok(());
         }
 
+        // One-shot pattern suppression: if the screen hasn't changed since
+        // the last typing_respond/enter match, skip those checks. Without
+        // this, vterm.contents() persists matched prompts and would
+        // re-trigger every time check_patterns() runs.
+        let current_hash = hash_str(&buffer);
+        if Some(current_hash) == self.last_action_screen_hash {
+            return Ok(());
+        }
+
         // Check typing response patterns
         for (response, patterns) in &self.cli_config.typing_respond {
             for pattern in patterns {
                 if pattern.is_match(&buffer) {
                     debug!("Typing response pattern matched, sending: {:?}", response);
                     send_text(msg_ctx, response).await?;
-                    // Clear raw buffer to prevent re-triggering
-                    // (vterm screen will be overwritten by new output naturally)
                     self.output_buffer.clear();
+                    self.last_action_screen_hash = Some(current_hash);
                     return Ok(());
                 }
             }
@@ -609,8 +629,8 @@ impl AgentContext {
                     self.pending_enter_detected_at = Some(Instant::now());
                     self.enter_sent_at = None;
                     self.enter_retry_count = 0;
-                    // Clear raw buffer to prevent re-triggering
                     self.output_buffer.clear();
+                    self.last_action_screen_hash = Some(current_hash);
                 }
                 return Ok(());
             }
@@ -618,6 +638,14 @@ impl AgentContext {
 
         Ok(())
     }
+}
+
+/// Hash a string with the default hasher — used to detect screen state changes.
+fn hash_str(s: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    s.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// Find the nearest char boundary at or after `at`, so split_off won't panic on multi-byte UTF-8.

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -51,6 +51,12 @@ pub struct AgentContext {
     // changes (vterm contents() persists, unlike the old append-only buffer).
     last_action_screen_hash: Option<u64>,
 
+    // Hash of vterm screen contents at the last full pattern check. Used to
+    // short-circuit check_patterns() entirely when nothing on screen changed
+    // — heartbeat_check() can call check_patterns() every 50ms for no_eol
+    // CLIs, so re-running all regexes on an unchanged screen is wasteful.
+    last_checked_screen_hash: Option<u64>,
+
     // Enter key scheduling
     pending_enter: bool,
     pending_enter_detected_at: Option<Instant>,
@@ -115,6 +121,7 @@ impl AgentContext {
             stdin_line_buffer: String::new(),
             codex_session_found: false,
             last_action_screen_hash: None,
+            last_checked_screen_hash: None,
         }
     }
 
@@ -569,6 +576,16 @@ impl AgentContext {
         // Use vterm rendered screen for pattern matching (correctly handles cursor movement, clearing, etc.)
         let buffer = self.vterm.contents();
 
+        // Short-circuit if screen contents are byte-identical to the last
+        // check. Sticky state (is_fatal, ready, pending_enter) cannot transition
+        // without a screen change, and one-shot patterns are already suppressed
+        // via last_action_screen_hash, so re-running all regexes is pure waste.
+        let buffer_hash = hash_str(&buffer);
+        if self.last_checked_screen_hash == Some(buffer_hash) {
+            return Ok(());
+        }
+        self.last_checked_screen_hash = Some(buffer_hash);
+
         // Check fatal patterns first (only if not already matched)
         if !self.is_fatal {
             for pattern in &self.cli_config.fatal {
@@ -612,8 +629,7 @@ impl AgentContext {
         // the last typing_respond/enter match, skip those checks. Without
         // this, vterm.contents() persists matched prompts and would
         // re-trigger every time check_patterns() runs.
-        let current_hash = hash_str(&buffer);
-        if self.last_action_screen_hash == Some(current_hash) {
+        if self.last_action_screen_hash == Some(buffer_hash) {
             return Ok(());
         }
         // Screen has diverged from the last handled action — clear the
@@ -628,7 +644,7 @@ impl AgentContext {
                     debug!("Typing response pattern matched, sending: {:?}", response);
                     send_text(msg_ctx, response).await?;
                     self.output_buffer.clear();
-                    self.last_action_screen_hash = Some(current_hash);
+                    self.last_action_screen_hash = Some(buffer_hash);
                     return Ok(());
                 }
             }
@@ -644,7 +660,7 @@ impl AgentContext {
                     self.enter_sent_at = None;
                     self.enter_retry_count = 0;
                     self.output_buffer.clear();
-                    self.last_action_screen_hash = Some(current_hash);
+                    self.last_action_screen_hash = Some(buffer_hash);
                 }
                 return Ok(());
             }

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -7,7 +7,8 @@ use crate::log_files::LogWriter;
 use crate::messaging::{send_ctrl_c, send_text, MessageContext};
 use crate::pty_spawner::{get_terminal_size, get_terminal_size_from_tty, PtyContext};
 use crate::ready_manager::ReadyManager;
-use crate::utils::{remove_control_characters, sleep_ms};
+use crate::utils::sleep_ms;
+use crate::vterm::VTermProxy;
 use anyhow::Result;
 use crossterm::terminal;
 use std::io::Write;
@@ -42,7 +43,7 @@ pub struct AgentContext {
 
     // Buffer for pattern matching
     output_buffer: String,
-    rendered_output: String,
+    vterm: VTermProxy,
     start_time: Instant,
 
     // Enter key scheduling
@@ -79,6 +80,8 @@ impl AgentContext {
         auto_yes_enabled: bool,
         cwd: String,
         pid: u32,
+        term_rows: u16,
+        term_cols: u16,
     ) -> Self {
         Self {
             cli,
@@ -94,7 +97,7 @@ impl AgentContext {
             next_stdout: ReadyManager::new(),
             idle_waiter: IdleWaiter::new(),
             output_buffer: String::new(),
-            rendered_output: String::new(),
+            vterm: VTermProxy::new(term_rows, term_cols),
             start_time: Instant::now(),
             pending_enter: false,
             pending_enter_detected_at: None,
@@ -245,6 +248,7 @@ impl AgentContext {
                     if let Err(e) = pty.resize(cols, rows) {
                         warn!("PTY resize to {}x{} failed: {}", cols, rows, e);
                     }
+                    self.vterm.resize(rows, cols);
                 }
 
                 // Stdin data
@@ -322,8 +326,9 @@ impl AgentContext {
                         }
                         if idle > timeout {
                             // Check if still working
+                            let screen = self.vterm.contents();
                             let is_working = self.cli_config.working.iter()
-                                .any(|p| p.is_match(&self.rendered_output));
+                                .any(|p| p.is_match(&screen));
 
                             debug!("Idle check: idle={}ms, timeout={}ms, is_working={}", idle, timeout, is_working);
 
@@ -390,8 +395,16 @@ impl AgentContext {
 
         // Update buffers
         self.output_buffer.push_str(output);
-        let stripped = remove_control_characters(output);
-        self.rendered_output.push_str(&stripped);
+
+        // Feed raw output to virtual terminal emulator for accurate screen state
+        self.vterm.process(output.as_bytes());
+
+        // Write back any terminal query responses (DSR, DA) to child process
+        for response in self.vterm.take_responses() {
+            let mut w = msg_ctx.writer.lock().map_err(|e| anyhow::anyhow!("Lock: {}", e))?;
+            w.write_all(&response)?;
+            w.flush()?;
+        }
 
         // Extract and store codex session ID (once per session)
         if self.cli == "codex" && !self.codex_session_found {
@@ -402,14 +415,11 @@ impl AgentContext {
             }
         }
 
-        // Keep buffer size reasonable
+        // Keep raw output buffer size reasonable
         if self.output_buffer.len() > 100000 {
             debug!("Output buffer truncated (was {} bytes)", self.output_buffer.len());
             let split_at = find_char_boundary(&self.output_buffer, 50000);
             self.output_buffer = self.output_buffer.split_off(split_at);
-            let rendered_len = self.rendered_output.len();
-            let rendered_split = find_char_boundary(&self.rendered_output, 50000.min(rendered_len));
-            self.rendered_output = self.rendered_output.split_off(rendered_split);
         }
 
         // Mark stdout received
@@ -417,6 +427,7 @@ impl AgentContext {
 
         // Only ping activity if there's visible content (not just ANSI codes)
         // This prevents cursor control sequences from resetting the idle timer
+        let stripped = strip_ansi_escapes::strip_str(output);
         if !stripped.trim().is_empty() {
             self.idle_waiter.ping();
         }
@@ -429,21 +440,8 @@ impl AgentContext {
 
     /// Heartbeat pattern check (for cursor-based rendering)
     async fn heartbeat_check(&mut self, msg_ctx: &mut MessageContext) -> Result<()> {
-        // Handle Device Attributes request
-        if self.output_buffer.contains("\x1b[c") || self.output_buffer.contains("\x1b[0c") {
-            debug!("Responding to DA request");
-            let mut w = msg_ctx.writer.lock().map_err(|e| anyhow::anyhow!("Lock: {}", e))?;
-            w.write_all(b"\x1b[?1;2c")?; // VT100 with AVO
-            w.flush()?;
-        }
-
-        // Handle cursor position request
-        if self.output_buffer.contains("\x1b[6n") {
-            debug!("Responding to cursor position request");
-            let mut w = msg_ctx.writer.lock().map_err(|e| anyhow::anyhow!("Lock: {}", e))?;
-            w.write_all(b"\x1b[1;1R")?; // Position 1,1
-            w.flush()?;
-        }
+        // Terminal query responses (DSR, DA) are now handled automatically
+        // by VTermProxy in handle_output() via vt100 callbacks.
 
         // Check patterns on heartbeat (for no-EOL CLIs)
         if self.cli_config.no_eol {
@@ -461,9 +459,9 @@ impl AgentContext {
                 };
                 if should_scan {
                     self.last_idle_scan_at = Some(Instant::now());
-                    let buffer = &self.rendered_output;
+                    let buffer = self.vterm.contents();
                     for pattern in &self.cli_config.enter {
-                        if pattern.is_match(buffer) {
+                        if pattern.is_match(&buffer) {
                             debug!("Idle scan: enter pattern matched after {}ms idle", idle_ms);
                             self.pending_enter = true;
                             self.pending_enter_detected_at = Some(Instant::now());
@@ -546,13 +544,13 @@ impl AgentContext {
 
     /// Check patterns and respond accordingly
     async fn check_patterns(&mut self, msg_ctx: &mut MessageContext) -> Result<()> {
-        // Use rendered output (ANSI codes stripped) for pattern matching
-        let buffer = &self.rendered_output;
+        // Use vterm rendered screen for pattern matching (correctly handles cursor movement, clearing, etc.)
+        let buffer = self.vterm.contents();
 
         // Check fatal patterns first (only if not already matched)
         if !self.is_fatal {
             for pattern in &self.cli_config.fatal {
-                if pattern.is_match(buffer) {
+                if pattern.is_match(&buffer) {
                     error!("Fatal pattern matched: {}", pattern);
                     self.is_fatal = true;
                     return Ok(());
@@ -563,7 +561,7 @@ impl AgentContext {
         // Check restart-without-continue patterns (only if not already matched)
         if !self.should_restart_without_continue {
             for pattern in &self.cli_config.restart_without_continue {
-                if pattern.is_match(buffer) {
+                if pattern.is_match(&buffer) {
                     warn!("Restart without continue pattern matched");
                     self.should_restart_without_continue = true;
                     break;
@@ -573,7 +571,7 @@ impl AgentContext {
 
         // Check ready patterns
         for pattern in &self.cli_config.ready {
-            if pattern.is_match(buffer) {
+            if pattern.is_match(&buffer) {
                 if !self.stdin_ready.is_ready().await {
                     debug!("Ready pattern matched");
                     self.stdin_ready.ready().await;
@@ -591,12 +589,12 @@ impl AgentContext {
         // Check typing response patterns
         for (response, patterns) in &self.cli_config.typing_respond {
             for pattern in patterns {
-                if pattern.is_match(buffer) {
+                if pattern.is_match(&buffer) {
                     debug!("Typing response pattern matched, sending: {:?}", response);
                     send_text(msg_ctx, response).await?;
-                    // Clear buffer to prevent re-triggering
+                    // Clear raw buffer to prevent re-triggering
+                    // (vterm screen will be overwritten by new output naturally)
                     self.output_buffer.clear();
-                    self.rendered_output.clear();
                     return Ok(());
                 }
             }
@@ -604,16 +602,15 @@ impl AgentContext {
 
         // Check enter patterns
         for pattern in &self.cli_config.enter {
-            if pattern.is_match(buffer) {
+            if pattern.is_match(&buffer) {
                 if !self.pending_enter {
                     debug!("Enter pattern matched, scheduling Enter after idle");
                     self.pending_enter = true;
                     self.pending_enter_detected_at = Some(Instant::now());
                     self.enter_sent_at = None;
                     self.enter_retry_count = 0;
-                    // Clear buffer to prevent re-triggering
+                    // Clear raw buffer to prevent re-triggering
                     self.output_buffer.clear();
-                    self.rendered_output.clear();
                 }
                 return Ok(());
             }

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -13,6 +13,7 @@ mod ready_manager;
 mod running_lock;
 mod swarm;
 mod utils;
+mod vterm;
 mod webhook;
 
 use anyhow::Result;
@@ -147,6 +148,7 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
         let mut ctx = spawn_agent(&args.cli, &cmd_args, &cli_config, cwd, args.verbose).await?;
 
         // Create agent context (also initialises log file)
+        let (term_cols, term_rows) = crate::pty_spawner::get_terminal_size();
         let mut agent_ctx = AgentContext::new(
             args.cli.clone(),
             cli_config.clone(),
@@ -155,6 +157,8 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
             args.auto_yes,
             cwd.to_string(),
             pid,
+            term_rows,
+            term_cols,
         );
 
         // Register in PID store and send RUNNING webhook

--- a/rs/src/utils.rs
+++ b/rs/src/utils.rs
@@ -8,40 +8,9 @@ pub async fn sleep_ms(ms: u64) {
     sleep(Duration::from_millis(ms)).await;
 }
 
-/// Remove ANSI control characters from string
-pub fn remove_control_characters(s: &str) -> String {
-    strip_ansi_escapes::strip_str(s).to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_remove_control_characters() {
-        let input = "\x1b[31mHello\x1b[0m World";
-        let output = remove_control_characters(input);
-        assert_eq!(output, "Hello World");
-    }
-
-    #[test]
-    fn test_remove_cursor_movement() {
-        let input = "\x1b[2J\x1b[1;1HClear and move";
-        let output = remove_control_characters(input);
-        assert_eq!(output, "Clear and move");
-    }
-
-    #[test]
-    fn test_remove_control_characters_plain() {
-        let input = "no ansi here";
-        let output = remove_control_characters(input);
-        assert_eq!(output, "no ansi here");
-    }
-
-    #[test]
-    fn test_remove_control_characters_empty() {
-        assert_eq!(remove_control_characters(""), "");
-    }
 
     #[tokio::test]
     async fn test_sleep_ms() {

--- a/rs/src/vterm.rs
+++ b/rs/src/vterm.rs
@@ -87,7 +87,11 @@ pub struct VTermProxy {
 
 impl VTermProxy {
     /// Create a new virtual terminal with the given dimensions.
+    /// Dimensions are clamped to at least 1×1 to avoid panics in the
+    /// underlying vt100 parser when upstream size detection yields 0.
     pub fn new(rows: u16, cols: u16) -> Self {
+        let rows = rows.max(1);
+        let cols = cols.max(1);
         let collector = ResponseCollector::default();
         let parser = vt100_ctt::Parser::new_with_callbacks(rows, cols, 1000, collector.clone());
         Self { parser, collector }
@@ -139,8 +143,11 @@ impl VTermProxy {
         self.parser.screen().cursor_position()
     }
 
-    /// Resize the virtual terminal.
+    /// Resize the virtual terminal. Dimensions are clamped to at least 1×1
+    /// to match the same guard in `new()`.
     pub fn resize(&mut self, rows: u16, cols: u16) {
+        let rows = rows.max(1);
+        let cols = cols.max(1);
         self.parser.screen_mut().set_size(rows, cols);
     }
 }
@@ -238,6 +245,19 @@ mod tests {
         let (row, col) = vt.parser.screen().size();
         assert_eq!(row, 30);
         assert_eq!(col, 120);
+    }
+
+    #[test]
+    fn test_zero_dimensions_clamped() {
+        // Both new() and resize() must clamp 0 → 1 to avoid vt100 panics
+        let mut vt = VTermProxy::new(0, 0);
+        let (row, col) = vt.parser.screen().size();
+        assert!(row >= 1);
+        assert!(col >= 1);
+        vt.resize(0, 0);
+        let (row, col) = vt.parser.screen().size();
+        assert!(row >= 1);
+        assert!(col >= 1);
     }
 
     #[test]

--- a/rs/src/vterm.rs
+++ b/rs/src/vterm.rs
@@ -1,0 +1,216 @@
+//! Virtual terminal emulator proxy wrapping vt100-ctt crate.
+//!
+//! Replaces naive strip-ansi approach with a real terminal emulator that
+//! correctly handles cursor movement, line clearing, scrolling, etc.
+//! Also auto-responds to terminal queries (DSR, DA) so the child process
+//! never blocks waiting for a terminal reply.
+
+use std::sync::{Arc, Mutex};
+use tracing::debug;
+
+/// Collects terminal query responses (DSR, DA, etc.) via vt100 callbacks.
+#[derive(Clone, Default)]
+struct ResponseCollector {
+    responses: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl ResponseCollector {
+    fn take_responses(&self) -> Vec<Vec<u8>> {
+        let mut responses = self.responses.lock().unwrap();
+        std::mem::take(&mut *responses)
+    }
+
+    fn push_response(&self, data: Vec<u8>) {
+        self.responses.lock().unwrap().push(data);
+    }
+}
+
+impl vt100_ctt::Callbacks for ResponseCollector {
+    fn unhandled_csi(
+        &mut self,
+        screen: &mut vt100_ctt::Screen,
+        _intermediates: Option<u8>,
+        _ignored_excess_intermediates: Option<u8>,
+        params: &[&[u16]],
+        c: char,
+    ) {
+        match c {
+            // DSR - Device Status Report: ESC[6n → respond ESC[<row>;<col>R
+            'n' => {
+                let param = params.first().and_then(|p| p.first()).copied().unwrap_or(0);
+                if param == 6 {
+                    let (row, col) = screen.cursor_position();
+                    // Terminal uses 1-based coordinates
+                    let response = format!("\x1b[{};{}R", row + 1, col + 1);
+                    debug!("vterm|DSR response: {:?}", response);
+                    self.push_response(response.into_bytes());
+                }
+            }
+            // DA - Device Attributes: ESC[c or ESC[0c → respond as VT100
+            'c' => {
+                let param = params.first().and_then(|p| p.first()).copied().unwrap_or(0);
+                if param == 0 {
+                    let response = b"\x1b[?1;2c".to_vec(); // VT100 with AVO
+                    debug!("vterm|DA response: {:?}", String::from_utf8_lossy(&response));
+                    self.push_response(response);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Virtual terminal proxy — wraps vt100-ctt::Parser to provide a rendered
+/// terminal screen buffer and auto-respond to terminal queries.
+pub struct VTermProxy {
+    parser: vt100_ctt::Parser<ResponseCollector>,
+    collector: ResponseCollector,
+}
+
+impl VTermProxy {
+    /// Create a new virtual terminal with the given dimensions.
+    pub fn new(rows: u16, cols: u16) -> Self {
+        let collector = ResponseCollector::default();
+        let parser = vt100_ctt::Parser::new_with_callbacks(rows, cols, 1000, collector.clone());
+        Self { parser, collector }
+    }
+
+    /// Feed raw PTY output bytes into the terminal emulator.
+    /// After calling this, check `take_responses()` for any terminal query
+    /// responses that need to be written back to the PTY stdin.
+    pub fn process(&mut self, data: &[u8]) {
+        self.parser.process(data);
+    }
+
+    /// Take any pending terminal query responses (DSR, DA, etc.).
+    /// These bytes should be written back to the child process PTY stdin.
+    pub fn take_responses(&self) -> Vec<Vec<u8>> {
+        self.collector.take_responses()
+    }
+
+    /// Get the full rendered terminal contents as plain text.
+    /// This correctly reflects cursor movement, line clearing, overwriting, etc.
+    pub fn contents(&self) -> String {
+        self.parser.screen().contents()
+    }
+
+    /// Get the last N lines of the rendered terminal.
+    pub fn tail(&self, n: usize) -> String {
+        let screen = self.parser.screen();
+        let (rows, _cols) = screen.size();
+        let total = rows as usize;
+        let start = total.saturating_sub(n);
+        let mut lines: Vec<String> = Vec::with_capacity(n);
+        for row in start..total {
+            lines.push(screen.contents_between(
+                row as u16,
+                0,
+                row as u16,
+                screen.size().1,
+            ));
+        }
+        // Trim trailing empty lines
+        while lines.len() > 1 && lines.last().map_or(false, |l| l.is_empty()) {
+            lines.pop();
+        }
+        lines.join("\n")
+    }
+
+    /// Get the current cursor position (0-based row, col).
+    pub fn cursor_position(&self) -> (u16, u16) {
+        self.parser.screen().cursor_position()
+    }
+
+    /// Resize the virtual terminal.
+    pub fn resize(&mut self, rows: u16, cols: u16) {
+        self.parser.screen_mut().set_size(rows, cols);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_output() {
+        let mut vt = VTermProxy::new(24, 80);
+        vt.process(b"Hello, World!\r\n");
+        let contents = vt.contents();
+        assert!(contents.contains("Hello, World!"));
+    }
+
+    #[test]
+    fn test_cursor_overwrite() {
+        let mut vt = VTermProxy::new(24, 80);
+        // Write "AAAA", move cursor back, overwrite with "BB"
+        vt.process(b"AAAA\x1b[4DBB");
+        let contents = vt.contents();
+        assert!(contents.contains("BBAA"), "expected 'BBAA' but got: {}", contents);
+    }
+
+    #[test]
+    fn test_line_clear() {
+        let mut vt = VTermProxy::new(24, 80);
+        // Write text, then clear the line with ESC[2K
+        vt.process(b"old text\r\x1b[2Knew text");
+        let contents = vt.contents();
+        assert!(!contents.contains("old text"), "old text should be cleared: {}", contents);
+        assert!(contents.contains("new text"));
+    }
+
+    #[test]
+    fn test_progress_bar_overwrite() {
+        let mut vt = VTermProxy::new(24, 80);
+        // Simulate progress bar: write, carriage return, overwrite
+        vt.process(b"[##--------] 20%\r[#####-----] 50%\r[##########] 100%");
+        let contents = vt.contents();
+        assert!(contents.contains("100%"), "should show final state: {}", contents);
+        assert!(!contents.contains("20%"), "should not show old progress: {}", contents);
+    }
+
+    #[test]
+    fn test_dsr_response() {
+        let mut vt = VTermProxy::new(24, 80);
+        // Move cursor to row 5, col 10, then send DSR query
+        vt.process(b"\x1b[5;10H\x1b[6n");
+        let responses = vt.take_responses();
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0], b"\x1b[5;10R");
+    }
+
+    #[test]
+    fn test_da_response() {
+        let mut vt = VTermProxy::new(24, 80);
+        vt.process(b"\x1b[c");
+        let responses = vt.take_responses();
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0], b"\x1b[?1;2c");
+    }
+
+    #[test]
+    fn test_resize() {
+        let mut vt = VTermProxy::new(24, 80);
+        vt.resize(30, 120);
+        let (row, col) = vt.parser.screen().size();
+        assert_eq!(row, 30);
+        assert_eq!(col, 120);
+    }
+
+    #[test]
+    fn test_ansi_colors_stripped_in_contents() {
+        let mut vt = VTermProxy::new(24, 80);
+        vt.process(b"\x1b[31mRed\x1b[0m Normal");
+        let contents = vt.contents();
+        assert_eq!(contents.trim(), "Red Normal");
+        assert!(!contents.contains("\x1b"));
+    }
+
+    #[test]
+    fn test_screen_clear() {
+        let mut vt = VTermProxy::new(24, 80);
+        vt.process(b"line 1\r\nline 2\r\n\x1b[2J\x1b[1;1Hfresh start");
+        let contents = vt.contents();
+        assert!(contents.contains("fresh start"));
+        assert!(!contents.contains("line 1"), "screen should be cleared: {}", contents);
+    }
+}

--- a/rs/src/vterm.rs
+++ b/rs/src/vterm.rs
@@ -29,31 +29,42 @@ impl vt100_ctt::Callbacks for ResponseCollector {
     fn unhandled_csi(
         &mut self,
         screen: &mut vt100_ctt::Screen,
-        _intermediates: Option<u8>,
+        intermediates: Option<u8>,
         _ignored_excess_intermediates: Option<u8>,
         params: &[&[u16]],
         c: char,
     ) {
+        // Only respond to plain (no private/intermediate marker) primary
+        // DA/DSR queries. CSI '?' n / CSI '>' c etc. are private or
+        // secondary forms that expect different (or no) replies.
+        if intermediates.is_some() {
+            return;
+        }
+        let param = params.first().and_then(|p| p.first()).copied().unwrap_or(0);
         match c {
-            // DSR - Device Status Report: ESC[6n → respond ESC[<row>;<col>R
-            'n' => {
-                let param = params.first().and_then(|p| p.first()).copied().unwrap_or(0);
-                if param == 6 {
+            // DSR - Device Status Report
+            'n' => match param {
+                // ESC[5n → terminal status: respond OK (ESC[0n)
+                5 => {
+                    let response = b"\x1b[0n".to_vec();
+                    debug!("vterm|DSR status response: {:?}", String::from_utf8_lossy(&response));
+                    self.push_response(response);
+                }
+                // ESC[6n → cursor position: respond ESC[<row>;<col>R
+                6 => {
                     let (row, col) = screen.cursor_position();
                     // Terminal uses 1-based coordinates
                     let response = format!("\x1b[{};{}R", row + 1, col + 1);
-                    debug!("vterm|DSR response: {:?}", response);
+                    debug!("vterm|DSR cursor response: {:?}", response);
                     self.push_response(response.into_bytes());
                 }
-            }
-            // DA - Device Attributes: ESC[c or ESC[0c → respond as VT100
-            'c' => {
-                let param = params.first().and_then(|p| p.first()).copied().unwrap_or(0);
-                if param == 0 {
-                    let response = b"\x1b[?1;2c".to_vec(); // VT100 with AVO
-                    debug!("vterm|DA response: {:?}", String::from_utf8_lossy(&response));
-                    self.push_response(response);
-                }
+                _ => {}
+            },
+            // DA - Device Attributes: ESC[c or ESC[0c → respond as VT100 with AVO
+            'c' if param == 0 => {
+                let response = b"\x1b[?1;2c".to_vec();
+                debug!("vterm|DA response: {:?}", String::from_utf8_lossy(&response));
+                self.push_response(response);
             }
             _ => {}
         }
@@ -185,6 +196,32 @@ mod tests {
         let responses = vt.take_responses();
         assert_eq!(responses.len(), 1);
         assert_eq!(responses[0], b"\x1b[?1;2c");
+    }
+
+    #[test]
+    fn test_dsr_status_response() {
+        // ESC[5n → terminal OK status
+        let mut vt = VTermProxy::new(24, 80);
+        vt.process(b"\x1b[5n");
+        let responses = vt.take_responses();
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0], b"\x1b[0n");
+    }
+
+    #[test]
+    fn test_secondary_da_not_answered() {
+        // ESC[>c → secondary DA, must NOT respond as primary DA
+        let mut vt = VTermProxy::new(24, 80);
+        vt.process(b"\x1b[>c");
+        assert!(vt.take_responses().is_empty());
+    }
+
+    #[test]
+    fn test_private_dsr_not_answered() {
+        // ESC[?6n → DEC private DSR, must NOT respond as plain CPR
+        let mut vt = VTermProxy::new(24, 80);
+        vt.process(b"\x1b[?6n");
+        assert!(vt.take_responses().is_empty());
     }
 
     #[test]

--- a/rs/src/vterm.rs
+++ b/rs/src/vterm.rs
@@ -16,12 +16,19 @@ struct ResponseCollector {
 
 impl ResponseCollector {
     fn take_responses(&self) -> Vec<Vec<u8>> {
-        let mut responses = self.responses.lock().unwrap();
+        let mut responses = self
+            .responses
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::mem::take(&mut *responses)
     }
 
     fn push_response(&self, data: Vec<u8>) {
-        self.responses.lock().unwrap().push(data);
+        let mut responses = self
+            .responses
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        responses.push(data);
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `VTermProxy` (rs/src/vterm.rs) wrapping `vt100-ctt` as a real headless terminal emulator
- Replaces naive `strip_ansi_escapes` in `context.rs` so cursor moves, line/screen clears, and progress bar overwrites are correctly reflected in the screen state used for pattern matching
- DSR/DA terminal queries (`ESC[6n`, `ESC[c`) now auto-respond with the real cursor position via the `vt100` `unhandled_csi` callback, replacing the hardcoded `ESC[1;1R` reply
- This is the Rust counterpart to the `@xterm/headless` `XtermProxy` introduced on the `sno-xterm` branch

## Test plan
- [x] `cargo test` — 165 unit + 5 integration tests pass
- [x] `cargo build --release` & `bun link` succeed
- [x] `agent-yes --version` / `--help` smoke checks
- [x] New `vterm.rs` tests cover: cursor overwrite, line clear, screen clear, progress bar overwrite, DSR response, DA response, resize, ANSI color stripping
- [ ] Manual run against `claude` / `codex` to confirm pattern matching still triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)