### PR TITLE
fix: use fileURLToPath for dev-checkout .git detection on Windows

### DIFF
--- a/ts/versionChecker.ts
+++ b/ts/versionChecker.ts
@@ -121,7 +121,11 @@ export async function checkAndAutoUpdate(): Promise<void> {
 
   // Skip auto-update when running from a linked local dev checkout (git repo)
   if (import.meta.url.startsWith("file://") && !import.meta.url.includes("node_modules")) {
-    const scriptDir = path.dirname(new URL(import.meta.url).pathname);
+    // Use fileURLToPath rather than `new URL(url).pathname`: on Windows the
+    // pathname of file:///C:/foo is "/C:/foo" (leading slash before the drive
+    // letter), which path.dirname/path.resolve misinterpret — the .git lookup
+    // then runs against a non-existent path and auto-update fires on dev clones.
+    const scriptDir = path.dirname(fileURLToPath(import.meta.url));
     const repoRoot = path.resolve(scriptDir, "..");
     if (existsSync(path.join(repoRoot, ".git"))) return;
   }


### PR DESCRIPTION
## Problem

The dev-checkout guard in `ts/versionChecker.ts:checkAndAutoUpdate` is supposed to skip the npm auto-update when the binary is running from a source clone. On Windows it doesn't work: a fresh `git clone https://github.com/snomiao/agent-yes.git ... && bun ts/cli.ts ...` triggers the auto-update, which overwrites the global install (and then re-execs with the published version, defeating the point of running from source).

## Root cause

```ts
const scriptDir = path.dirname(new URL(import.meta.url).pathname);
const repoRoot = path.resolve(scriptDir, "..");
if (existsSync(path.join(repoRoot, ".git"))) return;
```

`import.meta.url` on Windows for a file at `C:\Users\foo\ts\versionChecker.ts` is `file:///C:/Users/foo/ts/versionChecker.ts`. `new URL(url).pathname` returns `/C:/Users/foo/ts/versionChecker.ts` — note the leading slash before the drive letter, which is not a valid Win32 path. `path.dirname` and `path.resolve` then produce a garbage `repoRoot`, the `.git` lookup runs against a non-existent path, and the guard never trips.

## Fix

Use `fileURLToPath` (already imported in this file) instead of constructing the path via `URL.pathname`. From the Node URL docs:

> The `url.fileURLToPath(url[, options])` function ensures that the absolute path is decoded correctly. It is recommended to use this function whenever possible instead of `url.pathname`.

```diff
-const scriptDir = path.dirname(new URL(import.meta.url).pathname);
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
```

Same behavior on macOS/Linux (where `pathname` and `fileURLToPath` already agree), correct behavior on Windows.

## Verification

Empirically reproduced on a Windows 11 box (`bun 1.3.13`, `Node 22`):

- **Pre-fix**: `bun ts/cli.ts claude --` → `[agent-yes] Updating 1.90.0 → 1.90.1` (auto-update fired despite running from a fresh `git clone` checkout).
- **Post-fix**: same invocation skips the updater silently.

## Test plan

- `bun run test:coverage` → 312 passed / 1 skipped (no regressions).
- Pre-existing `ts/versionChecker.spec.ts` failure (`importOriginal is not a function` under `bun test`) is unrelated — it fails identically on `main` before this change. The vitest path (which the husky pre-commit uses) does not hit it.
- The change is a single-line swap of a Node stdlib call that's already imported; no new dependencies and no API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)