### PR TITLE
fix(versionChecker): break stale-bundle auto-update loop (#39)

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "fmt": "oxlint --fix --fix-suggestions && oxfmt",
     "verify-deps": "node ./scripts/verify-deps.js",
     "_prepack": "bun run build",
-    "prepublishOnly": "npm run verify-deps",
+    "prepublishOnly": "bun run build && npm run verify-deps",
     "prepare": "husky",
     "release": "standard-version && npm publish",
     "release:beta": "standard-version && npm publish --tag beta",

--- a/rs/src/running_lock.rs
+++ b/rs/src/running_lock.rs
@@ -143,9 +143,17 @@ fn lock_path() -> PathBuf {
 }
 
 fn get_git_root(cwd: &str) -> Option<String> {
+    // Scrub inherited GIT_* repo-locating vars so `git` resolves the repo from
+    // `cwd` only. Otherwise, running inside a git hook (where these vars are
+    // exported) hijacks the lookup and returns the hook's repo or the cwd
+    // itself instead of the requested directory's true toplevel.
     std::process::Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(cwd)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
         .output()
         .ok()
         .filter(|o| o.status.success())

--- a/ts/core/spawner.ts
+++ b/ts/core/spawner.ts
@@ -5,7 +5,7 @@ import pty, { type IPty } from "../pty.ts";
 import type { AgentCliConfig } from "../index.ts";
 import type { SUPPORTED_CLIS } from "../SUPPORTED_CLIS.ts";
 import { execSync } from "node:child_process";
-import pkg from "../../package.json" with { type: "json" };
+import { getInstalledPackage } from "../versionChecker.ts";
 
 /**
  * Agent spawning utilities
@@ -134,7 +134,9 @@ export function spawnAgent(options: SpawnOptions): IPty {
     let [bin, ...args] = [...parseCommandString(cliCommand), ...cliArgs];
     logger.debug(`Spawning ${bin} with args: ${JSON.stringify(args)}`);
     const spawned = pty.spawn(bin!, args, ptyOptions);
-    logger.info(`[${cli}-yes] Spawned ${bin} with PID ${spawned.pid} (agent-yes v${pkg.version})`);
+    logger.info(
+      `[${cli}-yes] Spawned ${bin} with PID ${spawned.pid} (agent-yes v${getInstalledPackage().version})`,
+    );
     return spawned;
   };
 

--- a/ts/runningLock.ts
+++ b/ts/runningLock.ts
@@ -44,6 +44,22 @@ function isProcessRunning(pid: number): boolean {
 }
 
 /**
+ * Build an env that scrubs inherited GIT_* repo-locating vars so the spawned
+ * `git` resolves the repo from `cwd` only. Without this, running inside a git
+ * hook (where GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE / GIT_COMMON_DIR are
+ * exported) makes `git rev-parse --show-toplevel` use the hook's repo context
+ * instead of the requested directory.
+ */
+function gitCleanEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_COMMON_DIR;
+  return env;
+}
+
+/**
  * Get git repository root for a directory
  */
 function getGitRoot(cwd: string): string | null {
@@ -52,6 +68,7 @@ function getGitRoot(cwd: string): string | null {
       cwd,
       encoding: "utf8",
       stdio: ["pipe", "pipe", "ignore"],
+      env: gitCleanEnv(),
     });
     return result.trim();
   } catch {

--- a/ts/rustBinary.ts
+++ b/ts/rustBinary.ts
@@ -6,7 +6,7 @@ import { execFileSync } from "child_process";
 import { existsSync, mkdirSync, unlinkSync } from "fs";
 import { chmod, copyFile } from "fs/promises";
 import path from "path";
-import pkg from "../package.json" with { type: "json" };
+import { getInstalledPackage } from "./versionChecker.ts";
 
 // Platform/arch to binary name mapping
 const PLATFORM_MAP: Record<string, string> = {
@@ -223,11 +223,12 @@ function autoRebuildIfOutdated(binaryPath: string, verbose: boolean): boolean {
   }
 
   const binaryVersion = getRustBinaryVersion(binaryPath);
+  const pkgVersion = getInstalledPackage().version;
   if (verbose) {
-    console.log(`[rust] Binary version: ${binaryVersion}, package version: ${pkg.version}`);
+    console.log(`[rust] Binary version: ${binaryVersion}, package version: ${pkgVersion}`);
   }
 
-  if (binaryVersion === pkg.version) {
+  if (binaryVersion === pkgVersion) {
     return true; // up to date
   }
 
@@ -239,7 +240,7 @@ function autoRebuildIfOutdated(binaryPath: string, verbose: boolean): boolean {
   }
 
   process.stderr.write(
-    `\x1b[33m[rust] Binary outdated (${binaryVersion ?? "unknown"} → ${pkg.version}), rebuilding…\x1b[0m\n`,
+    `\x1b[33m[rust] Binary outdated (${binaryVersion ?? "unknown"} → ${pkgVersion}), rebuilding…\x1b[0m\n`,
   );
 
   try {

--- a/ts/versionChecker.spec.ts
+++ b/ts/versionChecker.spec.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
+  _setInstalledPackageForTesting,
   checkAndAutoUpdate,
   compareVersions,
   fetchLatestVersion,
   displayVersion,
   detectInstallMethod,
+  getInstalledPackage,
   versionString,
-} from "./versionChecker";
+} from "./versionChecker.ts";
 
 vi.mock("execa", () => ({ execaCommand: vi.fn().mockResolvedValue({}) }));
 vi.mock("fs/promises", () => ({
@@ -18,8 +20,12 @@ vi.mock("fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs")>();
   return {
     ...actual,
-    // Return false for .git checks so the dev-checkout guard doesn't skip auto-update in tests
+    // Return false for .git / package.json lookups so neither the dev-checkout
+    // guard nor getInstalledPackage's disk read fires during the auto-update tests.
     existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => {
+      throw new Error("readFileSync not stubbed");
+    }),
     lstatSync: actual.lstatSync,
     readlinkSync: actual.readlinkSync,
   };
@@ -99,6 +105,7 @@ describe("versionChecker", () => {
   describe("checkAndAutoUpdate", () => {
     beforeEach(() => {
       vi.clearAllMocks();
+      _setInstalledPackageForTesting(null);
       vi.stubGlobal("fetch", vi.fn());
       vi.spyOn(process.stderr, "write").mockImplementation(() => true);
       // Use a mock for process.exit to prevent actual exit in tests
@@ -298,6 +305,59 @@ describe("versionChecker", () => {
       const str = versionString();
       expect(str).toContain("agent-yes v");
       expect(str).toMatch(/agent-yes v\d+\.\d+\.\d+ \(.+\)/);
+    });
+  });
+
+  // Regression test for https://github.com/snomiao/agent-yes/issues/39:
+  // a stale bundled version string must not pin the auto-update comparison
+  // when a fresh package.json is on disk next to the running module.
+  describe("getInstalledPackage (issue #39)", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      _setInstalledPackageForTesting(null);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      _setInstalledPackageForTesting(null);
+    });
+
+    it("prefers the on-disk package.json over the bundled (potentially stale) import", async () => {
+      const fs = await import("fs");
+      vi.mocked(fs.existsSync).mockReturnValueOnce(true);
+      vi.mocked(fs.readFileSync).mockReturnValueOnce(
+        JSON.stringify({ name: "agent-yes", version: "999.0.0" }) as any,
+      );
+
+      const resolved = getInstalledPackage();
+      expect(resolved.version).toBe("999.0.0");
+      expect(resolved.name).toBe("agent-yes");
+    });
+
+    it("does not trigger an auto-update when on-disk version already matches the registry", async () => {
+      // Simulate the post-fix scenario: the bundled `pkg.version` (frozen at
+      // build time) is older than the registry, but the runtime resolver
+      // surfaces the correct on-disk version and the comparison short-circuits.
+      // Pre-fix behavior was install + reExec on every invocation → infinite loop.
+      _setInstalledPackageForTesting({ name: "agent-yes", version: "999.0.0" });
+
+      const { readFile } = await import("fs/promises");
+      const { execaCommand } = await import("execa");
+      vi.mocked(readFile).mockRejectedValueOnce(new Error("no cache"));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ version: "999.0.0" }),
+        } as Response),
+      );
+      vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+      delete process.env.AGENT_YES_NO_UPDATE;
+      delete process.env.AGENT_YES_UPDATED;
+
+      await checkAndAutoUpdate();
+      expect(execaCommand).not.toHaveBeenCalled();
     });
   });
 });

--- a/ts/versionChecker.spec.ts
+++ b/ts/versionChecker.spec.ts
@@ -334,6 +334,26 @@ describe("versionChecker", () => {
       expect(resolved.name).toBe("agent-yes");
     });
 
+    it("continues walking parents when a candidate package.json is unreadable", async () => {
+      // Per-candidate try/catch: an unreadable/unparsable manifest at one
+      // level must not abort the upward walk and silently fall back to the
+      // bundled (stale) manifest. The walk must keep going until it finds
+      // a matching package.json or exhausts parents.
+      const fs = await import("fs");
+      let call = 0;
+      vi.mocked(fs.existsSync).mockImplementation(() => true);
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        call += 1;
+        if (call === 1) throw new Error("EACCES");
+        if (call === 2) return "{not json" as any;
+        return JSON.stringify({ name: "agent-yes", version: "999.0.0" }) as any;
+      });
+
+      const resolved = getInstalledPackage();
+      expect(resolved.version).toBe("999.0.0");
+      expect(call).toBeGreaterThanOrEqual(3);
+    });
+
     it("does not trigger an auto-update when on-disk version already matches the registry", async () => {
       // Simulate the post-fix scenario: the bundled `pkg.version` (frozen at
       // build time) is older than the registry, but the runtime resolver

--- a/ts/versionChecker.ts
+++ b/ts/versionChecker.ts
@@ -1,13 +1,58 @@
 import { execFileSync } from "child_process";
-import { existsSync, lstatSync, readlinkSync } from "fs";
+import { existsSync, lstatSync, readFileSync, readlinkSync } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
-import pkg from "../package.json" with { type: "json" };
+import { fileURLToPath } from "url";
+import bundledPkg from "../package.json" with { type: "json" };
 
 const CACHE_DIR = path.join(homedir(), ".cache", "agent-yes");
 const CACHE_FILE = path.join(CACHE_DIR, "update-check.json");
 const TTL_MS = 60 * 60 * 1000; // 1 hour
+
+let cachedInstalledPkg: { name: string; version: string } | null = null;
+
+/**
+ * Read the live `package.json` from disk for the running module.
+ *
+ * The bundled `package.json` import is inlined at build time; if `dist/` is
+ * published without a fresh build (issue #39), the inlined `version` lies
+ * and the auto-update loop fires forever. Reading the on-disk manifest each
+ * run keeps the version honest even when the bundle is stale.
+ */
+export function getInstalledPackage(): { name: string; version: string } {
+  if (cachedInstalledPkg) return cachedInstalledPkg;
+  try {
+    let dir = path.dirname(fileURLToPath(import.meta.url));
+    for (let i = 0; i < 6; i++) {
+      const candidate = path.join(dir, "package.json");
+      if (existsSync(candidate)) {
+        const json = JSON.parse(readFileSync(candidate, "utf8")) as {
+          name?: string;
+          version?: string;
+        };
+        if (json.name === bundledPkg.name && typeof json.version === "string") {
+          cachedInstalledPkg = { name: json.name, version: json.version };
+          return cachedInstalledPkg;
+        }
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // fall through to bundled fallback
+  }
+  cachedInstalledPkg = { name: bundledPkg.name, version: bundledPkg.version };
+  return cachedInstalledPkg;
+}
+
+/** Test-only: clear or seed the memoized lookup. */
+export function _setInstalledPackageForTesting(
+  value: { name: string; version: string } | null,
+): void {
+  cachedInstalledPkg = value;
+}
 
 type UpdateCache = { checkedAt: number; latestVersion: string };
 
@@ -75,7 +120,7 @@ export async function checkAndAutoUpdate(): Promise<void> {
       await writeUpdateCache({ checkedAt: Date.now(), latestVersion });
     }
 
-    if (compareVersions(pkg.version, latestVersion) < 0) {
+    if (compareVersions(getInstalledPackage().version, latestVersion) < 0) {
       const installed = await runInstall(latestVersion);
       if (installed) {
         reExec(latestVersion);
@@ -93,7 +138,9 @@ async function runInstall(latestVersion: string): Promise<boolean> {
       ? `bun add -g agent-yes@${latestVersion}`
       : `npm install -g agent-yes@${latestVersion}`;
 
-  process.stderr.write(`\x1b[33m[agent-yes] Updating ${pkg.version} → ${latestVersion}…\x1b[0m\n`);
+  process.stderr.write(
+    `\x1b[33m[agent-yes] Updating ${getInstalledPackage().version} → ${latestVersion}…\x1b[0m\n`,
+  );
   try {
     const { execaCommand } = await import("execa");
     await execaCommand(installCmd, { stdio: "inherit" });
@@ -128,9 +175,12 @@ function reExec(version: string): never {
  */
 export async function fetchLatestVersion(): Promise<string | null> {
   try {
-    const response = await fetch(`https://registry.npmjs.org/${pkg.name}/latest`, {
-      signal: AbortSignal.timeout(3000), // 3 second timeout
-    });
+    const response = await fetch(
+      `https://registry.npmjs.org/${getInstalledPackage().name}/latest`,
+      {
+        signal: AbortSignal.timeout(3000), // 3 second timeout
+      },
+    );
 
     if (!response.ok) {
       return null;
@@ -215,7 +265,7 @@ export function detectInstallMethod(): string {
  * Format version string with install method
  */
 export function versionString(): string {
-  return `agent-yes v${pkg.version} (${detectInstallMethod()})`;
+  return `agent-yes v${getInstalledPackage().version} (${detectInstallMethod()})`;
 }
 
 /**
@@ -227,7 +277,7 @@ export async function displayVersion(): Promise<void> {
   const latestVersion = await fetchLatestVersion();
 
   if (latestVersion) {
-    const comparison = compareVersions(pkg.version, latestVersion);
+    const comparison = compareVersions(getInstalledPackage().version, latestVersion);
 
     if (comparison < 0) {
       console.log(`\x1b[33m${latestVersion} (update available)\x1b[0m`);

--- a/ts/versionChecker.ts
+++ b/ts/versionChecker.ts
@@ -31,26 +31,38 @@ let cachedInstalledPkg: { name: string; version: string } | null = null;
  */
 export function getInstalledPackage(): { name: string; version: string } {
   if (cachedInstalledPkg) return cachedInstalledPkg;
+  let dir: string | null = null;
   try {
-    let dir = path.dirname(fileURLToPath(import.meta.url));
+    dir = path.dirname(fileURLToPath(import.meta.url));
+  } catch {
+    // import.meta.url malformed; fall through to bundled
+  }
+  if (dir) {
     for (let i = 0; i < 6; i++) {
       const candidate = path.join(dir, "package.json");
-      if (existsSync(candidate)) {
-        const json = JSON.parse(readFileSync(candidate, "utf8")) as {
-          name?: string;
-          version?: string;
-        };
-        if (json.name === bundledPkg.name && typeof json.version === "string") {
-          cachedInstalledPkg = { name: json.name, version: json.version };
-          return cachedInstalledPkg;
+      // A per-candidate try/catch: a transient read error, partial write, or
+      // BOM on any single package.json must NOT abort the upward walk —
+      // otherwise we'd silently fall back to the stale bundled manifest that
+      // issue #39 was about. Keep walking until we either find a matching
+      // manifest or exhaust parents.
+      try {
+        if (existsSync(candidate)) {
+          const json = JSON.parse(readFileSync(candidate, "utf8")) as {
+            name?: string;
+            version?: string;
+          };
+          if (json.name === bundledPkg.name && typeof json.version === "string") {
+            cachedInstalledPkg = { name: json.name, version: json.version };
+            return cachedInstalledPkg;
+          }
         }
+      } catch {
+        // unreadable / unparsable — continue walking
       }
       const parent = path.dirname(dir);
       if (parent === dir) break;
       dir = parent;
     }
-  } catch {
-    // fall through to bundled fallback
   }
   cachedInstalledPkg = { name: bundledPkg.name, version: bundledPkg.version };
   return cachedInstalledPkg;

--- a/ts/versionChecker.ts
+++ b/ts/versionChecker.ts
@@ -10,6 +10,15 @@ const CACHE_DIR = path.join(homedir(), ".cache", "agent-yes");
 const CACHE_FILE = path.join(CACHE_DIR, "update-check.json");
 const TTL_MS = 60 * 60 * 1000; // 1 hour
 
+// The release pipeline publishes both `agent-yes` and `claude-yes` from the
+// same source by flipping `package.json#name` and re-running `npm publish`
+// (which now triggers `bun run build`, rebuilding dist with whichever name is
+// set). The auto-updater's registry lookup, install command, and shared
+// cache file must all stay pinned to the canonical package — otherwise a
+// `claude-yes` install would query `claude-yes/latest` while `runInstall`
+// still hard-codes `agent-yes`.
+const CANONICAL_PKG_NAME = "agent-yes";
+
 let cachedInstalledPkg: { name: string; version: string } | null = null;
 
 /**
@@ -135,8 +144,8 @@ async function runInstall(latestVersion: string): Promise<boolean> {
   const pm = detectPackageManager();
   const installCmd =
     pm === "bun"
-      ? `bun add -g agent-yes@${latestVersion}`
-      : `npm install -g agent-yes@${latestVersion}`;
+      ? `bun add -g ${CANONICAL_PKG_NAME}@${latestVersion}`
+      : `npm install -g ${CANONICAL_PKG_NAME}@${latestVersion}`;
 
   process.stderr.write(
     `\x1b[33m[agent-yes] Updating ${getInstalledPackage().version} → ${latestVersion}…\x1b[0m\n`,
@@ -175,11 +184,7 @@ function reExec(version: string): never {
  */
 export async function fetchLatestVersion(): Promise<string | null> {
   try {
-    // Always query the canonical package name. The release pipeline publishes
-    // both `agent-yes` and `claude-yes` from the same dist, and `runInstall`
-    // is hard-coded to install `agent-yes` — switching this to the on-disk
-    // name would desync the lookup, install command, and shared cache file.
-    const response = await fetch(`https://registry.npmjs.org/${bundledPkg.name}/latest`, {
+    const response = await fetch(`https://registry.npmjs.org/${CANONICAL_PKG_NAME}/latest`, {
       signal: AbortSignal.timeout(3000), // 3 second timeout
     });
 

--- a/ts/versionChecker.ts
+++ b/ts/versionChecker.ts
@@ -175,12 +175,13 @@ function reExec(version: string): never {
  */
 export async function fetchLatestVersion(): Promise<string | null> {
   try {
-    const response = await fetch(
-      `https://registry.npmjs.org/${getInstalledPackage().name}/latest`,
-      {
-        signal: AbortSignal.timeout(3000), // 3 second timeout
-      },
-    );
+    // Always query the canonical package name. The release pipeline publishes
+    // both `agent-yes` and `claude-yes` from the same dist, and `runInstall`
+    // is hard-coded to install `agent-yes` — switching this to the on-disk
+    // name would desync the lookup, install command, and shared cache file.
+    const response = await fetch(`https://registry.npmjs.org/${bundledPkg.name}/latest`, {
+      signal: AbortSignal.timeout(3000), // 3 second timeout
+    });
 
     if (!response.ok) {
       return null;


### PR DESCRIPTION
## Summary

Fixes #39: `agent-yes@1.73.0` and `@1.73.2` were published with a stale `dist/` whose bundled `version` string disagreed with `package.json`. The auto-updater compared the frozen-at-build-time string against the registry, found "1.72.4 < 1.73.0", reinstalled, re-exec'd — and looped forever, truncating its own files in the process.

- Resolve the running version at **runtime** by walking up from `import.meta.url` to find the nearest `package.json` whose `name` matches; fall back to the bundled manifest only if the disk lookup fails. Used in `versionChecker`, `rustBinary`, and `core/spawner`.
- Wire `bun run build` into `prepublishOnly` so a stale `dist/` cannot ship again.
- Scrub `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` / `GIT_COMMON_DIR` from `getGitRoot`'s `git rev-parse` invocation (TS + Rust). Inherited from a parent git hook those vars override `cwd` and corrupt the lockKey; not strictly part of #39 but it was masking the test bench.

## Test plan

- [x] `bunx vitest run ts/versionChecker.spec.ts` — 27/27 pass, including new regression test that simulates a stale bundled version + matching disk version
- [x] `bun run test:coverage` — 294/294 + 1 skipped, coverage thresholds met
- [x] `cargo test running_lock` — both `test_get_git_root_*` pass with and without ambient `GIT_DIR`
- [x] `bun run build` — builds clean; freshly built dist reports the correct `v1.75.2` at runtime
- [x] Pre-commit hook (husky → fmt → lint-staged → build → test:coverage → cargo tarpaulin) succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)