### PR TITLE
feat(rust): implement Windows named pipes in rs/src/fifo.rs

### DIFF
--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -224,7 +224,7 @@ impl AgentContext {
         // Forwards into the same stdin_tx as user keystrokes, so /auto
         // detection, Ctrl+C handling, and stdin_ready gating apply identically.
         let fifo_handle: Option<std::thread::JoinHandle<()>> = if let Some(ref path) = fifo_path {
-            #[cfg(unix)]
+            #[cfg(any(unix, windows))]
             {
                 match crate::fifo::spawn_fifo_reader(path.clone(), stdin_tx.clone()) {
                     Ok(h) => Some(h),
@@ -234,7 +234,7 @@ impl AgentContext {
                     }
                 }
             }
-            #[cfg(not(unix))]
+            #[cfg(not(any(unix, windows)))]
             {
                 let _ = path;
                 None

--- a/rs/src/fifo.rs
+++ b/rs/src/fifo.rs
@@ -4,27 +4,43 @@
 //! external CLI invocations (`cy send <keyword> <msg>`) inject text into the
 //! agent's stdin without going through the user's terminal.
 //!
-//! Path: `~/.agent-yes/fifo/<pid>.stdin` (homedir keeps it out of the user's
-//! working tree — no .gitignore needed).
+//! Unix path: `~/.agent-yes/fifo/<pid>.stdin` (homedir keeps it out of the
+//! user's working tree — no .gitignore needed).
+//!
+//! Windows path: `\\.\pipe\agent-yes-<pid>` — the Win32 named-pipe namespace,
+//! not a filesystem path. Must match `ts/pidStore.ts:getFifoPath` so that
+//! `ay send` (TS-side `net.connect`) reaches the same endpoint.
 //!
 //! On Unix we use `mkfifo(3)` and then open the FIFO with O_RDWR in our own
 //! process. RDWR keeps the read-end unblocked at open time and prevents EOF
 //! when an external writer closes — same trick `terminal-ws-lib` and the TS
 //! `fifo.ts` use (paired read + dummy-write fds).
 //!
-//! Windows: not yet supported on the Rust side. (TS uses Named Pipes via
-//! `net.createServer`; a Rust port would need `windows::Win32::Pipes` and
-//! is out of scope here.)
+//! On Windows we use Tokio's `NamedPipeServer` (a thin wrapper over
+//! `CreateNamedPipeW`). The pipe is created when the server starts listening
+//! — there is no separate "mknode" step — so `create_fifo` is a no-op there
+//! and `spawn_fifo_reader` owns the entire lifecycle. After each client
+//! disconnects we recreate the server instance so subsequent `ay send` calls
+//! see a live endpoint.
 
 #[cfg(unix)]
 use std::ffi::CString;
 use std::path::{Path, PathBuf};
 use tracing::warn;
 
-/// Resolve the FIFO path for a given pid. Mirrors the layout chosen for the
-/// raw log: a single user-scoped directory under `$HOME/.agent-yes`.
+/// Resolve the FIFO path for a given pid. On Unix this is a filesystem path
+/// under `$HOME/.agent-yes/fifo/`; on Windows it's the Win32 named-pipe
+/// namespace string (`\\.\pipe\agent-yes-<pid>`), which `net.connect` /
+/// `CreateFileW` accept directly.
 pub fn fifo_path(pid: u32) -> Option<PathBuf> {
-    crate::log_files::log_dir().map(|dir| dir.join("fifo").join(format!("{}.stdin", pid)))
+    #[cfg(windows)]
+    {
+        Some(PathBuf::from(format!(r"\\.\pipe\agent-yes-{}", pid)))
+    }
+    #[cfg(not(windows))]
+    {
+        crate::log_files::log_dir().map(|dir| dir.join("fifo").join(format!("{}.stdin", pid)))
+    }
 }
 
 /// Create the FIFO (idempotent — if it already exists from a stale run, unlink first).
@@ -48,7 +64,16 @@ pub fn create_fifo(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+pub fn create_fifo(_path: &Path) -> std::io::Result<()> {
+    // No-op: Win32 named pipes are created the moment the server listens
+    // (see `spawn_fifo_reader`), not by a separate mknode-style call.
+    // Reporting Ok here keeps main.rs's spawn flow symmetric across platforms
+    // without having to special-case "the pipe doesn't exist yet".
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
 pub fn create_fifo(_path: &Path) -> std::io::Result<()> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
@@ -67,15 +92,23 @@ pub fn open_for_reading(path: &Path) -> std::io::Result<std::fs::File> {
         .open(path)
 }
 
+// Kept as a stub on non-unix targets for source-level symmetry — the Windows
+// `spawn_fifo_reader` owns the `NamedPipeServer` directly (the server can't be
+// re-expressed as a `std::fs::File`), so this is not called in practice.
 #[cfg(not(unix))]
+#[allow(dead_code)]
 pub fn open_for_reading(_path: &Path) -> std::io::Result<std::fs::File> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
-        "FIFO IPC not yet supported on this platform",
+        "open_for_reading is not implemented on this platform; use spawn_fifo_reader",
     ))
 }
 
 /// Best-effort cleanup. Failures are logged at debug level.
+///
+/// On Windows the named pipe is reclaimed by the kernel when the last server
+/// instance handle drops, so `remove_file` on `\\.\pipe\<name>` is meaningless
+/// — but it's also harmless (NotFound is silenced below).
 pub fn cleanup_fifo(path: &Path) {
     if let Err(e) = std::fs::remove_file(path) {
         if e.kind() != std::io::ErrorKind::NotFound {
@@ -122,6 +155,118 @@ pub fn spawn_fifo_reader(
                 }
             }
         }
+    });
+    Ok(handle)
+}
+
+/// Windows counterpart: a server-side Win32 named pipe. The thread runs its
+/// own current-thread Tokio runtime because the existing caller (context.rs)
+/// expects a `std::thread::JoinHandle` — wrapping `tokio::spawn` would break
+/// that contract — and because `NamedPipeServer::read` is async-only.
+///
+/// Uses the **pre-create** pattern: at each iteration the next server
+/// instance is created *before* `current.connect()` is awaited. When the
+/// current client disconnects and `current` is dropped, `next` already holds
+/// an instance bound to the same name, so the kernel namespace stays
+/// continuously populated. Without this, the gap between drop and recreate
+/// leaks: clients arriving in that window get `ERROR_FILE_NOT_FOUND` (which
+/// Node surfaces as `connect ENOENT`). Empirically confirmed on Windows 11
+/// build 26200: the *first* `ay send` worked, the *second* failed with
+/// ENOENT until the next instance was staged ahead of the disconnect.
+#[cfg(windows)]
+pub fn spawn_fifo_reader(
+    path: PathBuf,
+    tx: tokio::sync::mpsc::Sender<Vec<u8>>,
+) -> std::io::Result<std::thread::JoinHandle<()>> {
+    use tokio::io::AsyncReadExt;
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("named-pipe path is not valid UTF-16: {:?}", path),
+            )
+        })?
+        .to_owned();
+
+    let handle = std::thread::spawn(move || {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                warn!("named-pipe reader: failed to build runtime: {}", e);
+                return;
+            }
+        };
+        rt.block_on(async move {
+            // Pre-create pattern: always have the NEXT server instance listening
+            // before we let the CURRENT one accept a client. Without this, the
+            // gap between `drop(current)` and `create(next)` removes the pipe
+            // name from the Win32 namespace, so any `ay send` issued in that
+            // window gets ENOENT. Empirically confirmed on Windows 11 build
+            // 26200: the first `ay send` worked, the second (after the gap)
+            // returned `connect ENOENT \\.\pipe\agent-yes-<pid>`.
+            let mut current = match ServerOptions::new()
+                .first_pipe_instance(true)
+                .create(&path_str)
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(
+                        "named-pipe create failed at {} (first instance): {}",
+                        path_str, e
+                    );
+                    return;
+                }
+            };
+            loop {
+                // Stage the next instance *now*, before letting `current`
+                // accept its client. When `current` is dropped at the end of
+                // this iteration, the namespace stays populated because `next`
+                // already holds an instance — so an `ay send` arriving in the
+                // handoff window connects to `next` instead of getting ENOENT.
+                let next = match ServerOptions::new().create(&path_str) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        warn!(
+                            "named-pipe create failed at {} (next instance): {}",
+                            path_str, e
+                        );
+                        return;
+                    }
+                };
+
+                if let Err(e) = current.connect().await {
+                    warn!("named-pipe connect at {} failed: {}", path_str, e);
+                    return;
+                }
+
+                let mut buf = [0u8; 4096];
+                loop {
+                    match current.read(&mut buf).await {
+                        Ok(0) => break, // client disconnected — promote `next`
+                        Ok(n) => {
+                            if tx.send(buf[..n].to_vec()).await.is_err() {
+                                return; // receiver dropped — main loop ended
+                            }
+                        }
+                        Err(e) => {
+                            warn!("named-pipe read error at {}: {}", path_str, e);
+                            break;
+                        }
+                    }
+                }
+
+                // `current` is dropped here (handle released → instance
+                // closes), but `next` already holds a live instance, so the
+                // pipe name remains continuously present in the namespace.
+                current = next;
+            }
+        });
     });
     Ok(handle)
 }


### PR DESCRIPTION
## Problem

`ay send <pid> "msg"` on Windows returned:

```
ay send: pid <N>: no fifo_file recorded — agent was not started with --stdpush
```

The default spawn path uses the Rust binary, and `rs/src/fifo.rs` had no Windows implementation — `create_fifo`/`open_for_reading`/`spawn_fifo_reader` were all `#[cfg(unix)]`, with `#[cfg(not(unix))]` arms returning `Unsupported`. So `fifo_file` was never populated in `pids.jsonl`, and every send hit the 409 path.

## Fix

Three platform-conditional changes in `rs/src/fifo.rs`:

1. **`fifo_path(pid)` on Windows** returns `\\.\pipe\agent-yes-<pid>` (the Win32 named-pipe namespace string). Matches `ts/pidStore.ts:getFifoPath`, so the path written to `pids.jsonl` is something `net.connect` and `CreateFileW` both accept.
2. **`create_fifo` on Windows** is a no-op. The pipe is materialized only when the server starts listening — there's no separate mknode step on Windows. Returning `Ok(())` keeps `main.rs`'s spawn flow symmetric across platforms.
3. **`spawn_fifo_reader` on Windows** owns the entire pipe lifecycle. Runs a current-thread Tokio runtime in a dedicated OS thread (the caller in `context.rs` expects `std::thread::JoinHandle`, not `tokio::JoinHandle`) and serves the pipe with the pre-create pattern (see below).

Plus a one-line widening of a cfg gate in `context.rs` so the spawn call runs on Windows too:

```diff
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
```

## The pre-create pattern — load-bearing

Naïve impl: `create → connect → read → EOF → drop → create → ...`. This *almost* works. The first `ay send` lands fine. The **second** fails with:

```
ay send: connect ENOENT \\.\pipe\agent-yes-<pid>
```

Reason: when `current` is dropped (after the first client disconnects) and **before** the next `ServerOptions::create` returns, the kernel removes the pipe name from the namespace. Any client trying to open the path in that window gets `ERROR_FILE_NOT_FOUND` → `ENOENT`.

The fix is to stage the next instance *before* `current` accepts its client:

```rust
let mut current = ServerOptions::new().first_pipe_instance(true).create(&path)?;
loop {
    let next = ServerOptions::new().create(&path)?;  // ← staged ahead
    current.connect().await?;
    // ... read loop ...
    // current dropped here, but `next` already holds an instance
    current = next;
}
```

`next` is created while `current` is still alive, so the namespace is continuously populated. The handoff is seamless.

## No new deps

`tokio = "1"` with the `full` feature already pulls in `tokio::net::windows::named_pipe`.

## Verification (Windows 11 build 26200, bun 1.3.14)

End-to-end smoke that exercises the previously-failing case:

```powershell
$bin = ".\rs\target\release\agent-yes.exe"
Start-Process -FilePath $bin -ArgumentList "--cli","claude","--robust","true","--prompt","wait silently" -WindowStyle Hidden -PassThru
# wait for register
$rec = Get-Content ~/.agent-yes/pids.jsonl | Select-Object -Last 1 | ConvertFrom-Json
ay send $rec.pid "first"   # ✓ delivered (this worked pre-fix too)
ay send $rec.pid "second"  # ✓ delivered (this was the failure pre-fix)
ay send $rec.pid "third"   # ✓ delivered
ay tail $rec.pid           # all three messages visible in the claude PTY
```

Pre-fix the second/third sends returned `connect ENOENT`; post-fix all three deliver and the PTY shows each prompt in sequence. `pids.jsonl` correctly carries `fifo_file: \\.\pipe\agent-yes-<pid>`.

## `cargo test --bins` on Windows

Confirms my new code is regression-free; surfaces a separate cluster of pre-existing portability gaps that are out of scope for this PR.

```
test result: FAILED. 171 passed; 4 failed; 0 ignored; 0 measured; 1 filtered out
```

| Failed test | Root cause | File | Touched by this PR? |
|---|---|---|---|
| `pid_store::test_is_process_alive_dead` | `is_process_alive` on Windows hard-codes `true` ("conservative"); test asserts `!is_alive(999999)` | `pid_store.rs:179-183` | No |
| `pid_store::test_clean_stale_removes_dead` | Depends on the above | `pid_store.rs` | No |
| `running_lock::test_clean_stale_removes_dead_pids` | Same `is_process_alive` issue | `running_lock.rs` | No |
| `pty_spawner::test_pty_resize_zero_guard` | Spawns `"true"` (Unix shell builtin); `CreateProcessW` errors with `file not found` | `pty_spawner.rs:531` | No |
| (filtered, `--skip`) `running_lock::test_acquire_with_stale_blocker` | Same `is_process_alive` issue → hangs in 2s-poll loop | `running_lock.rs` | No |

All four (five with the skipped one) are Unix-assumption test code in modules I did not touch; none reference `fifo.rs` or `context.rs`. The `#[cfg(all(test, unix))]` test block in `fifo.rs` is unchanged and still passes on Unix.

A follow-up PR can add a Windows `is_process_alive` impl (`OpenProcess` + `GetExitCodeProcess` against `STILL_ACTIVE`) and replace the `"true"` test fixture with something cross-platform. Out of scope here.

## Compatibility

- Unix: zero change to behavior. The `#[cfg(unix)]` block for `create_fifo` / `open_for_reading` / `spawn_fifo_reader` is unmodified; existing tests still pass.
- `wasi`/other non-unix non-windows targets: still get the `Unsupported` error from the catch-all arm — gated under `#[cfg(not(any(unix, windows)))]`.

## Out of scope

- TS-side `ts/beta/fifo.ts` Windows pipe creation (used with `--no-rust`) appears to silently no-op under Bun — separate issue, separate PR.
- Microsecond gap during the very first iteration before `first_pipe_instance(true)` returns. In practice unobservable; closing it would require holding two instances permanently rather than handing off, which complicates ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
