### PR TITLE
feat(status): add --wait-idle to block on state == idle

### DIFF
--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -926,6 +926,109 @@ describe("subcommands.cmdStatus", () => {
     expect(snap).toMatchObject({ pid: process.pid, cli: "claude" });
     expect(typeof snap.age_ms).toBe("number");
   });
+
+  it("--wait-idle returns 0 immediately for an idle agent", async () => {
+    const mod = await loadModule();
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    const logFile = path.join(testHome, "idle.raw.log");
+    await writeFile(logFile, "old\n");
+    // Stale mtime: > IDLE_THRESHOLD_MS (60s) in the past
+    const stale = (Date.now() - 5 * 60 * 1000) / 1000;
+    const { utimes } = await import("fs/promises");
+    await utimes(logFile, stale, stale);
+    await appendGlobalPid({
+      pid: process.pid,
+      cli: "claude",
+      prompt: "wait-idle-test",
+      cwd: process.cwd(),
+      log_file: logFile,
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now() - 10_000,
+    });
+
+    const stdout: string[] = [];
+    (process.stdout as any).write = (s: any) => {
+      stdout.push(String(s));
+      return true;
+    };
+    (process.stderr as any).write = () => true;
+    const code = await mod.runSubcommand([
+      "bun",
+      "cli.js",
+      "status",
+      String(process.pid),
+      "--wait-idle",
+      "--timeout=2s",
+      "--interval=0.5",
+    ]);
+    expect(code).toBe(0);
+    const snap = JSON.parse(stdout.join("").trim().split("\n").pop()!);
+    expect(snap.state).toBe("idle");
+  });
+
+  it("--wait-idle returns 1 when the agent is stopped", async () => {
+    const mod = await loadModule();
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    // Pick a pid that is almost certainly not alive.
+    const deadPid = 999_999;
+    await appendGlobalPid({
+      pid: deadPid,
+      cli: "claude",
+      prompt: "wait-idle-stopped",
+      cwd: process.cwd(),
+      log_file: null,
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now() - 10_000,
+    });
+
+    (process.stdout as any).write = () => true;
+    (process.stderr as any).write = () => true;
+    const code = await mod.runSubcommand([
+      "bun",
+      "cli.js",
+      "status",
+      String(deadPid),
+      "--wait-idle",
+      "--interval=0.5",
+    ]);
+    expect(code).toBe(1);
+  });
+
+  it("--wait-idle returns 2 on timeout while still active", async () => {
+    const mod = await loadModule();
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    const logFile = path.join(testHome, "active.raw.log");
+    await writeFile(logFile, "fresh\n");
+    // Fresh mtime keeps state = active
+    await appendGlobalPid({
+      pid: process.pid,
+      cli: "claude",
+      prompt: "wait-idle-timeout",
+      cwd: process.cwd(),
+      log_file: logFile,
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now() - 10_000,
+    });
+
+    (process.stdout as any).write = () => true;
+    (process.stderr as any).write = () => true;
+    const code = await mod.runSubcommand([
+      "bun",
+      "cli.js",
+      "status",
+      String(process.pid),
+      "--wait-idle",
+      "--timeout=600ms",
+      "--interval=0.5",
+    ]);
+    expect(code).toBe(2);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -12,6 +12,7 @@
  */
 
 import { appendFile, mkdir, open, readFile, stat, writeFile } from "fs/promises";
+import ms from "ms";
 import { homedir } from "os";
 import path from "path";
 import { type GlobalPidRecord, readGlobalPids } from "./globalPidIndex.ts";
@@ -422,6 +423,7 @@ async function cmdLs(rest: string[]): Promise<number> {
     if (alive) {
       hints.push(`  ay status ${alive.pid}                # JSON status snapshot\n`);
       hints.push(`  ay status ${alive.pid} --watch        # stream changes as JSON\n`);
+      hints.push(`  ay status ${alive.pid} --wait-idle    # block until state == idle\n`);
       hints.push(`  ay tail ${alive.pid}                  # view latest output\n`);
       hints.push(`  ay tail -f ${alive.pid}               # follow live output\n`);
       hints.push(
@@ -1032,6 +1034,15 @@ async function cmdStatus(rest: string[]): Promise<number> {
       default: false,
       description: "Stream changes as JSON",
     })
+    .option("wait-idle", {
+      type: "boolean",
+      default: false,
+      description: "Block until state == idle. Exit 0 idle, 1 stopped, 2 timeout",
+    })
+    .option("timeout", {
+      type: "string",
+      description: "Timeout for --wait-idle (e.g. 30s, 5m). Default: no timeout",
+    })
     .option("interval", { type: "number", default: 2, description: "Poll interval in seconds" })
     .option("latest", { type: "boolean", default: false, description: "Use most recent match" })
     .option("cwd", { type: "string", description: "Restrict to agents under this dir" })
@@ -1049,11 +1060,20 @@ async function cmdStatus(rest: string[]): Promise<number> {
   };
   const keyword = argv._[0] !== undefined ? String(argv._[0]) : undefined;
 
-  if (!keyword) throw new Error("usage: ay status <keyword> [--watch] [--interval=N]");
+  if (!keyword)
+    throw new Error("usage: ay status <keyword> [--watch | --wait-idle] [--timeout=Ns]");
 
   const watch = argv.watch;
+  const waitIdle = argv["wait-idle"];
   const intervalFlag = argv.interval;
   const intervalMs = Math.max(500, (Number.isFinite(intervalFlag) ? intervalFlag : 2) * 1000);
+  const timeoutMs =
+    typeof argv.timeout === "string" && argv.timeout.length > 0
+      ? (ms(argv.timeout) ?? Number.NaN)
+      : null;
+  if (timeoutMs !== null && !Number.isFinite(timeoutMs)) {
+    throw new Error(`invalid --timeout value: ${argv.timeout}`);
+  }
 
   const record = await resolveOne(keyword, opts);
 
@@ -1061,6 +1081,26 @@ async function cmdStatus(rest: string[]): Promise<number> {
     const out = ts !== undefined ? { ts, ...snap } : snap;
     process.stdout.write(JSON.stringify(out) + "\n");
   };
+
+  if (waitIdle) {
+    const startedAt = Date.now();
+    for (;;) {
+      const snap = await snapshotStatus(record);
+      if (snap.state === "idle") {
+        emit(snap);
+        return 0;
+      }
+      if (snap.state === "stopped") {
+        emit(snap);
+        return 1;
+      }
+      if (timeoutMs !== null && Date.now() - startedAt >= timeoutMs) {
+        emit(snap);
+        return 2;
+      }
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  }
 
   if (!watch) {
     emit(await snapshotStatus(record));


### PR DESCRIPTION
## Summary
- Adds `ay status <pid> --wait-idle [--timeout=Ns] [--interval=N]` so scripts can block until an agent transitions to `state == "idle"`.
- Exit codes: `0` = idle, `1` = stopped before idle, `2` = timeout.
- Surfaces the new idiom in the `ay status` hint line shown after `ay ls`.

### Why
`ay status --json` has two distinct fields users keep confusing:

- `state` (`"active" | "idle" | "stopped"`) — lifecycle, also the STATUS column in `ay ls`
- `activity` — free-text summary extracted from the log (often `null`)

A polling loop like `until ay status <pid> --json | grep '"activity":"idle"'; do sleep 5; done` loops **forever**, because `"idle"` lives on `state`, not `activity`. `--wait-idle` removes the field-naming footgun.

## Test plan
- [x] Unit tests in `ts/subcommands.spec.ts` cover all three exit codes (idle / stopped / timeout)
- [x] Full suite: 308 passed, 1 skipped
- [x] Manual smoke against live agents:
  - idle agent → exit 0 immediately
  - stopped agent → exit 1
  - active agent + `--timeout=2s` → exit 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)