### PR TITLE
feat: enable --stdpush by default so ay send works out of the box

### DIFF
--- a/ts/parseCliArgs.spec.ts
+++ b/ts/parseCliArgs.spec.ts
@@ -425,15 +425,18 @@ describe("CLI argument parsing", () => {
   it("enables stdpush IPC by default", () => {
     // --stdpush defaults to true so `ay send` works out of the box.
     // Without this, fifo_file ends up null in pids.jsonl and `ay send` returns 409.
-    const result = parseCliArgs(["node", "/path/to/cy", "claude"]);
+    const result = parseCliArgs(["node", "/path/to/ay", "claude"]);
 
     expect(result.useStdinAppend).toBe(true);
   });
 
-  it("respects --no-stdpush opt-out (placed before the CLI name)", () => {
+  it("respects --no-stdpush opt-out only when placed before the CLI positional", () => {
     // halt-at-non-option means agent-yes flags must precede the CLI positional.
-    const result = parseCliArgs(["node", "/path/to/cy", "--no-stdpush", "claude"]);
+    const beforeCli = parseCliArgs(["node", "/path/to/ay", "--no-stdpush", "claude"]);
+    const afterCli = parseCliArgs(["node", "/path/to/ay", "claude", "--no-stdpush"]);
 
-    expect(result.useStdinAppend).toBe(false);
+    expect(beforeCli.useStdinAppend).toBe(false);
+    expect(afterCli.useStdinAppend).toBe(true);
+    expect(afterCli.cliArgs).toContain("--no-stdpush");
   });
 });

--- a/ts/parseCliArgs.spec.ts
+++ b/ts/parseCliArgs.spec.ts
@@ -421,4 +421,19 @@ describe("CLI argument parsing", () => {
     expect(result.queue).toBe(false);
     expect(result.cliArgs).not.toContain("--no-queue");
   });
+
+  it("enables stdpush IPC by default", () => {
+    // --stdpush defaults to true so `ay send` works out of the box.
+    // Without this, fifo_file ends up null in pids.jsonl and `ay send` returns 409.
+    const result = parseCliArgs(["node", "/path/to/cy", "claude"]);
+
+    expect(result.useStdinAppend).toBe(true);
+  });
+
+  it("respects --no-stdpush opt-out (placed before the CLI name)", () => {
+    // halt-at-non-option means agent-yes flags must precede the CLI positional.
+    const result = parseCliArgs(["node", "/path/to/cy", "--no-stdpush", "claude"]);
+
+    expect(result.useStdinAppend).toBe(false);
+  });
 });

--- a/ts/parseCliArgs.ts
+++ b/ts/parseCliArgs.ts
@@ -114,8 +114,9 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
     })
     .option("stdpush", {
       type: "boolean",
-      description: "Enable external input stream to push additional data to stdin",
-      default: false,
+      description:
+        "Enable external input stream to push additional data to stdin (default: true; pass --no-stdpush to disable). Required for `ay send` to deliver messages to this agent.",
+      default: true,
       alias: ["ipc", "fifo"], // backward compatibility
     })
     .option("auto", {
@@ -321,7 +322,7 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
     useSkills: parsedArgv.useSkills,
     swarmHint: parsedArgv.swarmHint,
     appendPrompt: parsedArgv.appendPrompt,
-    useStdinAppend: Boolean(parsedArgv.stdpush || parsedArgv.ipc || parsedArgv.fifo), // Support --stdpush, --ipc, and --fifo (backward compatibility)
+    useStdinAppend: Boolean(parsedArgv.stdpush), // --ipc and --fifo are yargs aliases of --stdpush; reading the canonical key ensures --no-stdpush wins over alias defaults
     showVersion: parsedArgv.version,
     autoYes: parsedArgv.auto !== "no", // auto-yes enabled by default, disabled with --auto=no
     idleAction: parsedArgv.idleAction as string | undefined,


### PR DESCRIPTION
## Problem

`ay send <pid> "msg"` on a freshly-spawned agent fails with:

```
ay send: pid <N>: no fifo_file recorded — agent was not started with --stdpush
```

The root cause is that `--stdpush` defaults to `false` in `parseCliArgs.ts`. Most users (and AI agents driving the CLI) never discover the flag, so the basic remote-control loop — spawn an agent, then talk to it — is broken out of the box.

Investigation context: while building remote control of a Windows dev box via SSH, I hit this on every send attempt. `ay ls` / `ay tail` / `ay serve` all work fine (they read from `pids.jsonl` + log files), but `ay send` always 409s because no agent we spawned the normal way had `fifo_file` populated.

## Fix

Flip `--stdpush` to default `true`. Add `--no-stdpush` for explicit opt-out.

```diff
 .option("stdpush", {
   type: "boolean",
-  description: "Enable external input stream to push additional data to stdin",
-  default: false,
+  description:
+    "Enable external input stream to push additional data to stdin (default: true; pass --no-stdpush to disable). Required for `ay send` to deliver messages to this agent.",
+  default: true,
   alias: ["ipc", "fifo"], // backward compatibility
 })
```

Also simplify the derivation:

```diff
-useStdinAppend: Boolean(parsedArgv.stdpush || parsedArgv.ipc || parsedArgv.fifo)
+useStdinAppend: Boolean(parsedArgv.stdpush)
```

`--ipc` and `--fifo` are yargs aliases of `--stdpush`, so the OR'd fallback is redundant. More importantly, with the new default `true`, the alias keys carry the default through even when the user types `--no-stdpush`, so the OR'd form prevents opt-out from taking effect. Reading the canonical key alone fixes that.

## Backward compatibility

- Anyone passing `--stdpush` explicitly: unaffected (still true).
- Anyone passing `--ipc` or `--fifo`: unaffected (yargs still treats them as aliases that set `stdpush=true`).
- Anyone relying on FIFO **not** existing: on platforms where `createFifoStream` can't create one, `ts/index.ts:911` already does `if (!ipcResult) return s;` — it gracefully falls through. So defaulting on doesn't break anything.
- New opt-out: `--no-stdpush` (must precede the CLI positional because of `halt-at-non-option: true` — covered by the new test).

## Test plan

- `bun test ts/parseCliArgs.spec.ts` → 46 pass / 0 fail (2 new tests cover the default and the opt-out).
- Manual smoke on macOS confirmed.
- Windows verification was attempted on a Tailscale-connected dev box but `checkAndAutoUpdate` kept clobbering the source checkout with the npm version (`ts/versionChecker.ts:122-127` — the `.git` detection appears to mis-trigger on Windows path forms). The fix to that gate is out of scope for this PR; CI/maintainer verification on Windows would be appreciated.
- Pre-existing full-suite failures (36 fail / 7 errors in `configLoader` / `rust-cwd` / etc.) are unrelated to this change — verified by running the same suite against `main` before patching.

## Related

- ROADMAP.md item 10 ("FIFO IPC — Done") implies parity but only Unix is implemented in Rust; this PR doesn't fix that gap, just makes the default behavior reach the TS-side named-pipe path on Windows. Rust-side Windows named pipes are a separate, larger PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)