### PR TITLE
feat: hybrid log split — project-local logs, pure-Rust render on exit

### DIFF
--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -53,18 +53,6 @@ vt100-ctt = "0.17"
 # Directories
 dirs = "5"
 
-# Unix-specific
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
-
-# Windows-specific
-[target.'cfg(windows)'.dependencies]
-# Used by `is_process_alive` (OpenProcess + GetExitCodeProcess vs STILL_ACTIVE)
-# so the stale-cleanup path correctly evicts dead pids on Windows. Without
-# this, the Unix fallback hard-coded `true` and three tests asserting against
-# `is_process_alive(<dead-pid>)` hung or failed.
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading"] }
-
 # Misc
 lazy_static = "1"
 once_cell = "1"
@@ -92,6 +80,18 @@ rand = { version = "0.8", optional = true }
 
 # UUID for agent identification
 uuid = { version = "1", features = ["v4"] }
+
+# Unix-specific
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+# Windows-specific
+[target.'cfg(windows)'.dependencies]
+# Used by `is_process_alive` (OpenProcess + GetExitCodeProcess vs STILL_ACTIVE)
+# so the stale-cleanup path correctly evicts dead pids on Windows. Without
+# this, the Unix fallback hard-coded `true` and three tests asserting against
+# `is_process_alive(<dead-pid>)` hung or failed.
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [features]
 default = []

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -87,6 +87,11 @@ pub struct AgentContext {
 
     // Stop scanning for codex session ID after first one is found
     codex_session_found: bool,
+
+    // True once the session ever switched to the alternate screen buffer.
+    // dump_scrollback() reconstructs only the normal buffer, so when this is
+    // set the raw log must NOT be replaced by the rendered log on exit.
+    used_alt_screen: bool,
 }
 
 impl AgentContext {
@@ -123,12 +128,13 @@ impl AgentContext {
             enter_retry_count: 0,
             last_idle_scan_at: None,
             stdout_drop_count: 0,
-            log_writer: LogWriter::new(pid),
+            log_writer: LogWriter::new(pid, &cwd),
             cwd,
             stdin_line_buffer: String::new(),
             codex_session_found: false,
             last_action_screen_hash: None,
             last_checked_screen_hash: None,
+            used_alt_screen: false,
         }
     }
 
@@ -138,6 +144,39 @@ impl AgentContext {
             .raw_log_path
             .as_ref()
             .map(|p| p.to_string_lossy().to_string())
+    }
+
+    /// On exit, render the full scrollback to `<pid>.log` and remove the raw
+    /// byte log (which exists only for live tailing). Returns the rendered log
+    /// path when it replaced the raw log, so the caller can repoint the pid
+    /// index at it. No-op (returns None, keeping the raw log) when the session
+    /// used the alternate screen — whose content the scrollback can't
+    /// reconstruct — or when the render is empty.
+    pub fn finalize_log(&mut self) -> Option<String> {
+        if self.used_alt_screen {
+            return None;
+        }
+        let raw_path = self.log_writer.raw_log_path.clone()?;
+        let raw_str = raw_path.to_string_lossy();
+        let base = raw_str.strip_suffix(".raw.log")?;
+        let rendered_path = std::path::PathBuf::from(format!("{base}.log"));
+
+        let rendered = self.vterm.dump_scrollback();
+        if rendered.trim().is_empty() {
+            return None;
+        }
+
+        // Write the rendered log first; only drop the raw log once it's durable.
+        if let Err(e) = std::fs::write(&rendered_path, rendered.as_bytes()) {
+            warn!("Failed to write rendered log {:?}: {}", rendered_path, e);
+            return None;
+        }
+        if let Err(e) = std::fs::remove_file(&raw_path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                warn!("Failed to remove raw log {:?}: {}", raw_path, e);
+            }
+        }
+        Some(rendered_path.to_string_lossy().to_string())
     }
 
     /// Run the main agent loop.
@@ -499,6 +538,9 @@ impl AgentContext {
 
         // Feed raw output to virtual terminal emulator for accurate screen state
         self.vterm.process(output.as_bytes());
+        // Latch alt-screen usage so finalize_log knows whether the rendered
+        // scrollback can safely stand in for the raw byte log.
+        self.used_alt_screen |= self.vterm.alternate_screen();
 
         // Write back any terminal query responses (DSR, DA) to child process.
         // Lock once and batch all responses to keep them atomic w.r.t. other writers.

--- a/rs/src/fifo.rs
+++ b/rs/src/fifo.rs
@@ -4,7 +4,8 @@
 //! external CLI invocations (`cy send <keyword> <msg>`) inject text into the
 //! agent's stdin without going through the user's terminal.
 //!
-//! Unix path: `~/.agent-yes/fifo/<pid>.stdin` (homedir keeps it out of the
+//! Unix path: `$AGENT_YES_HOME/fifo/<pid>.stdin` or `~/.agent-yes/fifo/<pid>.stdin`
+//! (homedir keeps it out of the
 //! user's working tree — no .gitignore needed).
 //!
 //! Windows path: `\\.\pipe\agent-yes-<pid>` — the Win32 named-pipe namespace,
@@ -29,7 +30,7 @@ use std::path::{Path, PathBuf};
 use tracing::warn;
 
 /// Resolve the FIFO path for a given pid. On Unix this is a filesystem path
-/// under `$HOME/.agent-yes/fifo/`; on Windows it's the Win32 named-pipe
+/// under `$AGENT_YES_HOME/fifo/` or `$HOME/.agent-yes/fifo/`; on Windows it's the Win32 named-pipe
 /// namespace string (`\\.\pipe\agent-yes-<pid>`), which `net.connect` /
 /// `CreateFileW` accept directly.
 pub fn fifo_path(pid: u32) -> Option<PathBuf> {
@@ -39,7 +40,7 @@ pub fn fifo_path(pid: u32) -> Option<PathBuf> {
     }
     #[cfg(not(windows))]
     {
-        crate::log_files::log_dir().map(|dir| dir.join("fifo").join(format!("{}.stdin", pid)))
+        crate::log_files::global_dir().map(|dir| dir.join("fifo").join(format!("{}.stdin", pid)))
     }
 }
 
@@ -332,9 +333,9 @@ mod tests {
     }
 
     #[test]
-    fn test_fifo_path_uses_log_dir() {
+    fn test_fifo_path_uses_global_dir() {
         let p = fifo_path(42).expect("home dir resolves in test env");
-        // Always under <log_dir>/fifo/<pid>.stdin
+        // Always under <global_dir>/fifo/<pid>.stdin
         assert!(p.ends_with("fifo/42.stdin"));
         let parent = p.parent().unwrap();
         assert!(parent.ends_with("fifo"));

--- a/rs/src/log_files.rs
+++ b/rs/src/log_files.rs
@@ -1,8 +1,13 @@
-//! Per-session file logging — write raw PTY output to ~/.agent-yes/<pid>.raw.log
+//! Per-session file logging.
+//!
+//! Durable PTY logs live under `<cwd>/.agent-yes/` so they stay with the
+//! project that produced them. Machine-global runtime state such as the pid
+//! index, FIFO endpoints, winsize signals, and locks lives under
+//! `$AGENT_YES_HOME` or `~/.agent-yes`.
 
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tracing::warn;
 
@@ -13,10 +18,11 @@ pub struct LogWriter {
 }
 
 impl LogWriter {
-    pub fn new(pid: u32) -> Self {
-        let (file, path) = match log_dir() {
+    pub fn new(pid: u32, cwd: &str) -> Self {
+        let (file, path) = match project_log_dir(cwd) {
             Some(dir) => {
                 let _ = fs::create_dir_all(&dir);
+                let _ = ensure_project_gitignore(&dir);
                 let path = dir.join(format!("{}.raw.log", pid));
                 match fs::OpenOptions::new().create(true).append(true).open(&path) {
                     Ok(f) => (Some(f), Some(path)),
@@ -43,8 +49,22 @@ impl LogWriter {
     }
 }
 
-pub fn log_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".agent-yes"))
+pub fn global_dir() -> Option<PathBuf> {
+    std::env::var_os("AGENT_YES_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".agent-yes")))
+}
+
+pub fn project_log_dir(cwd: &str) -> Option<PathBuf> {
+    Some(Path::new(cwd).join(".agent-yes"))
+}
+
+fn ensure_project_gitignore(dir: &Path) -> std::io::Result<()> {
+    let path = dir.join(".gitignore");
+    if path.exists() {
+        return Ok(());
+    }
+    fs::write(path, "/*\n!.gitignore\n")
 }
 
 #[cfg(test)]
@@ -52,34 +72,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_log_dir_returns_some() {
-        let dir = log_dir();
+    fn test_global_dir_returns_some() {
+        let dir = global_dir();
         assert!(dir.is_some());
         assert!(dir.unwrap().ends_with(".agent-yes"));
     }
 
     #[test]
+    fn test_project_log_dir_uses_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = project_log_dir(dir.path().to_str().unwrap()).unwrap();
+        assert_eq!(log_dir, dir.path().join(".agent-yes"));
+    }
+
+    #[test]
     fn test_log_writer_new_and_write() {
-        let writer = LogWriter::new(std::process::id());
+        let dir = tempfile::tempdir().unwrap();
+        let writer = LogWriter::new(std::process::id(), dir.path().to_str().unwrap());
         assert!(writer.raw_log_path.is_some());
         writer.write("test log line\n");
         // Verify file exists and has content
         let path = writer.raw_log_path.as_ref().unwrap();
+        assert!(path.starts_with(dir.path().join(".agent-yes")));
         let content = std::fs::read_to_string(path).unwrap();
         assert!(content.contains("test log line"));
-        // Cleanup
-        let _ = std::fs::remove_file(path);
+        assert!(dir.path().join(".agent-yes/.gitignore").exists());
     }
 
     #[test]
     fn test_log_writer_write_multiple() {
-        let writer = LogWriter::new(std::process::id() + 100000);
+        let dir = tempfile::tempdir().unwrap();
+        let writer = LogWriter::new(std::process::id() + 100000, dir.path().to_str().unwrap());
         writer.write("line1\n");
         writer.write("line2\n");
         let path = writer.raw_log_path.as_ref().unwrap();
         let content = std::fs::read_to_string(path).unwrap();
         assert!(content.contains("line1"));
         assert!(content.contains("line2"));
-        let _ = std::fs::remove_file(path);
     }
 }

--- a/rs/src/log_files.rs
+++ b/rs/src/log_files.rs
@@ -64,7 +64,7 @@ fn ensure_project_gitignore(dir: &Path) -> std::io::Result<()> {
     if path.exists() {
         return Ok(());
     }
-    fs::write(path, "/*\n!.gitignore\n")
+    fs::write(path, "*\n")
 }
 
 #[cfg(test)]

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -179,6 +179,7 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
 
     // Clean up stale PID records on startup
     let pid_store = PidStore::new();
+    pid_store.prune_old_logs();
     pid_store.clean_stale();
 
     loop {
@@ -242,6 +243,11 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
             fifo::cleanup_fifo(p);
         }
 
+        // Render the full scrollback to <pid>.log and drop the now-redundant
+        // raw byte log (kept only when the session used the alternate screen).
+        // The returned path repoints the pid index from the raw log to it.
+        let rendered_log = agent_ctx.finalize_log();
+
         // Update PID store and send EXIT webhook
         let exit_reason = if agent_ctx.is_user_abort {
             "user_abort"
@@ -252,7 +258,13 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
         } else {
             "crashed"
         };
-        pid_store.update_status(pid, "exited", Some(exit_code), Some(exit_reason));
+        pid_store.update_status(
+            pid,
+            "exited",
+            Some(exit_code),
+            Some(exit_reason),
+            rendered_log.as_deref(),
+        );
         webhook::notify(
             "EXIT",
             &format!("{} exitCode={}", exit_reason, exit_code),

--- a/rs/src/pid_store.rs
+++ b/rs/src/pid_store.rs
@@ -4,8 +4,10 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{BufRead, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::warn;
+
+const DEFAULT_LOG_RETENTION_DAYS: i64 = 7;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PidRecord {
@@ -84,6 +86,7 @@ impl PidStore {
         status: &str,
         exit_code: Option<i32>,
         exit_reason: Option<&str>,
+        log_file: Option<&str>,
     ) {
         let result = (|| -> Result<()> {
             let mut records = self.read_all()?;
@@ -92,6 +95,11 @@ impl PidStore {
                     r.status = status.to_string();
                     r.exit_code = exit_code;
                     r.exit_reason = exit_reason.map(|s| s.to_string());
+                    // Only repoint the log when given one (raw -> rendered on
+                    // clean exit); otherwise keep the raw path recorded at start.
+                    if let Some(lf) = log_file {
+                        r.log_file = Some(lf.to_string());
+                    }
                 }
             }
             self.write_all(&records)
@@ -112,6 +120,37 @@ impl PidStore {
         })();
         if let Err(e) = result {
             warn!("PidStore: failed to clean stale: {}", e);
+        }
+    }
+
+    pub fn prune_old_logs(&self) {
+        let result = (|| -> Result<usize> {
+            let records = self.read_all()?;
+            let now = chrono::Utc::now().timestamp_millis();
+            let max_age_ms = log_retention_ms();
+            let mut removed = 0;
+            for r in records {
+                let dead = r.status == "exited" || !is_process_alive(r.pid);
+                let old = now.saturating_sub(r.started_at) > max_age_ms;
+                if !dead || !old {
+                    continue;
+                }
+                for path in log_siblings(r.log_file.as_deref()) {
+                    match fs::remove_file(&path) {
+                        Ok(()) => removed += 1,
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(e) => warn!("PidStore: failed to prune log {:?}: {}", path, e),
+                    }
+                }
+            }
+            Ok(removed)
+        })();
+        match result {
+            Ok(removed) if removed > 0 => {
+                tracing::debug!("PidStore: pruned {} stale log file(s)", removed);
+            }
+            Ok(_) => {}
+            Err(e) => warn!("PidStore: failed to prune old logs: {}", e),
         }
     }
 
@@ -166,9 +205,36 @@ impl PidStore {
 }
 
 fn store_path() -> PathBuf {
-    crate::log_files::log_dir()
+    crate::log_files::global_dir()
         .unwrap_or_else(|| PathBuf::from(".agent-yes"))
         .join("pids.jsonl")
+}
+
+fn log_retention_ms() -> i64 {
+    let days = std::env::var("AGENT_YES_LOG_RETENTION_DAYS")
+        .ok()
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|d| *d > 0)
+        .unwrap_or(DEFAULT_LOG_RETENTION_DAYS);
+    days * 24 * 60 * 60 * 1000
+}
+
+fn log_siblings(log_file: Option<&str>) -> Vec<PathBuf> {
+    let Some(log_file) = log_file else {
+        return vec![];
+    };
+    let path = Path::new(log_file);
+    let s = path.to_string_lossy();
+    let base = s
+        .strip_suffix(".raw.log")
+        .or_else(|| s.strip_suffix(".log"))
+        .unwrap_or(&s);
+    vec![
+        PathBuf::from(format!("{base}.raw.log")),
+        PathBuf::from(format!("{base}.log")),
+        PathBuf::from(format!("{base}.lines.log")),
+        PathBuf::from(format!("{base}.debug.log")),
+    ]
 }
 
 pub fn is_process_alive(pid: u32) -> bool {
@@ -241,7 +307,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = PidStore::with_path(dir.path().join("pids.jsonl"));
         store.register(42, "claude", None, "/tmp", None);
-        store.update_status(42, "exited", Some(0), Some("done"));
+        store.update_status(42, "exited", Some(0), Some("done"), None);
         let records = store.read_all().unwrap();
         assert_eq!(records[0].status, "exited");
         assert_eq!(records[0].exit_code, Some(0));
@@ -313,5 +379,41 @@ mod tests {
         let loaded = store.read_all().unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].pid, 1);
+    }
+
+    #[test]
+    fn test_prune_old_logs_removes_dead_old_log_siblings() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = PidStore::with_path(dir.path().join("pids.jsonl"));
+        let base = dir.path().join("1234");
+        let raw = PathBuf::from(format!("{}.raw.log", base.display()));
+        let rendered = PathBuf::from(format!("{}.log", base.display()));
+        let lines = PathBuf::from(format!("{}.lines.log", base.display()));
+        std::fs::write(&raw, "raw").unwrap();
+        std::fs::write(&rendered, "rendered").unwrap();
+        std::fs::write(&lines, "lines").unwrap();
+
+        let old_started_at = chrono::Utc::now().timestamp_millis()
+            - (DEFAULT_LOG_RETENTION_DAYS + 1) * 24 * 60 * 60 * 1000;
+        store
+            .write_all(&[PidRecord {
+                pid: 999999,
+                cli: "claude".into(),
+                prompt: None,
+                cwd: "/tmp".into(),
+                log_file: Some(raw.to_string_lossy().to_string()),
+                fifo_file: None,
+                status: "exited".into(),
+                exit_code: Some(0),
+                exit_reason: Some("completed".into()),
+                started_at: old_started_at,
+            }])
+            .unwrap();
+
+        store.prune_old_logs();
+
+        assert!(!raw.exists());
+        assert!(!rendered.exists());
+        assert!(!lines.exists());
     }
 }

--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -38,14 +38,15 @@ pub fn get_terminal_size_from_tty() -> (u16, u16) {
 /// PTY at the wrong size forever.
 const WINSIZE_STALE_MS: u128 = 30_000;
 
-/// Read `~/.agent-yes/winsize/<pid>` if a recent `ay attach` wrote one.
+/// Read `$AGENT_YES_HOME/winsize/<pid>` or `~/.agent-yes/winsize/<pid>` if a
+/// recent `ay attach` wrote one.
 /// Format: `<cols> <rows> <timestamp_ms>\n`. Returns None when the file is
 /// missing, malformed, or older than [`WINSIZE_STALE_MS`].
 ///
 /// Used by the SIGWINCH handler so attach clients can override the agent's
 /// PTY size even though the agent has no TTY of its own.
 pub fn read_external_winsize(pid: u32) -> Option<(u16, u16)> {
-    let dir = crate::log_files::log_dir()?;
+    let dir = crate::log_files::global_dir()?;
     read_external_winsize_from(&dir, pid)
 }
 

--- a/rs/src/running_lock.rs
+++ b/rs/src/running_lock.rs
@@ -1,5 +1,5 @@
 //! File-based process lock — prevents concurrent agent-yes runs in the same directory.
-//! Lock file: ~/.agent-yes/running.lock.json
+//! Lock file: `$AGENT_YES_HOME/running.lock.json` or `~/.agent-yes/running.lock.json`
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -137,7 +137,7 @@ impl Drop for RunningLock {
 }
 
 fn lock_path() -> PathBuf {
-    crate::log_files::log_dir()
+    crate::log_files::global_dir()
         .unwrap_or_else(|| PathBuf::from(".agent-yes"))
         .join("running.lock.json")
 }

--- a/rs/src/vterm.rs
+++ b/rs/src/vterm.rs
@@ -142,6 +142,54 @@ impl VTermProxy {
         self.parser.screen().cursor_position()
     }
 
+    /// True if the terminal is currently showing the alternate screen buffer.
+    /// Used to detect alt-screen TUIs, whose content is NOT retained in the
+    /// normal-buffer scrollback that `dump_scrollback` reconstructs.
+    pub fn alternate_screen(&self) -> bool {
+        self.parser.screen().alternate_screen()
+    }
+
+    /// Render the full normal-buffer history (scrollback + visible screen) as
+    /// plain text — the rust equivalent of the TS `XtermProxy.render()`.
+    ///
+    /// vt100 only exposes one visible window at a time, so we walk the
+    /// scrollback from the oldest line down to the live screen, indexing every
+    /// row by its absolute position (overlapping windows simply overwrite the
+    /// same slot). The viewport is restored to the live screen before return.
+    pub fn dump_scrollback(&mut self) -> String {
+        let (rows, cols) = self.parser.screen().size();
+        let h = rows.max(1) as usize;
+
+        // set_scrollback clamps to the real scrollback size; read it back to
+        // learn the maximum offset (number of rows above the visible screen).
+        self.parser.screen_mut().set_scrollback(usize::MAX);
+        let max = self.parser.screen().scrollback();
+
+        let total = max + h;
+        let mut lines: Vec<String> = vec![String::new(); total];
+        let mut off = max;
+        loop {
+            self.parser.screen_mut().set_scrollback(off);
+            let base = max - off; // absolute index of the first visible row
+            for (i, row) in self.parser.screen().rows(0, cols).enumerate() {
+                if base + i < total {
+                    lines[base + i] = row;
+                }
+            }
+            if off == 0 {
+                break;
+            }
+            off = off.saturating_sub(h);
+        }
+        self.parser.screen_mut().set_scrollback(0); // restore the live view
+
+        // Trim trailing blank lines.
+        while lines.len() > 1 && lines.last().map_or(false, |l| l.trim().is_empty()) {
+            lines.pop();
+        }
+        lines.join("\n")
+    }
+
     /// Resize the virtual terminal. Dimensions are clamped to at least 1×1
     /// to match the same guard in `new()`.
     pub fn resize(&mut self, rows: u16, cols: u16) {
@@ -295,5 +343,62 @@ mod tests {
             "screen should be cleared: {}",
             contents
         );
+    }
+
+    #[test]
+    fn test_dump_scrollback_recovers_lines_scrolled_off_screen() {
+        // 3-row screen; write 10 lines so the first 7 scroll into history.
+        // Trailing '!' terminator keeps "line 1!" from matching "line 10!".
+        let mut vt = VTermProxy::new(3, 80);
+        for i in 1..=10 {
+            vt.process(format!("line {i}!\r\n").as_bytes());
+        }
+
+        // The visible screen only holds the last few lines...
+        let visible = vt.contents();
+        assert!(
+            !visible.contains("line 1!"),
+            "early line should have scrolled off the visible screen: {visible}"
+        );
+
+        // ...but dump_scrollback walks the scrollback and recovers the whole
+        // history, start to end.
+        let full = vt.dump_scrollback();
+        assert!(
+            full.contains("line 1!"),
+            "dump should recover line 1: {full}"
+        );
+        assert!(
+            full.contains("line 5!"),
+            "dump should recover line 5: {full}"
+        );
+        assert!(
+            full.contains("line 10!"),
+            "dump should recover line 10: {full}"
+        );
+        // Ordered: line 1 appears before line 10.
+        assert!(full.find("line 1!").unwrap() < full.find("line 10!").unwrap());
+
+        // The viewport is restored to the live screen after dumping.
+        assert_eq!(vt.contents(), visible);
+    }
+
+    #[test]
+    fn test_dump_scrollback_no_scrollback_returns_visible() {
+        let mut vt = VTermProxy::new(24, 80);
+        vt.process(b"hello\r\nworld");
+        let full = vt.dump_scrollback();
+        assert!(full.contains("hello"));
+        assert!(full.contains("world"));
+    }
+
+    #[test]
+    fn test_alternate_screen_detection() {
+        let mut vt = VTermProxy::new(24, 80);
+        assert!(!vt.alternate_screen());
+        vt.process(b"\x1b[?1049h"); // enter alternate screen
+        assert!(vt.alternate_screen());
+        vt.process(b"\x1b[?1049l"); // leave alternate screen
+        assert!(!vt.alternate_screen());
     }
 }

--- a/rs/tests/integration_tests.rs
+++ b/rs/tests/integration_tests.rs
@@ -332,8 +332,8 @@ fn test_cwd_flag_rejects_missing_directory() {
     cmd.assert().failure();
 }
 
-/// Integration test: `agent-yes` creates a per-pid FIFO at the expected
-/// path and registers it in `~/.agent-yes/pids.jsonl` with `fifo_file`
+/// Integration test: `agent-yes` creates project-local logs, a per-pid
+/// global FIFO, and registers both absolute paths in `~/.agent-yes/pids.jsonl`
 /// populated. End-to-end byte flow through the FIFO is covered by the
 /// unit tests in `src/fifo.rs` (round-trip read after external writer
 /// closes via the RDWR-keepalive trick) and the live smoke test in the
@@ -351,6 +351,8 @@ fn test_fifo_registered() {
     fs::create_dir_all(&bin_dir).unwrap();
     let home_dir = dir.path().join("home");
     fs::create_dir_all(&home_dir).unwrap();
+    let project_dir = dir.path().join("project");
+    fs::create_dir_all(&project_dir).unwrap();
 
     // Mock claude that prints the ready cue and exits quickly, so agent-yes
     // creates+registers the FIFO and then cleans it up on the natural exit.
@@ -378,6 +380,7 @@ exit 0
         let mut cmd = Command::cargo_bin("agent-yes").unwrap();
         cmd.env("PATH", new_path)
             .env("HOME", &home_dir)
+            .current_dir(&project_dir)
             .arg("--cli")
             .arg("claude")
             .arg("--timeout")
@@ -388,8 +391,7 @@ exit 0
         cmd.output().expect("agent-yes failed to run")
     };
 
-    // Registry should exist and contain a record with a fifo_file path
-    // under our home dir.
+    // Registry should exist under the global home dir.
     let pids_file = home_dir.join(".agent-yes/pids.jsonl");
     if !pids_file.exists() {
         // Soft-skip if the agent didn't progress far enough on this CI
@@ -405,6 +407,24 @@ exit 0
         pids_content.contains("\"fifo_file\""),
         "expected pids.jsonl to record fifo_file, got:\n{pids_content}"
     );
+    let record: serde_json::Value = pids_content
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .last()
+        .expect("expected at least one pid record");
+    let log_file = record["log_file"].as_str().expect("log_file should be set");
+    let fifo_file = record["fifo_file"]
+        .as_str()
+        .expect("fifo_file should be set");
+    let project_agent_dir = fs::canonicalize(project_dir.join(".agent-yes")).unwrap();
+    assert!(
+        log_file.starts_with(project_agent_dir.to_str().unwrap()),
+        "expected log_file under project .agent-yes, got {log_file}"
+    );
+    assert!(
+        fifo_file.starts_with(home_dir.join(".agent-yes/fifo").to_str().unwrap()),
+        "expected fifo_file under global home fifo dir, got {fifo_file}"
+    );
 
     // Cleanup-on-clean-exit: only assert when the process actually exited
     // normally. assert_cmd's .timeout() SIGKILLs which (correctly) skips
@@ -419,5 +439,21 @@ exit 0
                 leftover.iter().map(|e| e.path()).collect::<Vec<_>>()
             );
         }
+
+        // On clean exit the scrollback is rendered to <pid>.log, the raw byte
+        // log is dropped, and the index is repointed at the rendered log.
+        assert!(
+            log_file.ends_with(".log") && !log_file.ends_with(".raw.log"),
+            "expected log_file repointed to the rendered .log, got {log_file}"
+        );
+        assert!(
+            std::path::Path::new(log_file).exists(),
+            "expected rendered log to exist at {log_file}"
+        );
+        let raw_log = log_file.strip_suffix(".log").unwrap().to_string() + ".raw.log";
+        assert!(
+            !std::path::Path::new(&raw_log).exists(),
+            "expected raw log to be removed after render, still present at {raw_log}"
+        );
     }
 }

--- a/ts/agentYesHome.spec.ts
+++ b/ts/agentYesHome.spec.ts
@@ -1,0 +1,25 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { homedir } from "os";
+import path from "path";
+import { agentYesHome } from "./agentYesHome.ts";
+
+describe("agentYesHome", () => {
+  let original: string | undefined;
+  beforeEach(() => {
+    original = process.env.AGENT_YES_HOME;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = original;
+  });
+
+  it("uses $AGENT_YES_HOME when set", () => {
+    process.env.AGENT_YES_HOME = "/custom/ay-home";
+    expect(agentYesHome()).toBe("/custom/ay-home");
+  });
+
+  it("falls back to ~/.agent-yes when unset", () => {
+    delete process.env.AGENT_YES_HOME;
+    expect(agentYesHome()).toBe(path.join(homedir(), ".agent-yes"));
+  });
+});

--- a/ts/agentYesHome.ts
+++ b/ts/agentYesHome.ts
@@ -1,0 +1,20 @@
+import { homedir } from "os";
+import path from "path";
+
+/**
+ * Root directory for cross-runtime, machine-global agent-yes state:
+ * the pid index (`pids.jsonl`), FIFO/named-pipe IPC endpoints (`fifo/`),
+ * winsize signals, notes, and the serve token.
+ *
+ * Durable per-session *logs* deliberately do NOT live here — they go under
+ * `<cwd>/.agent-yes/` so they stay colocated with the project that produced
+ * them (see `PidStore`). Only ephemeral IPC + the discovery index are global,
+ * which keeps FIFOs on the local home filesystem (reliable `mkfifo`) and lets
+ * `ay ls`/`ay attach` find every agent regardless of the caller's cwd.
+ *
+ * Resolved at call time (not module load) so tests and callers can override
+ * via `$AGENT_YES_HOME` without juggling the module cache.
+ */
+export function agentYesHome(): string {
+  return process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes");
+}

--- a/ts/core/logging.ts
+++ b/ts/core/logging.ts
@@ -20,17 +20,17 @@ export interface LogPaths {
  * @returns Object containing all log paths
  */
 export async function initializeLogPaths(pidStore: PidStore, pid: number): Promise<LogPaths> {
-  const logDir = pidStore.getLogDir();
-  await mkdir(logDir, { recursive: true });
-  const rawLogPath = path.resolve(path.dirname(logDir), `${pid}.raw.log`);
-  const rawLinesLogPath = path.resolve(path.dirname(logDir), `${pid}.lines.log`);
-  const debuggingLogsPath = path.resolve(path.dirname(logDir), `${pid}.debug.log`);
+  const storeDir = pidStore.getStoreDir();
+  await mkdir(storeDir, { recursive: true });
 
   return {
-    logPath: logDir,
-    rawLogPath,
-    rawLinesLogPath,
-    debuggingLogsPath,
+    // Rendered plain-text log (final). Previously this was the logs/ *directory*,
+    // so saveLogFile's writeFile() hit EISDIR and the render was silently lost —
+    // which is why raw logs piled up forever (nothing was ever "rendered").
+    logPath: pidStore.getRenderedLogPath(pid),
+    rawLogPath: pidStore.getRawLogPath(pid),
+    rawLinesLogPath: path.resolve(storeDir, `${pid}.lines.log`),
+    debuggingLogsPath: path.resolve(storeDir, `${pid}.debug.log`),
   };
 }
 
@@ -55,12 +55,19 @@ export async function setupDebugLogging(debuggingLogsPath: string | false): Prom
  * @param logPath Path to log file
  * @param content Rendered content to save
  */
-export async function saveLogFile(logPath: string | false, content: string) {
-  if (!logPath) return;
+export async function saveLogFile(logPath: string | false, content: string): Promise<boolean> {
+  if (!logPath) return false;
+  if (!content.trim()) return false; // nothing meaningful to persist
 
-  await mkdir(path.dirname(logPath), { recursive: true }).catch(() => null);
-  await writeFile(logPath, content).catch(() => null);
-  logger.info(`Full logs saved to ${logPath}`);
+  try {
+    await mkdir(path.dirname(logPath), { recursive: true });
+    await writeFile(logPath, content);
+    logger.info(`Full logs saved to ${logPath}`);
+    return true;
+  } catch (error) {
+    logger.warn(`Failed to save rendered log to ${logPath}:`, error);
+    return false;
+  }
 }
 
 /**

--- a/ts/globalPidIndex.spec.ts
+++ b/ts/globalPidIndex.spec.ts
@@ -205,6 +205,146 @@ describe("globalPidIndex", () => {
     await mod.maybeCompactGlobalPids(); // no throw, no error
   });
 
+  it("updateGlobalPidStatus can repoint log_file (raw -> rendered)", async () => {
+    const mod = await loadModule();
+    await mod.appendGlobalPid({
+      pid: 4242,
+      cli: "claude",
+      prompt: null,
+      cwd: "/a",
+      log_file: "/a/.agent-yes/4242.raw.log",
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: 1,
+    });
+    await mod.updateGlobalPidStatus(4242, { log_file: "/a/.agent-yes/4242.log" });
+    const records = await mod.readGlobalPids();
+    expect(records[0]?.log_file).toBe("/a/.agent-yes/4242.log");
+  });
+
+  describe("pruneOldLogs", () => {
+    it("deletes log siblings of old, dead sessions but keeps live/recent ones", async () => {
+      const mod = await loadModule();
+      const { mkdir, writeFile } = await import("fs/promises");
+      const { existsSync } = await import("fs");
+      const dir = path.join(testHome, "logs");
+      await mkdir(dir, { recursive: true });
+
+      // Old + dead pid: should be pruned (raw + rendered + sidecars).
+      const deadRaw = path.join(dir, "999999.raw.log");
+      const deadRendered = path.join(dir, "999999.log");
+      const deadLines = path.join(dir, "999999.lines.log");
+      for (const f of [deadRaw, deadRendered, deadLines]) await writeFile(f, "x");
+
+      // Live pid (this process), old timestamp: must be kept (still running).
+      const liveRaw = path.join(dir, `${process.pid}.raw.log`);
+      await writeFile(liveRaw, "x");
+
+      // Dead pid but recent: must be kept (inside retention window).
+      const recentRaw = path.join(dir, "999998.raw.log");
+      await writeFile(recentRaw, "x");
+
+      const oldTs = Date.now() - 30 * 24 * 60 * 60 * 1000; // 30 days ago
+      await mod.appendGlobalPid({
+        pid: 999999,
+        cli: "claude",
+        prompt: null,
+        cwd: "/a",
+        log_file: deadRaw,
+        status: "exited",
+        exit_code: 0,
+        exit_reason: null,
+        started_at: oldTs,
+      });
+      await mod.appendGlobalPid({
+        pid: process.pid,
+        cli: "claude",
+        prompt: null,
+        cwd: "/a",
+        log_file: liveRaw,
+        status: "active",
+        exit_code: null,
+        exit_reason: null,
+        started_at: oldTs,
+      });
+      await mod.appendGlobalPid({
+        pid: 999998,
+        cli: "claude",
+        prompt: null,
+        cwd: "/a",
+        log_file: recentRaw,
+        status: "exited",
+        exit_code: 0,
+        exit_reason: null,
+        started_at: Date.now(),
+      });
+
+      const removed = await mod.pruneOldLogs();
+
+      expect(removed).toBe(3); // deadRaw + deadRendered + deadLines
+      expect(existsSync(deadRaw)).toBe(false);
+      expect(existsSync(deadRendered)).toBe(false);
+      expect(existsSync(deadLines)).toBe(false);
+      expect(existsSync(liveRaw)).toBe(true);
+      expect(existsSync(recentRaw)).toBe(true);
+    });
+
+    it("returns 0 and does not throw when the index is empty", async () => {
+      const mod = await loadModule();
+      expect(await mod.pruneOldLogs()).toBe(0);
+    });
+
+    it("skips records with no log_file and honors an explicit maxAge", async () => {
+      const mod = await loadModule();
+      await mod.appendGlobalPid({
+        pid: 999999,
+        cli: "claude",
+        prompt: null,
+        cwd: "/a",
+        log_file: null,
+        status: "exited",
+        exit_code: 0,
+        exit_reason: null,
+        started_at: 1,
+      });
+      // Old + dead but no log_file to delete → nothing removed, no throw.
+      expect(await mod.pruneOldLogs(1)).toBe(0);
+    });
+
+    it("respects $AGENT_YES_LOG_RETENTION_DAYS for the default window", async () => {
+      const mod = await loadModule();
+      const { mkdir, writeFile } = await import("fs/promises");
+      const { existsSync } = await import("fs");
+      const dir = path.join(testHome, "logs");
+      await mkdir(dir, { recursive: true });
+      const raw = path.join(dir, "999999.raw.log");
+      await writeFile(raw, "x");
+      const twoDaysAgo = Date.now() - 2 * 24 * 60 * 60 * 1000;
+      await mod.appendGlobalPid({
+        pid: 999999,
+        cli: "claude",
+        prompt: null,
+        cwd: "/a",
+        log_file: raw,
+        status: "exited",
+        exit_code: 0,
+        exit_reason: null,
+        started_at: twoDaysAgo,
+      });
+
+      const original = process.env.AGENT_YES_LOG_RETENTION_DAYS;
+      try {
+        process.env.AGENT_YES_LOG_RETENTION_DAYS = "1"; // 1-day window → 2-day-old log is stale
+        expect(await mod.pruneOldLogs()).toBe(1);
+        expect(existsSync(raw)).toBe(false);
+      } finally {
+        if (original === undefined) delete process.env.AGENT_YES_LOG_RETENTION_DAYS;
+        else process.env.AGENT_YES_LOG_RETENTION_DAYS = original;
+      }
+    });
+  });
+
   it("skips corrupt lines without throwing", async () => {
     const mod = await loadModule();
     await mod.appendGlobalPid({

--- a/ts/globalPidIndex.ts
+++ b/ts/globalPidIndex.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, readFile, rename, writeFile } from "fs/promises";
+import { appendFile, mkdir, readFile, rename, unlink, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
 import { lock } from "proper-lockfile";
@@ -86,10 +86,10 @@ export async function appendGlobalPid(record: GlobalPidRecord): Promise<void> {
   }
 }
 
-/** Append a partial status update by pid (status, exit_code, exit_reason). */
+/** Append a partial update by pid (status, exit_code, exit_reason, log_file). */
 export async function updateGlobalPidStatus(
   pid: number,
-  patch: Partial<Pick<GlobalPidRecord, "status" | "exit_code" | "exit_reason">>,
+  patch: Partial<Pick<GlobalPidRecord, "status" | "exit_code" | "exit_reason" | "log_file">>,
 ): Promise<void> {
   try {
     await withLock(async () => {
@@ -189,4 +189,56 @@ export async function maybeCompactGlobalPids(): Promise<void> {
   } catch (error) {
     logger.debug("[globalPidIndex] compact failed:", error);
   }
+}
+
+/** Default log retention: sessions older than this whose process is gone. */
+const DEFAULT_RETENTION_DAYS = 7;
+
+function retentionMs(): number {
+  const days = Number(process.env.AGENT_YES_LOG_RETENTION_DAYS);
+  return (Number.isFinite(days) && days > 0 ? days : DEFAULT_RETENTION_DAYS) * 24 * 60 * 60 * 1000;
+}
+
+/** All on-disk log files associated with a record (raw + rendered + sidecars). */
+function logSiblings(logFile: string | null): string[] {
+  if (!logFile) return [];
+  // logFile may point at either `<pid>.raw.log` or `<pid>.log`; derive the rest.
+  const base = logFile.replace(/\.raw\.log$|\.log$/, "");
+  return [`${base}.raw.log`, `${base}.log`, `${base}.lines.log`, `${base}.debug.log`];
+}
+
+/**
+ * Index-driven retention sweep: delete the log files of sessions whose process
+ * is gone (exited or dead pid) and that started longer ago than the retention
+ * window. Because the index records absolute `log_file` paths, this reclaims
+ * logs scattered across many project `.agent-yes/` dirs from one call.
+ * Best-effort; never throws. Returns the number of files removed.
+ */
+export async function pruneOldLogs(maxAgeMs: number = retentionMs()): Promise<number> {
+  let records: GlobalPidRecord[];
+  try {
+    records = await readGlobalPidsRaw();
+  } catch {
+    return 0;
+  }
+  const now = Date.now();
+  let removed = 0;
+  for (const r of records) {
+    const dead = r.status === "exited" || !isProcessAlive(r.pid);
+    const old = now - (r.started_at ?? now) > maxAgeMs;
+    if (!dead || !old) continue;
+    for (const f of logSiblings(r.log_file)) {
+      try {
+        await unlink(f);
+        removed++;
+      } catch {
+        // missing / already gone — ignore
+      }
+    }
+  }
+  if (removed > 0) {
+    logger.debug(`[globalPidIndex] pruned ${removed} stale log file(s)`);
+    await maybeCompactGlobalPids();
+  }
+  return removed;
 }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1,6 +1,6 @@
 import { execaCommandSync, parseCommandString } from "execa";
 import { fromWritable } from "from-node-stream";
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { mkdir, readFile, unlink, writeFile } from "fs/promises";
 import path from "path";
 import DIE from "phpdie";
 import sflow from "sflow";
@@ -382,6 +382,13 @@ export default async function agentYes({
   // Initialize log paths (independent of registration)
   const logPaths = await initializeLogPaths(pidStore, shell.pid);
   await setupDebugLogging(logPaths.debuggingLogsPath);
+
+  // Track whether the session ever switched to the alternate screen buffer.
+  // render() reconstructs scrollback of the normal buffer only; the alt buffer
+  // keeps no scrollback, so for alt-screen apps the rendered log would be just
+  // the final frame and must NOT replace the raw byte log. Current CLIs (ink-
+  // based claude/codex) stay on the normal buffer, but guard for the future.
+  let usedAltScreen = false;
 
   // Create agent context
   const ctx = new AgentContext({
@@ -949,6 +956,11 @@ export default async function agentYes({
           logger.debug(`[${cli}-yes] raw logs streaming to ${rawLogPath}`);
           return f
             .forEach(async (chars) => {
+              // Detect alt-screen enter (DECSET 1049/1047/47) so we know whether
+              // the rendered log can safely stand in for this raw log on exit.
+              if (!usedAltScreen && /\[\?(?:1049|1047|47)h/.test(chars)) {
+                usedAltScreen = true;
+              }
               await writeFile(rawLogPath, chars, { flag: "a" }).catch(() => null);
             })
             .run();
@@ -1054,7 +1066,17 @@ export default async function agentYes({
     .by(createTerminatorStream(pendingExitCode.promise))
     .to(fromWritable(process.stdout));
 
-  await saveLogFile(ctx.logPaths.logPath, xtermProxy.render());
+  const renderedSaved = await saveLogFile(ctx.logPaths.logPath, xtermProxy.render());
+
+  // The raw byte log exists for live tailing during the run. Once a non-empty
+  // rendered log is durably written — and the session stayed on the normal
+  // screen buffer, so the render holds the full scrollback — the raw log is
+  // redundant: drop it and repoint the index at the rendered log. On crash /
+  // empty render / alt-screen we keep the raw log; the startup sweep prunes it.
+  if (renderedSaved && !usedAltScreen && ctx.logPaths.rawLogPath && ctx.logPaths.logPath) {
+    await unlink(ctx.logPaths.rawLogPath).catch(() => null);
+    await pidStore.markRendered(shell.pid, ctx.logPaths.logPath).catch(() => null);
+  }
 
   // and then get its exitcode
   const exitCode = await pendingExitCode.promise;

--- a/ts/pidStore.spec.ts
+++ b/ts/pidStore.spec.ts
@@ -106,7 +106,9 @@ describe("PidStore", () => {
         cwd: "/tmp",
       });
 
-      expect(rec.logFile).toContain("42.log");
+      // The index points at the raw log during the run (repointed to the
+      // rendered <pid>.log on clean exit via markRendered).
+      expect(rec.logFile).toContain("42.raw.log");
       if (isWindows) {
         expect(rec.fifoFile).toContain("agent-yes-42");
       } else {
@@ -245,8 +247,31 @@ describe("PidStore", () => {
       if (isWindows) {
         expect(fifo).toBe(`\\\\.\\pipe\\agent-yes-42`);
       } else {
-        expect(fifo).toBe(path.resolve(TEST_DIR, ".agent-yes", "fifo", "42.stdin"));
+        // FIFO lives under the global home root (AGENT_YES_HOME), not the
+        // project dir — ephemeral IPC is intentionally not colocated with logs.
+        expect(fifo).toBe(path.resolve(GLOBAL_TEST_DIR, "fifo", "42.stdin"));
       }
+    });
+
+    it("raw/rendered/store paths resolve under the project store dir", () => {
+      expect(store.getStoreDir()).toBe(path.resolve(TEST_DIR, ".agent-yes"));
+      expect(store.getRawLogPath(42)).toBe(path.resolve(TEST_DIR, ".agent-yes", "42.raw.log"));
+      expect(store.getRenderedLogPath(42)).toBe(path.resolve(TEST_DIR, ".agent-yes", "42.log"));
+    });
+  });
+
+  describe("markRendered", () => {
+    it("repoints the record's logFile to the rendered path", async () => {
+      await store.registerProcess({ pid: 51, cli: "claude", args: [], cwd: "/tmp" });
+      const rendered = store.getRenderedLogPath(51);
+      await store.markRendered(51, rendered);
+
+      const rec = store.getAllRecords().find((r) => r.pid === 51);
+      expect(rec?.logFile).toBe(rendered);
+    });
+
+    it("is a no-op for an unknown pid", async () => {
+      await expect(store.markRendered(999123, "/whatever/999123.log")).resolves.toBeUndefined();
     });
   });
 

--- a/ts/pidStore.ts
+++ b/ts/pidStore.ts
@@ -2,9 +2,11 @@ import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import { logger } from "./logger.ts";
 import { JsonlStore } from "./JsonlStore.ts";
+import { agentYesHome } from "./agentYesHome.ts";
 import {
   appendGlobalPid,
   maybeCompactGlobalPids,
+  pruneOldLogs,
   updateGlobalPidStatus,
 } from "./globalPidIndex.ts";
 
@@ -37,6 +39,10 @@ export class PidStore {
       await this.ensureGitignore();
       await this.store.load();
       await this.cleanStaleRecords();
+      // Best-effort, fire-and-forget: reclaim raw/rendered logs of long-dead
+      // sessions across all projects. Index-driven so scattered pwd logs are
+      // still swept. Never block startup on it.
+      pruneOldLogs().catch(() => null);
     } catch (error) {
       logger.warn("[pidStore] Failed to initialize:", error);
     }
@@ -57,7 +63,10 @@ export class PidStore {
   }): Promise<PidRecord> {
     const now = Date.now();
     const argsJson = JSON.stringify(args);
-    const logFile = path.resolve(this.getLogDir(), `${pid}.log`);
+    // The index points at the file readers should tail. During the run that is
+    // the raw byte log (`ay logs`/`attach` stream it live); on clean exit it is
+    // repointed to the rendered log via `markRendered`.
+    const logFile = this.getRawLogPath(pid);
     const fifoFile = this.getFifoPath(pid);
 
     const record: Omit<PidRecord, "_id"> = {
@@ -138,16 +147,47 @@ export class PidStore {
     return this.store.getAll();
   }
 
+  /** Project-local store dir: `<cwd>/.agent-yes`. Durable logs live here. */
+  getStoreDir() {
+    return this.storeDir;
+  }
+
   getLogDir() {
     return path.resolve(this.storeDir, "logs");
+  }
+
+  /** Raw PTY byte log (runtime), `<cwd>/.agent-yes/<pid>.raw.log`. */
+  getRawLogPath(pid: number) {
+    return path.resolve(this.storeDir, `${pid}.raw.log`);
+  }
+
+  /** Rendered plain-text log (final), `<cwd>/.agent-yes/<pid>.log`. */
+  getRenderedLogPath(pid: number) {
+    return path.resolve(this.storeDir, `${pid}.log`);
   }
 
   getFifoPath(pid: number) {
     if (process.platform === "win32") {
       return `\\\\.\\pipe\\agent-yes-${pid}`;
     } else {
-      return path.resolve(this.storeDir, "fifo", `${pid}.stdin`);
+      // Ephemeral IPC lives under the global home root, not the project dir:
+      // keeps the FIFO on a local filesystem (reliable mkfifo) and stable even
+      // if the project dir is moved/removed while the agent runs.
+      return path.resolve(agentYesHome(), "fifo", `${pid}.stdin`);
     }
+  }
+
+  /**
+   * Repoint a session's log from the raw byte stream to its rendered text log
+   * (called on clean exit once the rendered log is durably written and the raw
+   * log has been reclaimed). Updates both the local record and global index.
+   */
+  async markRendered(pid: number, renderedPath: string): Promise<void> {
+    const existing = this.store.findOne((doc) => doc.pid === pid);
+    if (existing) {
+      await this.store.updateById(existing._id!, { logFile: renderedPath });
+    }
+    updateGlobalPidStatus(pid, { log_file: renderedPath }).catch(() => null);
   }
 
   async cleanStaleRecords(): Promise<void> {


### PR DESCRIPTION
## Summary

- **Storage split**: durable PTY logs now live in `<cwd>/.agent-yes/` (colocated with the project, auto-gitignored); ephemeral IPC state (FIFO, pid index, winsize, lock) moves to `$AGENT_YES_HOME` / `~/.agent-yes/`. Fixes 709-file / 1.2 GB log accumulation in `~/.agent-yes/`.
- **Pure-Rust render on exit**: `VTermProxy::dump_scrollback()` reconstructs the full normal-buffer scrollback; `AgentContext::finalize_log()` writes `<pid>.log`, removes the raw log, and repoints the pid index — no TS renderer dependency.
- **Log retention**: `PidStore::prune_old_logs()` reclaims raw/rendered logs of dead sessions older than 7d (configurable via `$AGENT_YES_LOG_RETENTION_DAYS`).
- **TS runtime fix**: fix EISDIR on rendered-log write, FIFO location (project→home), and missing retention sweep.
- **gitignore**: simplify project `.agent-yes/.gitignore` content to `*\n`.

## Test plan

- [ ] Unit tests for `dump_scrollback` (scrollback recovery), alt-screen detection, prune, project-vs-global path placement
- [ ] `test_fifo_registered` integration test asserts rendered `<pid>.log` exists, raw log removed, index repointed on clean exit
- [ ] All 322 vitest tests pass (`bun run test:coverage`)
- [ ] Cargo tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)