### PR TITLE
feat: agent-yes.com remote console — WebRTC sharing, xterm TUI, launch URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ bin
 TODO.md
 package-lock.json
 tests/ui-test/screenshots/
+
+# generated: deploy copies lab/ui/index.html here
+lab/ui/cf/public/

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "main",
@@ -33,6 +33,7 @@
         "@vitest/coverage-v8": "4.1.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
+        "node-datachannel": "^0.32.3",
         "node-pty": "^1.1.0",
         "oxfmt": "^0.26.0",
         "oxlint": "^1.41.0",
@@ -58,6 +59,9 @@
       ],
     },
   },
+  "trustedDependencies": [
+    "node-datachannel",
+  ],
   "packages": {
     "@actions/core": ["@actions/core@2.0.2", "", { "dependencies": { "@actions/exec": "^2.0.0", "@actions/http-client": "^3.0.1" } }, "sha512-Ast1V7yHbGAhplAsuVlnb/5J8Mtr/Zl6byPPL+Qjq3lmfIgWF1ak1iYfF/079cRERiuTALTXkSuEUdZeDCfGtA=="],
 
@@ -515,9 +519,13 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
     "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
@@ -526,6 +534,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bson": ["bson@6.10.4", "", {}, "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -552,6 +562,8 @@
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
@@ -713,6 +725,8 @@
 
     "decamelize-keys": ["decamelize-keys@1.1.1", "", { "dependencies": { "decamelize": "^1.1.0", "map-obj": "^1.0.0" } }, "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg=="],
 
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
@@ -724,6 +738,8 @@
     "delaunator": ["delaunator@5.0.1", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw=="],
 
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-newline": ["detect-newline@3.1.0", "", {}, "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="],
 
@@ -748,6 +764,8 @@
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
     "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "env-ci": ["env-ci@11.1.1", "", { "dependencies": { "execa": "^8.0.0", "java-properties": "^1.0.2" } }, "sha512-mT3ks8F0kwpo7SYNds6nWj0PaRh+qJxIeBVBXAKTN9hphAzZv7s0QAZQbqnB1fAv/r4pJUGE15BV9UrS31FP2w=="],
 
@@ -783,6 +801,8 @@
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "expect": ["expect@30.0.4", "", { "dependencies": { "@jest/expect-utils": "30.0.4", "@jest/get-type": "30.0.1", "jest-matcher-utils": "30.0.4", "jest-message-util": "30.0.2", "jest-mock": "30.0.2", "jest-util": "30.0.2" } }, "sha512-dDLGjnP2cKbEppxVICxI/Uf4YemmGMPNy0QytCbfafbpYk9AFQsxb8Uyrxii0RPK7FWgLGlSem+07WirwS3cFQ=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
@@ -812,6 +832,8 @@
     "from-node-stream": ["from-node-stream@0.2.0", "", {}, "sha512-Ufc5Bwzu3MuMtST0F/Nm9YoVWO9xi6I/YAGen5H31z2NzNk1d7V20JFUmYizMemw4Bp6R80sjQuRCw03IiXckA=="],
 
     "from2": ["from2@2.3.0", "", { "dependencies": { "inherits": "^2.0.1", "readable-stream": "^2.0.0" } }, "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
@@ -852,6 +874,8 @@
     "git-semver-tags": ["git-semver-tags@4.1.1", "", { "dependencies": { "meow": "^8.0.0", "semver": "^6.0.0" }, "bin": { "git-semver-tags": "cli.js" } }, "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA=="],
 
     "gitconfiglocal": ["gitconfiglocal@1.0.0", "", { "dependencies": { "ini": "^1.3.2" } }, "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
@@ -896,6 +920,8 @@
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
@@ -1097,6 +1123,8 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
@@ -1104,6 +1132,8 @@
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minimist-options": ["minimist-options@4.1.0", "", { "dependencies": { "arrify": "^1.0.1", "is-plain-obj": "^1.1.0", "kind-of": "^6.0.3" } }, "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "modify-values": ["modify-values@1.0.1", "", {}, "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="],
 
@@ -1115,13 +1145,19 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "nerf-dart": ["nerf-dart@1.0.0", "", {}, "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g=="],
 
     "nice-try": ["nice-try@1.0.5", "", {}, "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="],
 
+    "node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
+
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "node-datachannel": ["node-datachannel@0.32.3", "", { "dependencies": { "prebuild-install": "^7.1.3" } }, "sha512-Aok1ZhLsll472lRefgWYuWJ0070jh0ecHravTdRyZEmoESumebMEQV8Y+poBwSW2ZbEwAokAOGsK5Cu8pDDT2g=="],
 
     "node-emoji": ["node-emoji@2.2.0", "", { "dependencies": { "@sindresorhus/is": "^4.6.0", "char-regex": "^1.0.2", "emojilib": "^2.4.0", "skin-tone": "^2.0.0" } }, "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw=="],
 
@@ -1146,6 +1182,8 @@
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
 
@@ -1221,6 +1259,8 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "pretty-format": ["pretty-format@30.0.2", "", { "dependencies": { "@jest/schemas": "30.0.1", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg=="],
 
     "pretty-ms": ["pretty-ms@9.2.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg=="],
@@ -1230,6 +1270,8 @@
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "q": ["q@1.5.1", "", {}, "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="],
 
@@ -1335,6 +1377,10 @@
 
     "signale": ["signale@1.4.0", "", { "dependencies": { "chalk": "^2.3.2", "figures": "^2.0.0", "pkg-conf": "^2.1.0" } }, "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w=="],
 
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
     "skin-tone": ["skin-tone@2.0.0", "", { "dependencies": { "unicode-emoji-modifier-base": "^1.0.0" } }, "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA=="],
 
     "slash": ["slash@2.0.0", "", {}, "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="],
@@ -1413,6 +1459,10 @@
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
     "temp-dir": ["temp-dir@3.0.0", "", {}, "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw=="],
 
     "tempy": ["tempy@3.1.0", "", { "dependencies": { "is-stream": "^3.0.0", "temp-dir": "^3.0.0", "type-fest": "^2.12.2", "unique-string": "^3.0.0" } }, "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g=="],
@@ -1462,6 +1512,8 @@
     "tsx": ["tsx@4.20.3", "", { "dependencies": { "esbuild": "~0.25.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ=="],
 
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
@@ -1532,6 +1584,8 @@
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 

--- a/lab/ui/README.md
+++ b/lab/ui/README.md
@@ -1,0 +1,68 @@
+# lab/ui — interactive web console for agent-yes
+
+A prototype web dashboard for agent-yes, grown out of peeking at **codehost**
+(the read-only access list on `:7700`) and asking what agent-yes can do that
+codehost structurally can't.
+
+```bash
+./run.sh          # starts `ay serve` :7432 + the lab UI :7777
+open http://localhost:7777
+```
+
+## What it is
+
+Two panes, GitHub-dark, no build step:
+
+- **Left — live list.** Polls `GET /api/ls` every 3 s and renders every agent
+  as a flat row with status dot, `cli`, `pid`, age, prompt, and mnemonic
+  `repo:` / `wt:` / `cli:` tags derived from the `cwd`. Space-separated filter
+  with `key:value` AND tokens — lifted straight from codehost.
+- **Right — tail + send.** Click an agent → its log streams into the right pane
+  and a composer at the bottom writes straight to its stdin
+  (`POST /api/send`). **This is the half codehost cannot have.**
+
+No new backend: `ay serve` already exposes the whole API. `server.ts` is a
+~50-line same-origin proxy that serves `index.html` and forwards `/api/*` with
+the `Authorization: Bearer <token>` (read from `~/.agent-yes/.serve-token`)
+injected — so the browser needs no token and hits no CORS wall.
+
+## What we learned from codehost
+
+codehost (`~/ws/snomiao/codehost`, `:7700`) does several things worth keeping:
+
+1. **One flat table, not a tree.** Everything reachable right now in a single
+   scannable list — agents and daemons side by side.
+2. **Tags are mnemonics, not identity.** `host:` / `repo:` / `wt:` tags exist
+   only to filter and remember; the canonical id stays the hard `pid`/peerId.
+   We mirror this: tags are derived from `cwd`, the `pid` is the real handle.
+3. **Filter-as-you-type with `key:value` AND tokens** — fast, keyboard-first,
+   no menus. Copied wholesale.
+4. **A tight GitHub-dark palette** that reads as one system. Reused verbatim so
+   the two consoles feel related.
+
+What codehost **can't** do, and we should: it only renders `ay ls`. agent-yes
+owns each agent's `log_file` and `fifo_file`, so it can **tail and talk back**.
+That read-write layer is the reason for a first-party UI.
+
+## What we found we should improve in agent-yes
+
+- **No HTML is served by `ay serve`.** The API is great but headless. A
+  first-party `ay serve --ui` (or shipping this page at `/`) would make the
+  whole thing usable without a side-car proxy.
+- **The root `index.html` is a static marketing page**, unrelated to the live
+  tooling. A real product would make the landing page _be_ this console.
+
+## Files
+
+| file         | role                                                       |
+| ------------ | ---------------------------------------------------------- |
+| `run.sh`     | starts `ay serve` + the proxy, prints the URL              |
+| `server.ts`  | same-origin static + `/api/*` proxy (injects the token)    |
+| `index.html` | the two-pane console (list + tail/send), zero dependencies |
+
+## API surface used (all from `ay serve`)
+
+- `GET  /api/ls?all=1` — list agents
+- `GET  /api/read/:pid?mode=tail&n=200` — one-shot xterm-rendered log tail
+- `GET  /api/tail/:pid` — SSE stream; the live tail (`EventSource`) this UI uses
+- `POST /api/send` `{keyword, msg, code}` — write to the agent's stdin fifo

--- a/lab/ui/cf/worker.ts
+++ b/lab/ui/cf/worker.ts
@@ -1,0 +1,127 @@
+// WebRTC signaling server for `ay serve --share=webrtc://room:token@s.agent-yes.com`.
+//
+// One Durable Object per room relays SDP offers/answers + ICE candidates between
+// the local `ay serve` peer (role=host) and one or more browser peers
+// (role=client). It is a *rendezvous* only — media/data never flow through here,
+// they go peer-to-peer over the WebRTC DataChannel once signaling completes.
+//
+// Auth: the room token is carried in the WebSocket subprotocol (NOT the URL, so
+// it can't leak into request logs). The first peer to open a room fixes its
+// token; every later peer must present the same token or it is rejected. The
+// token is never logged.
+
+export interface Env {
+  ROOMS: DurableObjectNamespace;
+  ASSETS: Fetcher;
+}
+
+const SUBPROTO = "ay-signal-1";
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/health") return new Response("ok\n");
+
+    // WebSocket to /<room> → signaling DO (this is the s.agent-yes.com path).
+    const m = /^\/([A-Za-z0-9_-]{1,64})$/.exec(url.pathname);
+    if (m && req.headers.get("Upgrade") === "websocket") {
+      const id = env.ROOMS.idFromName(m[1]!);
+      return env.ROOMS.get(id).fetch(req);
+    }
+
+    // Everything else → the static console UI (agent-yes.com).
+    return env.ASSETS.fetch(req);
+  },
+};
+
+type Attach = { authed: boolean; role?: "host" | "client"; peer?: string };
+
+export class Room {
+  constructor(private state: DurableObjectState) {}
+
+  async fetch(req: Request): Promise<Response> {
+    if (req.headers.get("Upgrade") !== "websocket") {
+      return new Response("expected websocket", { status: 426 });
+    }
+    // The subprotocol only marks our protocol version — NO token here. (The token
+    // is sent in the first message instead: Bun's WS client mangles long
+    // subprotocol values, and keeping it out of the handshake also avoids any
+    // chance of it reaching request logs.)
+    const offered = (req.headers.get("Sec-WebSocket-Protocol") ?? "")
+      .split(",")
+      .map((s) => s.trim());
+    if (offered[0] && offered[0] !== SUBPROTO) {
+      return new Response("bad subprotocol", { status: 400 });
+    }
+
+    const { 0: client, 1: server } = new WebSocketPair();
+    this.state.acceptWebSocket(server);
+    server.serializeAttachment({ authed: false } satisfies Attach);
+
+    return new Response(null, {
+      status: 101,
+      webSocket: client,
+      headers: { "Sec-WebSocket-Protocol": SUBPROTO },
+    });
+  }
+
+  async webSocketMessage(ws: WebSocket, raw: string): Promise<void> {
+    const self = ws.deserializeAttachment() as Attach;
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return; // ignore non-JSON
+    }
+
+    if (!self.authed) {
+      // First message must be the hello that carries role + token.
+      if (msg.type !== "hello") return ws.close(1008, "expected hello");
+      const role: "host" | "client" = msg.role === "host" ? "host" : "client";
+      const token = String(msg.token ?? "");
+      const stored = await this.state.storage.get<string>("token");
+      if (stored === undefined) {
+        if (role !== "host") return ws.close(1008, "room not open");
+        await this.state.storage.put("token", token);
+      } else if (stored !== token) {
+        return ws.close(1008, "forbidden"); // token never echoed
+      }
+      const peer = role === "host" ? "host" : crypto.randomUUID().slice(0, 8);
+      ws.serializeAttachment({ authed: true, role, peer } satisfies Attach);
+      ws.send(JSON.stringify({ type: "welcome", peer, role }));
+      if (role === "client") this.toHost({ type: "peer-join", peer });
+      return;
+    }
+
+    if (self.role === "client") {
+      msg.from = self.peer; // tag so the host can route the reply back
+      this.toHost(msg);
+    } else {
+      const to = typeof msg.to === "string" ? msg.to : "";
+      if (to) this.toPeer(to, msg);
+    }
+  }
+
+  webSocketClose(ws: WebSocket): void {
+    const self = ws.deserializeAttachment() as Attach;
+    if (self.authed && self.role === "client") this.toHost({ type: "peer-leave", peer: self.peer });
+  }
+
+  // Role isn't a hibernation tag (it's only known after the hello), so route by
+  // walking the sockets and reading each one's attachment.
+  private toHost(obj: unknown): void {
+    const data = JSON.stringify(obj);
+    for (const s of this.state.getWebSockets()) {
+      const a = s.deserializeAttachment() as Attach | null;
+      if (a?.authed && a.role === "host") s.send(data);
+    }
+  }
+  private toPeer(peer: string, obj: unknown): void {
+    const data = JSON.stringify(obj);
+    for (const s of this.state.getWebSockets()) {
+      const a = s.deserializeAttachment() as Attach | null;
+      if (a?.authed && a.peer === peer) s.send(data);
+    }
+  }
+}

--- a/lab/ui/cf/wrangler.jsonc
+++ b/lab/ui/cf/wrangler.jsonc
@@ -1,0 +1,23 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "agent-yes-signal",
+  // SNOLAB account — agent-yes.com lives here. account_id in config is honored
+  // (CLOUDFLARE_ACCOUNT_ID env is ignored by some wrangler commands).
+  "account_id": "0beef4cd2d2da6befa47d8d149d6e157",
+  "main": "worker.ts",
+  "compatibility_date": "2025-05-01",
+  // Static console UI (served for every non-WebSocket request).
+  "assets": { "directory": "./public", "binding": "ASSETS" },
+  "durable_objects": {
+    "bindings": [{ "name": "ROOMS", "class_name": "Room" }],
+  },
+  // SQLite-backed DO classes (required on the free plan, fine on paid).
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["Room"] }],
+  // One Worker, two custom domains: the UI on agent-yes.com, signaling on
+  // s.agent-yes.com. Custom domains auto-provision DNS in the zone.
+  "routes": [
+    { "pattern": "agent-yes.com", "custom_domain": true },
+    { "pattern": "s.agent-yes.com", "custom_domain": true },
+  ],
+  "observability": { "enabled": true },
+}

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1,0 +1,1118 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>agent-yes · console</title>
+    <style>
+      /* Palette borrowed from codehost (GitHub-dark) so the two feel like one system. */
+      :root {
+        --bg: #0d1117;
+        --panel: #161b22;
+        --panel2: #1c2430;
+        --line: #2d3748;
+        --line2: #222b38;
+        --fg: #e6edf3;
+        --muted: #8b949e;
+        --accent: #58a6ff;
+        --green: #3fb950;
+        --amber: #d29922;
+        --purple: #bc8cff;
+        --pink: #f778ba;
+        --red: #f85149;
+        --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--fg);
+        height: 100vh;
+        overflow: hidden;
+        font:
+          14px/1.55 -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          system-ui,
+          sans-serif;
+      }
+      code {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        background: var(--panel2);
+        padding: 1px 5px;
+        border-radius: 5px;
+        color: var(--purple);
+      }
+
+      /* grid-template-rows:minmax(0,1fr) caps the row at the viewport so the inner
+     panes scroll instead of growing the page (the min-height:0 below lets the
+     flex children actually shrink — without it overflow:auto never engages). */
+      .app {
+        display: grid;
+        grid-template-columns: minmax(360px, 42%) 1fr;
+        grid-template-rows: minmax(0, 1fr);
+        height: 100vh;
+      }
+
+      /* ---- left: list ---- */
+      .left {
+        border-right: 1px solid var(--line);
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        min-height: 0;
+      }
+      .head {
+        padding: 16px 18px 10px;
+        border-bottom: 1px solid var(--line);
+      }
+      h1 {
+        font-size: 18px;
+        margin: 0 0 2px;
+        letter-spacing: -0.02em;
+      }
+      h1 .tag {
+        color: var(--accent);
+      }
+      .sub {
+        color: var(--muted);
+        font-size: 12.5px;
+      }
+      .ibox {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 9px;
+        padding: 7px 11px;
+        margin-top: 11px;
+      }
+      .ibox:focus-within {
+        border-color: var(--accent);
+      }
+      .ibox .mag {
+        color: var(--muted);
+      }
+      #q {
+        flex: 1;
+        background: transparent;
+        border: 0;
+        outline: 0;
+        color: var(--fg);
+        font: 13px var(--mono);
+      }
+      .meta {
+        display: flex;
+        justify-content: space-between;
+        color: var(--muted);
+        font-size: 11.5px;
+        margin-top: 8px;
+      }
+      .connbadge {
+        cursor: pointer;
+        user-select: none;
+      }
+      .connbadge:hover {
+        filter: brightness(1.3);
+      }
+      .rooms {
+        position: relative;
+        margin-top: 8px;
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 9px;
+        padding: 8px;
+        font-size: 12px;
+      }
+      .rooms .rtitle {
+        color: var(--muted);
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        padding: 2px 4px 6px;
+      }
+      .rooms .ritem {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 6px;
+        border-radius: 7px;
+      }
+      .rooms .ritem:hover {
+        background: var(--panel2);
+      }
+      .rooms .ritem.cur {
+        box-shadow: inset 2px 0 0 var(--green);
+      }
+      .rooms .rname {
+        font-family: var(--mono);
+        color: var(--accent);
+        cursor: pointer;
+        flex: 1;
+      }
+      .rooms .rhost {
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 10.5px;
+      }
+      .rooms .rx {
+        color: var(--muted);
+        cursor: pointer;
+        padding: 0 4px;
+      }
+      .rooms .rx:hover {
+        color: var(--red);
+      }
+      .rooms .radd {
+        display: flex;
+        gap: 6px;
+        margin-top: 6px;
+        padding-top: 6px;
+        border-top: 1px solid var(--line2);
+      }
+      .rooms .radd input {
+        flex: 1;
+        background: var(--bg);
+        border: 1px solid var(--line);
+        border-radius: 7px;
+        color: var(--fg);
+        font: 11.5px var(--mono);
+        padding: 6px 8px;
+        outline: 0;
+      }
+      .rooms .radd button {
+        background: var(--accent);
+        color: var(--bg);
+        border: 0;
+        border-radius: 7px;
+        font-weight: 600;
+        padding: 0 12px;
+        cursor: pointer;
+      }
+      .rooms .empty2 {
+        color: var(--muted);
+        padding: 6px;
+      }
+      .rooms .rconnect {
+        margin-top: 6px;
+        padding: 8px 6px 2px;
+        border-top: 1px solid var(--line2);
+        color: var(--muted);
+        font-size: 11px;
+        line-height: 1.7;
+      }
+      .rooms .rconnect code {
+        display: block;
+        margin-top: 4px;
+        cursor: pointer;
+      }
+      .rooms .rconnect code:hover {
+        color: var(--accent);
+      }
+
+      /* launch overlay (command-only launch URLs: #launch=<json>) */
+      .launchoverlay {
+        position: fixed;
+        inset: 0;
+        z-index: 20;
+        background: rgba(2, 6, 12, 0.7);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .lcard {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 22px 24px;
+        width: min(560px, 92vw);
+      }
+      .lcard .ltitle {
+        font-size: 16px;
+        font-weight: 600;
+        margin-bottom: 12px;
+      }
+      .lcard .lcmd {
+        font-family: var(--mono);
+        font-size: 13px;
+        background: var(--bg);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 10px 12px;
+        color: var(--green);
+        word-break: break-word;
+      }
+      .lcard .lcwd {
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 11.5px;
+        margin-top: 6px;
+      }
+      .lcard .lfleets {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 16px;
+      }
+      .lcard .lfleet {
+        background: var(--accent);
+        color: var(--bg);
+        border: 0;
+        border-radius: 8px;
+        font-weight: 600;
+        font-family: var(--mono);
+        padding: 8px 14px;
+        cursor: pointer;
+      }
+      .lcard .lwarn {
+        color: var(--amber);
+        font-size: 12.5px;
+        margin-top: 16px;
+        line-height: 1.6;
+      }
+      .lcard .lwarn code {
+        font-family: var(--mono);
+        background: var(--bg);
+        padding: 1px 6px;
+        border-radius: 5px;
+        color: var(--fg);
+      }
+      .lcard .lhint {
+        color: var(--muted);
+        font-size: 11.5px;
+        margin-top: 12px;
+      }
+      .lcard .lcancel {
+        background: transparent;
+        color: var(--muted);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 6px 14px;
+        cursor: pointer;
+        margin-top: 16px;
+      }
+
+      .list {
+        overflow-y: auto;
+        flex: 1;
+        min-height: 0;
+      }
+      .row {
+        padding: 11px 18px;
+        border-bottom: 1px solid var(--line2);
+        cursor: pointer;
+      }
+      .row:hover {
+        background: var(--panel);
+      }
+      .row.sel {
+        background: var(--panel);
+        box-shadow: inset 3px 0 0 var(--accent);
+      }
+      .r1 {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex: none;
+      }
+      .dot.active,
+      .dot.running {
+        background: var(--green);
+      }
+      .dot.idle {
+        background: var(--amber);
+      }
+      .dot.stopped,
+      .dot.exited {
+        background: var(--muted);
+      }
+      .name {
+        font-weight: 600;
+      }
+      .badge {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        padding: 1px 6px;
+        border-radius: 5px;
+        border: 1px solid var(--line);
+        color: var(--muted);
+      }
+      .age {
+        margin-left: auto;
+        color: var(--muted);
+        font-size: 11.5px;
+      }
+      .detail {
+        color: var(--muted);
+        font-size: 12.5px;
+        margin-top: 4px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .rowtags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 5px;
+        margin-top: 6px;
+      }
+      .rtag {
+        font-family: var(--mono);
+        font-size: 11px;
+        padding: 1px 7px;
+        border-radius: 999px;
+        border: 1px solid var(--line);
+        color: var(--muted);
+        white-space: nowrap;
+      }
+      .rtag[data-k="repo"],
+      .rtag[data-k="wt"] {
+        color: var(--green);
+        border-color: #1d3b25;
+      }
+      .rtag[data-k="cli"] {
+        color: var(--purple);
+        border-color: #3a2a4a;
+      }
+      .empty {
+        text-align: center;
+        color: var(--muted);
+        padding: 40px;
+      }
+
+      /* ---- right: live tail + send (this is what codehost structurally can't do) ---- */
+      .right {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        min-height: 0;
+      }
+      .rhead {
+        padding: 14px 20px;
+        border-bottom: 1px solid var(--line);
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .rhead .name {
+        font-size: 15px;
+      }
+      .rhead .live {
+        margin-left: auto;
+        font-size: 11px;
+        font-family: var(--mono);
+        color: var(--muted);
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .rhead .live .dot {
+        width: 7px;
+        height: 7px;
+      }
+      .log {
+        flex: 1;
+        min-height: 0;
+        overflow: hidden;
+        padding: 8px 10px;
+        background: #0d1117;
+      }
+      .log .xterm {
+        height: 100%;
+      }
+      .log .xterm-viewport {
+        background: transparent !important;
+      }
+      .placeholder {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      .composer {
+        border-top: 1px solid var(--line);
+        padding: 12px 16px;
+        display: flex;
+        gap: 8px;
+        align-items: flex-end;
+      }
+      .composer textarea {
+        flex: 1;
+        resize: none;
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 9px;
+        color: var(--fg);
+        font: 13px var(--mono);
+        padding: 9px 12px;
+        outline: 0;
+        min-height: 40px;
+        max-height: 160px;
+      }
+      .composer textarea:focus {
+        border-color: var(--accent);
+      }
+      .send {
+        background: var(--accent);
+        color: var(--bg);
+        border: 0;
+        border-radius: 9px;
+        font-weight: 600;
+        padding: 10px 18px;
+        cursor: pointer;
+        font-size: 13px;
+      }
+      .send:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
+      .hint {
+        color: var(--muted);
+        font-size: 11px;
+        font-family: var(--mono);
+        margin-top: 6px;
+        padding: 0 16px 10px;
+      }
+    </style>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+  </head>
+  <body>
+    <div class="app">
+      <div class="left">
+        <div class="head">
+          <h1><span class="tag">agent-yes</span> · console</h1>
+          <div class="sub">
+            Live <code>ay ls</code> + per-agent tail &amp; send. Backed by <code>ay serve</code>.
+          </div>
+          <div class="ibox">
+            <span class="mag">⌕</span>
+            <input
+              id="q"
+              placeholder="filter…  repo:agent-yes  claude  symval  (space = AND)"
+              autocomplete="off"
+              autofocus
+            />
+          </div>
+          <div class="meta">
+            <span id="count"></span
+            ><span id="conn" class="connbadge" title="rooms — click to manage">● local</span>
+          </div>
+          <div class="rooms" id="rooms" style="display: none"></div>
+        </div>
+        <div class="list" id="list"></div>
+      </div>
+
+      <div class="right">
+        <div class="rhead" id="rhead" style="display: none">
+          <span class="dot" id="rdot"></span>
+          <span class="name" id="rname"></span>
+          <span class="badge" id="rpid"></span>
+          <span class="live"
+            ><span class="dot" id="livedot"></span><span id="livetxt">connecting…</span></span
+          >
+        </div>
+        <div class="log" id="log">
+          <div class="placeholder">← pick an agent to tail its log and send it a message</div>
+        </div>
+        <div class="composer" id="composer" style="display: none">
+          <textarea
+            id="msg"
+            rows="1"
+            placeholder="message to send to the agent…  (⌘/Ctrl+Enter)"
+          ></textarea>
+          <button class="send" id="send">Send ⏎</button>
+        </div>
+        <div class="hint" id="hint" style="display: none">
+          POST /api/send → writes to the agent's stdin fifo, then Enter.
+        </div>
+      </div>
+    </div>
+
+    <div class="launchoverlay" id="launch" style="display: none"></div>
+
+    <script>
+      let entries = [];
+      let sel = null; // selected keyword (pid as string)
+      let es = null; // live-tail subscription closer
+      let term = null; // xterm.js Terminal rendering the raw PTY stream
+      let fit = null;
+
+      const $ = (id) => document.getElementById(id);
+      const esc = (s) =>
+        String(s ?? "").replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
+
+      // ---- transport ---------------------------------------------------------
+      // Local: same-origin fetch + EventSource (via the ay-serve proxy).
+      // Remote: an /api/* call tunnelled over a WebRTC DataChannel to a peer running
+      // `ay serve --share` — established through the signaling server. Same call
+      // sites, two wires. Remote is selected by a URL hash: #room:token[@sighost].
+      const SIG_DEFAULT = "s.agent-yes.com"; // signaling host (override in the hash with @host)
+      const SUB = "ay-signal-1";
+
+      // Tunnels request/response + streaming over one DataChannel. Mirrors the
+      // envelope in lab/ui/share-host.ts: {t:"req"|"abort"} out, {t:"res"|"data"|"end"} in.
+      class RTCClient {
+        constructor(host, room, token) {
+          Object.assign(this, {
+            host,
+            room,
+            token,
+            dc: null,
+            nextId: 1,
+            calls: new Map(),
+            streams: new Map(),
+            onstate: () => {},
+          });
+        }
+        connect() {
+          return new Promise((resolve, reject) => {
+            const ws = new WebSocket(`wss://${this.host}/${this.room}`, [SUB]);
+            let pc,
+              settled = false;
+            const fail = (e) => {
+              if (!settled) {
+                settled = true;
+                reject(e);
+              }
+            };
+            ws.onopen = () =>
+              ws.send(JSON.stringify({ type: "hello", role: "client", token: this.token }));
+            ws.onmessage = async (ev) => {
+              const m = JSON.parse(ev.data);
+              if (m.type === "welcome") {
+                pc = new RTCPeerConnection({
+                  iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
+                });
+                this.pc = pc;
+                pc.onicecandidate = (e) => {
+                  if (e.candidate)
+                    ws.send(JSON.stringify({ type: "candidate", candidate: e.candidate }));
+                };
+                pc.onconnectionstatechange = () => this.onstate(pc.connectionState);
+                pc.ondatachannel = (e) => {
+                  this.dc = e.channel;
+                  this.dc.onopen = () => {
+                    settled = true;
+                    this.onstate("open");
+                    resolve();
+                  };
+                  this.dc.onmessage = (ev2) => this._recv(JSON.parse(ev2.data));
+                  this.dc.onclose = () => this.onstate("closed");
+                };
+              } else if (m.type === "offer") {
+                await pc.setRemoteDescription({ type: "offer", sdp: m.sdp });
+                await pc.setLocalDescription(await pc.createAnswer());
+                ws.send(JSON.stringify({ type: "answer", sdp: pc.localDescription.sdp }));
+              } else if (m.type === "candidate") {
+                await pc.addIceCandidate(m.candidate).catch(() => {});
+              }
+            };
+            ws.onerror = () => fail(new Error("signaling error"));
+            ws.onclose = () => fail(new Error("signaling closed"));
+            setTimeout(() => fail(new Error("connect timeout")), 15000);
+          });
+        }
+        _recv(r) {
+          const call = this.calls.get(r.id),
+            stream = this.streams.get(r.id);
+          if (r.t === "res") {
+            if (call) {
+              call.status = r.status;
+            }
+          } else if (r.t === "data") {
+            if (call) call.body += r.chunk;
+            if (stream) stream(r.chunk);
+          } else if (r.t === "end") {
+            if (call) {
+              this.calls.delete(r.id);
+              r.error
+                ? call.reject(new Error(r.error))
+                : call.resolve({ status: call.status, text: call.body });
+            }
+          }
+        }
+        req(method, path, body) {
+          const id = this.nextId++;
+          return new Promise((resolve, reject) => {
+            this.calls.set(id, { status: 0, body: "", resolve, reject });
+            this.dc.send(JSON.stringify({ t: "req", id, method, path, body }));
+          });
+        }
+        subscribe(path, onRaw) {
+          const id = this.nextId++;
+          this.streams.set(id, onRaw);
+          this.dc.send(JSON.stringify({ t: "req", id, method: "GET", path }));
+          return () => {
+            this.streams.delete(id);
+            try {
+              this.dc.send(JSON.stringify({ t: "abort", id }));
+            } catch {}
+          };
+        }
+      }
+
+      const Conn = {
+        rtc: null, // RTCClient when remote, null when local
+        async fetchJSON(path) {
+          if (this.rtc) return JSON.parse((await this.rtc.req("GET", path)).text);
+          return (await fetch(path)).json();
+        },
+        async post(path, bodyObj) {
+          if (this.rtc) {
+            const r = await this.rtc.req("POST", path, JSON.stringify(bodyObj));
+            return { ok: r.status >= 200 && r.status < 300, text: r.text };
+          }
+          const r = await fetch(path, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(bodyObj),
+          });
+          return { ok: r.ok, text: await r.text() };
+        },
+        // onText gets each parsed SSE data payload (same shape as the local EventSource path).
+        subscribe(path, onText, onOpen, onError) {
+          if (this.rtc) {
+            onOpen && onOpen();
+            let buf = "";
+            return this.rtc.subscribe(path, (raw) => {
+              buf += raw;
+              let i;
+              while ((i = buf.indexOf("\n\n")) >= 0) {
+                const evt = buf.slice(0, i);
+                buf = buf.slice(i + 2);
+                for (const line of evt.split("\n"))
+                  if (line.startsWith("data:")) {
+                    try {
+                      onText(JSON.parse(line.slice(5).trim()));
+                    } catch {}
+                  }
+              }
+            });
+          }
+          const ev = new EventSource(path);
+          ev.onopen = () => onOpen && onOpen();
+          ev.onmessage = (e) => onText(JSON.parse(e.data));
+          ev.onerror = () => onError && onError();
+          return () => ev.close();
+        },
+      };
+
+      // Derive codehost-style mnemonic tags from a cwd like .../ws/<owner>/<repo>/tree/<wt>
+      function tagsFor(e) {
+        const t = [];
+        const m = /\/([^/]+)\/([^/]+)\/tree\/([^/]+)/.exec(e.cwd || "");
+        if (m) {
+          t.push(["repo", `${m[1]}/${m[2]}`], ["wt", m[3]]);
+        }
+        if (e.cli) t.push(["cli", e.cli]);
+        return t;
+      }
+      function age(e) {
+        if (!e.started_at) return "";
+        const s = Math.max(0, (Date.now() - e.started_at) / 1000);
+        if (s < 60) return Math.floor(s) + "s";
+        if (s < 3600) return Math.floor(s / 60) + "m";
+        return Math.floor(s / 3600) + "h";
+      }
+
+      function matches(e, toks) {
+        const hay = (e.prompt || "") + " " + e.cli + " " + (e.cwd || "") + " " + e.status;
+        return toks.every((tok) => {
+          tok = tok.toLowerCase();
+          const ci = tok.indexOf(":");
+          if (ci > 0) {
+            const k = tok.slice(0, ci),
+              v = tok.slice(ci + 1);
+            return tagsFor(e).some(([tk, tv]) => tk === k && tv.toLowerCase().includes(v));
+          }
+          return hay.toLowerCase().includes(tok);
+        });
+      }
+
+      function renderList() {
+        const toks = $("q").value.trim().split(/\s+/).filter(Boolean);
+        const shown = entries.filter((e) => matches(e, toks));
+        $("count").textContent = `${shown.length} / ${entries.length} agents`;
+        $("list").innerHTML =
+          shown
+            .map((e) => {
+              const tags = tagsFor(e)
+                .map(
+                  ([k, v]) =>
+                    `<span class="rtag" data-k="${k}"><span style="opacity:.55">${k}:</span>${esc(v)}</span>`,
+                )
+                .join("");
+              return `<div class="row ${String(e.pid) === sel ? "sel" : ""}" data-pid="${e.pid}">
+        <div class="r1"><span class="dot ${esc(e.status)}"></span>
+          <span class="name">${esc(e.cli)}</span>
+          <span class="badge">pid ${e.pid}</span>
+          <span class="age">${age(e)}</span></div>
+        ${e.prompt ? `<div class="detail" title="${esc(e.prompt)}">${esc(e.prompt)}</div>` : ""}
+        <div class="rowtags">${tags}</div>
+      </div>`;
+            })
+            .join("") || `<div class="empty">no match</div>`;
+      }
+
+      async function loadList() {
+        try {
+          entries = await Conn.fetchJSON("/api/ls?all=1");
+          setConn(Conn.rtc ? "● " + (curRoom || "remote") : "● local", "var(--green)");
+        } catch (e) {
+          setConn(Conn.rtc ? "● peer down" : "● ay serve down", "var(--red)");
+        }
+        renderList();
+      }
+
+      function select(pid) {
+        sel = String(pid);
+        const e = entries.find((x) => String(x.pid) === sel);
+        if (!e) return;
+        renderList();
+        $("rhead").style.display = "flex";
+        $("composer").style.display = "flex";
+        $("hint").style.display = "block";
+        $("rdot").className = "dot " + e.status;
+        $("rname").textContent = e.cli;
+        $("rpid").textContent = "pid " + e.pid;
+        $("msg").focus();
+
+        // Render the agent's native TUI with xterm.js by feeding it the raw PTY
+        // stream (ANSI/cursor control intact) — see /api/tail?raw=1.
+        if (es) es.close();
+        if (term) {
+          term.dispose();
+          term = null;
+        }
+        const logEl = $("log");
+        logEl.innerHTML = "";
+        term = new Terminal({
+          convertEol: false,
+          disableStdin: false,
+          cursorBlink: true,
+          scrollback: 5000,
+          fontSize: 12,
+          fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+          theme: { background: "#0d1117", foreground: "#c9d1d9", cursor: "#0d1117" },
+        });
+        fit = new FitAddon.FitAddon();
+        term.loadAddon(fit);
+        term.open(logEl);
+        // Drive the agent's PTY to the browser's terminal size so its TUI reflows to
+        // match what we render (POST /api/resize → winsize file + SIGWINCH on the host).
+        const pushSize = () => {
+          if (term && sel)
+            Conn.post("/api/resize/" + encodeURIComponent(sel), {
+              cols: term.cols,
+              rows: term.rows,
+            }).catch(() => {});
+        };
+        term.onResize(pushSize);
+        // Forward keystrokes/mouse typed into the terminal straight to the agent stdin
+        // (raw, no trailing Enter) so it's directly interactive, not just a viewer.
+        term.onData((d) => {
+          if (sel) Conn.post("/api/send", { keyword: sel, msg: d, code: "none" }).catch(() => {});
+        });
+        try {
+          fit.fit();
+        } catch {}
+        pushSize();
+
+        // True live tail via ay serve's SSE stream. First event is an xterm-rendered
+        // tail snapshot; later events are incremental deltas. We normalise terminal
+        // carriage returns so the stream reads cleanly as HTML, autoscroll while the
+        // viewer is pinned to the bottom, and cap the buffer so it can't grow forever.
+        $("livedot").className = "dot idle";
+        $("livetxt").textContent = "connecting…";
+        const close = Conn.subscribe(
+          "/api/tail/" + encodeURIComponent(sel) + "?raw=1",
+          (raw) => {
+            if (term) term.write(raw);
+          },
+          () => {
+            $("livedot").className = "dot active";
+            $("livetxt").textContent = "live";
+          },
+          () => {
+            $("livedot").className = "dot stopped";
+            $("livetxt").textContent = "disconnected";
+          },
+        );
+        es = { close };
+      }
+
+      async function send() {
+        if (!sel) return;
+        const msg = $("msg").value;
+        if (!msg.trim()) return;
+        $("send").disabled = true;
+        try {
+          const r = await Conn.post("/api/send", { keyword: sel, msg, code: "enter" });
+          if (r.ok) {
+            $("msg").value = "";
+          } else {
+            alert("send failed: " + r.text);
+          }
+        } finally {
+          $("send").disabled = false;
+          $("msg").focus();
+        }
+      }
+
+      $("list").addEventListener("click", (ev) => {
+        const row = ev.target.closest(".row");
+        if (row) select(row.dataset.pid);
+      });
+      $("q").addEventListener("input", renderList);
+      window.addEventListener("resize", () => {
+        if (fit)
+          try {
+            fit.fit();
+          } catch {}
+      });
+      $("send").addEventListener("click", send);
+      $("msg").addEventListener("keydown", (ev) => {
+        if (ev.key === "Enter" && (ev.metaKey || ev.ctrlKey)) {
+          ev.preventDefault();
+          send();
+        }
+      });
+
+      // ---- rooms: localStorage cache + a manager you open by clicking the badge ----
+      const ROOMS_KEY = "ay.rooms";
+      let curRoom = null;
+      const loadRooms = () => {
+        try {
+          return JSON.parse(localStorage.getItem(ROOMS_KEY) || "{}");
+        } catch {
+          return {};
+        }
+      };
+      const saveRoom = (room, token, host) => {
+        const r = loadRooms();
+        r[room] = { token, host: host || SIG_DEFAULT, ts: Date.now() };
+        localStorage.setItem(ROOMS_KEY, JSON.stringify(r));
+      };
+      const dropRoom = (room) => {
+        const r = loadRooms();
+        delete r[room];
+        localStorage.setItem(ROOMS_KEY, JSON.stringify(r));
+      };
+      function setConn(text, color) {
+        $("conn").textContent = text;
+        $("conn").style.color = color;
+      }
+
+      async function connectRoom(room, token, host) {
+        host = host || SIG_DEFAULT;
+        saveRoom(room, token, host); // cache so the badge can list & reconnect later
+        curRoom = room;
+        if (Conn.rtc) {
+          try {
+            Conn.rtc.pc?.close();
+          } catch {}
+          Conn.rtc = null;
+        }
+        setConn("● connecting " + room + "…", "var(--amber)");
+        const c = new RTCClient(host, room, token);
+        c.onstate = (s) => {
+          if (s === "failed" || s === "closed") setConn("● peer lost", "var(--red)");
+        };
+        try {
+          await c.connect();
+          Conn.rtc = c;
+        } catch (e) {
+          setConn("● connect failed", "var(--red)");
+        }
+        loadList();
+      }
+
+      function parseRoomInput(s) {
+        s = s.trim();
+        const hash = s.indexOf("#");
+        if (hash >= 0) s = s.slice(hash + 1);
+        const m = /^([A-Za-z0-9_-]+):([^@\s]+)(?:@(.+))?$/.exec(decodeURIComponent(s));
+        return m ? { room: m[1], token: m[2], host: m[3] } : null;
+      }
+
+      function renderRooms() {
+        const r = loadRooms();
+        const names = Object.keys(r).sort((a, b) => r[b].ts - r[a].ts);
+        const items = names.length
+          ? names
+              .map(
+                (n) => `<div class="ritem ${n === curRoom ? "cur" : ""}">
+          <span class="rname" data-room="${esc(n)}">${esc(n)}</span>
+          <span class="rhost">${esc(r[n].host)}</span>
+          <span class="rx" data-del="${esc(n)}" title="forget">✕</span></div>`,
+              )
+              .join("")
+          : `<div class="empty2">no saved rooms — paste a share link below</div>`;
+        $("rooms").innerHTML = `<div class="rtitle">rooms · stored on this device</div>${items}
+      <div class="radd"><input id="roomin" placeholder="room:token  or  https://…/#room:token" /><button id="roomadd">add</button></div>
+      <div class="rconnect">share your own fleet — run this, then open the printed link:
+        <code id="cmd" title="click to copy">bunx agent-yes serve --share</code></div>`;
+      }
+
+      $("conn").addEventListener("click", () => {
+        const el = $("rooms");
+        if (el.style.display === "none") {
+          renderRooms();
+          el.style.display = "block";
+          $("roomin")?.focus();
+        } else el.style.display = "none";
+      });
+      $("rooms").addEventListener("click", (ev) => {
+        const name = ev.target.closest(".rname");
+        if (name) {
+          const r = loadRooms()[name.dataset.room];
+          if (r) {
+            connectRoom(name.dataset.room, r.token, r.host);
+            $("rooms").style.display = "none";
+          }
+          return;
+        }
+        const del = ev.target.closest(".rx");
+        if (del) {
+          dropRoom(del.dataset.del);
+          renderRooms();
+          return;
+        }
+        if (ev.target.id === "roomadd") {
+          const p = parseRoomInput($("roomin").value);
+          if (p) {
+            connectRoom(p.room, p.token, p.host);
+            $("rooms").style.display = "none";
+          } else alert("expected  room:token  or a share link");
+        }
+        if (ev.target.id === "cmd") {
+          navigator.clipboard?.writeText(ev.target.textContent).then(() => {
+            const o = ev.target.textContent;
+            ev.target.textContent = "copied ✓";
+            setTimeout(() => {
+              ev.target.textContent = o;
+            }, 1000);
+          });
+        }
+      });
+
+      // ---- launch: command-only URLs (#launch=<json>, NO token) ----
+      // The link carries only WHAT to run; the capability to run it is the viewer's
+      // own connected fleet (cached room) + a y/N confirm on that host. So a public
+      // launch link can never spawn on a machine the clicker doesn't already control.
+      function showLaunch(spec) {
+        const rooms = loadRooms();
+        const names = Object.keys(rooms).sort((a, b) => rooms[b].ts - rooms[a].ts);
+        const cmd = "ay " + (spec.cli || "claude") + (spec.prompt ? ` -- "${spec.prompt}"` : "");
+        const fleets = names.length
+          ? `<div class="lfleets">${names.map((n) => `<button class="lfleet" data-room="${esc(n)}">▷ ${esc(n)}</button>`).join("")}</div>
+         <div class="lhint">pick a fleet to run on — its host will ask to confirm</div>`
+          : `<div class="lwarn">No connected fleet on this device. Run <code>bunx agent-yes serve --share --allow-spawn</code>, open its link once, then reopen this launch link.</div>`;
+        $("launch").innerHTML = `<div class="lcard">
+      <div class="ltitle">Launch agent</div>
+      <div class="lcmd">${esc(cmd)}</div>
+      <div class="lcwd">cwd: ${esc(spec.cwd || "(host default)")}</div>
+      ${fleets}
+      <button class="lcancel">cancel</button></div>`;
+        $("launch").dataset.spec = JSON.stringify(spec);
+        $("launch").style.display = "flex";
+      }
+
+      async function launchOn(room, spec) {
+        const r = loadRooms()[room];
+        if (!r) return;
+        $("launch").style.display = "none";
+        await connectRoom(room, r.token, r.host);
+        await loadList();
+        // Match by "newest agent that wasn't here before" — the spawn returns the
+        // wrapper pid, but the agent registers under the runtime's own pid.
+        const before = new Set(entries.map((e) => e.pid));
+        const res = await Conn.post("/api/spawn", {
+          cli: spec.cli || "claude",
+          cwd: spec.cwd,
+          prompt: spec.prompt,
+        });
+        if (!res.ok) {
+          alert("launch failed: " + res.text);
+          return;
+        }
+        for (let i = 0; i < 14; i++) {
+          await loadList();
+          const fresh = entries
+            .filter((e) => !before.has(e.pid))
+            .sort((a, b) => (b.started_at || 0) - (a.started_at || 0));
+          if (fresh.length) {
+            select(fresh[0].pid);
+            return;
+          }
+          await new Promise((r) => setTimeout(r, 800));
+        }
+      }
+
+      $("launch").addEventListener("click", (ev) => {
+        const f = ev.target.closest(".lfleet");
+        if (f) {
+          launchOn(f.dataset.room, JSON.parse($("launch").dataset.spec));
+          return;
+        }
+        if (ev.target.closest(".lcancel")) $("launch").style.display = "none";
+      });
+
+      // boot: a launch URL opens the launcher; otherwise connect from the hash (then
+      // eat the token); a bare #room reconnects from the cached token; else local.
+      async function boot() {
+        const raw = location.hash.replace(/^#/, "");
+        if (raw.startsWith("launch=")) {
+          let spec = null;
+          try {
+            spec = JSON.parse(decodeURIComponent(raw.slice(7)));
+          } catch {}
+          history.replaceState(null, document.title, location.pathname + location.search); // eat launch params
+          if (spec) showLaunch(spec);
+          setConn("● local", "var(--muted)");
+          loadList();
+          setInterval(loadList, 3000);
+          return;
+        }
+        const h = decodeURIComponent(raw);
+        const full = /^([A-Za-z0-9_-]+):([^@]+)(?:@(.+))?$/.exec(h);
+        const bare = /^([A-Za-z0-9_-]+)$/.exec(h);
+        if (full) {
+          const [, room, token, host] = full;
+          // SECURITY: strip the token from the URL immediately so it never lingers in
+          // the omnibox, history, or a screenshot. Keep only the room mnemonic.
+          history.replaceState(
+            null,
+            document.title,
+            location.pathname + location.search + "#" + room,
+          );
+          await connectRoom(room, token, host);
+        } else if (bare && loadRooms()[bare[1]]) {
+          const r = loadRooms()[bare[1]];
+          await connectRoom(bare[1], r.token, r.host);
+        } else {
+          setConn("● local", "var(--muted)");
+          loadList();
+        }
+        setInterval(loadList, 3000); // refresh statuses / new agents
+      }
+      boot();
+    </script>
+  </body>
+</html>

--- a/lab/ui/run.sh
+++ b/lab/ui/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Lab: an interactive web console for agent-yes.
+#
+# codehost (the read-only access list on :7700) renders `ay ls` and stops there.
+# This lab adds the read-write half codehost structurally can't: click an agent,
+# watch its log stream live, and type a message straight into its stdin.
+#
+# How it works: `ay serve` already exposes the whole API (ls / tail-SSE / send).
+# We just start it and put a tiny same-origin proxy (server.ts) in front that
+# serves index.html and injects the auth token — no new backend, no CORS.
+set -e
+cd "$(dirname "$0")"
+
+AY_PORT="${AY_PORT:-7432}"
+UI_PORT="${UI_PORT:-7777}"
+
+echo "Starting ay serve on :$AY_PORT …"
+ay serve --port "$AY_PORT" &
+SERVE_PID=$!
+trap 'kill $SERVE_PID 2>/dev/null' EXIT
+sleep 1.5
+
+echo "Starting lab UI on :$UI_PORT …"
+echo ""
+echo "  open →  http://localhost:$UI_PORT"
+echo ""
+AY_API="http://127.0.0.1:$AY_PORT" UI_PORT="$UI_PORT" bun server.ts

--- a/lab/ui/server.ts
+++ b/lab/ui/server.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+// Tiny same-origin proxy for the lab UI.
+//
+// `ay serve` exposes a token-gated JSON/SSE API but no HTML and no CORS.
+// This server serves index.html and forwards /api/* to `ay serve`, injecting
+// the Bearer token read from ~/.agent-yes/.serve-token. Same-origin => the
+// browser needs no token and hits no CORS wall; SSE streams pass straight
+// through because we return the upstream body untouched.
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+const UI_PORT = Number(process.env.UI_PORT ?? 7777);
+const AY_API = process.env.AY_API ?? "http://127.0.0.1:7432";
+const TOKEN = readFileSync(path.join(homedir(), ".agent-yes", ".serve-token"), "utf-8").trim();
+
+const HTML = readFileSync(path.join(import.meta.dir, "index.html"));
+
+Bun.serve({
+  port: UI_PORT,
+  idleTimeout: 0, // never time out SSE connections
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      return new Response(HTML, { headers: { "Content-Type": "text/html; charset=utf-8" } });
+    }
+
+    if (url.pathname.startsWith("/api/")) {
+      const upstream = AY_API + url.pathname + url.search;
+      const res = await fetch(upstream, {
+        method: req.method,
+        headers: {
+          Authorization: `Bearer ${TOKEN}`,
+          ...(req.headers.get("content-type")
+            ? { "Content-Type": req.headers.get("content-type")! }
+            : {}),
+        },
+        body: req.method === "GET" || req.method === "HEAD" ? undefined : await req.text(),
+        // @ts-expect-error Bun supports this for streaming responses
+        signal: req.signal,
+      }).catch((e) => new Response(`upstream unreachable: ${e}`, { status: 502 }));
+      // Pass the body straight through — keeps SSE (text/event-stream) live.
+      return new Response(res.body, { status: res.status, headers: res.headers });
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+});
+
+console.log(`lab/ui  →  http://localhost:${UI_PORT}   (proxying ${AY_API})`);

--- a/lab/ui/share-host.ts
+++ b/lab/ui/share-host.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env bun
+// Host side of `ay serve --share=webrtc://room:token@s.agent-yes.com`.
+//
+// Connects to the signaling server as the room "host", and for every browser
+// peer that joins, opens a WebRTC DataChannel and bridges it to the LOCAL
+// `ay serve` HTTP API (ls / read / tail-SSE / send). The browser thus talks to
+// the local agent over a peer-to-peer DataChannel — no public port, no tunnel.
+//
+// Wire protocol over the DataChannel (JSON strings, one message per line of work):
+//   browser → host : {t:"req",   id, method, path, body?}   // an /api/* call
+//                    {t:"abort", id}                         // cancel a stream
+//   host → browser : {t:"res",   id, status, ct}            // response head
+//                    {t:"data",  id, chunk}                  // a body/SSE chunk
+//                    {t:"end",   id, error?}                 // response complete
+import { RTCPeerConnection } from "node-datachannel/polyfill";
+import { randomBytes } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+const ICE = [{ urls: "stun:stun.l.google.com:19302" }];
+const SUB = "ay-signal-1";
+const MAX_CHUNK = 15_000; // DataChannel messages must stay well under the SCTP limit
+
+// webrtc://room:token@host  →  { room, token, host }
+function parseShare(s: string) {
+  const m = /^webrtc:\/\/([^:@/]+):([^@/]+)@(.+)$/.exec(s);
+  if (!m) throw new Error(`bad --share url: ${s} (want webrtc://room:token@host)`);
+  return { room: m[1]!, token: m[2]!, host: m[3]! };
+}
+
+function localToken(): string {
+  if (process.env.AY_TOKEN) return process.env.AY_TOKEN;
+  return readFileSync(path.join(homedir(), ".agent-yes", ".serve-token"), "utf-8").trim();
+}
+
+// `--new [sighost]` mints a fresh room + 64-char token and prints a share link;
+// otherwise pass a full webrtc://room:token@host url.
+const arg = process.argv[2] ?? process.env.AY_SHARE;
+let room: string, token: string, host: string;
+if (!arg) {
+  console.error("usage: bun share-host.ts --new [sighost]   |   webrtc://room:token@host");
+  process.exit(1);
+} else if (arg === "--new") {
+  host = process.argv[3] ?? process.env.AY_SIGHOST ?? "s.agent-yes.com";
+  room = "r" + randomBytes(3).toString("hex"); // short, non-secret mnemonic
+  token = randomBytes(32).toString("hex"); // 64 hex chars — unscreenshotable in the omnibox
+  const ui = host === "s.agent-yes.com" ? "https://agent-yes.com" : "http://localhost:7778";
+  const suffix = host === "s.agent-yes.com" ? "" : "@" + host;
+  console.log(`\n  share this link (the token is eaten from the URL on open):`);
+  console.log(`  ${ui}/#${room}:${token}${suffix}\n`);
+} else {
+  ({ room, token, host } = parseShare(arg));
+}
+const API = process.env.AY_API ?? "http://127.0.0.1:7432";
+const API_TOKEN = localToken();
+const wsScheme = host.startsWith("localhost") || host.startsWith("127.") ? "ws" : "wss";
+
+const peers = new Map<string, { pc: RTCPeerConnection; aborts: Map<number, AbortController> }>();
+
+const ws = new WebSocket(`${wsScheme}://${host}/${room}`, [SUB]);
+ws.onopen = () => {
+  ws.send(JSON.stringify({ type: "hello", role: "host", token })); // token in first msg, not URL/subprotocol
+  console.log(`[share] host online · room=${room} · bridging ${API}`);
+};
+ws.onclose = (e) => console.log(`[share] signaling closed (${e.code})`);
+ws.onerror = () => console.log(`[share] signaling error`);
+ws.onmessage = async (ev) => {
+  const m = JSON.parse(ev.data as string);
+  if (m.type === "peer-join") startPeer(m.peer);
+  else if (m.type === "answer")
+    await peers.get(m.from)?.pc.setRemoteDescription({ type: "answer", sdp: m.sdp });
+  else if (m.type === "candidate")
+    await peers
+      .get(m.from)
+      ?.pc.addIceCandidate(m.candidate)
+      .catch(() => {});
+  else if (m.type === "peer-leave") closePeer(m.peer);
+};
+
+function sig(to: string, obj: object) {
+  ws.send(JSON.stringify({ ...obj, to }));
+}
+
+function startPeer(peerId: string) {
+  console.log(`[share] peer ${peerId} joined`);
+  const pc = new RTCPeerConnection({ iceServers: ICE });
+  const aborts = new Map<number, AbortController>();
+  peers.set(peerId, { pc, aborts });
+
+  pc.onicecandidate = (e) => {
+    if (e.candidate) sig(peerId, { type: "candidate", candidate: e.candidate });
+  };
+  pc.onconnectionstatechange = () => {
+    if (["failed", "closed", "disconnected"].includes(pc.connectionState)) closePeer(peerId);
+  };
+
+  const dc = pc.createDataChannel("api");
+  dc.onopen = () => console.log(`[share] datachannel open · ${peerId}`);
+  dc.onmessage = (e) => onReq(dc, aborts, JSON.parse(e.data as string));
+
+  pc.createOffer()
+    .then((o) => pc.setLocalDescription(o))
+    .then(() => sig(peerId, { type: "offer", sdp: pc.localDescription!.sdp }));
+}
+
+function closePeer(peerId: string) {
+  const p = peers.get(peerId);
+  if (!p) return;
+  for (const a of p.aborts.values()) a.abort();
+  try {
+    p.pc.close();
+  } catch {
+    /* already closed */
+  }
+  peers.delete(peerId);
+  console.log(`[share] peer ${peerId} gone`);
+}
+
+function send(dc: any, obj: object) {
+  if (dc.readyState === "open") dc.send(JSON.stringify(obj));
+}
+
+async function onReq(dc: any, aborts: Map<number, AbortController>, req: any) {
+  if (req.t === "abort") {
+    aborts.get(req.id)?.abort();
+    aborts.delete(req.id);
+    return;
+  }
+  if (req.t !== "req") return;
+  const { id, method, path: p, body } = req;
+  const ac = new AbortController();
+  aborts.set(id, ac);
+  try {
+    const res = await fetch(API + p, {
+      method,
+      headers: {
+        Authorization: `Bearer ${API_TOKEN}`,
+        ...(body ? { "Content-Type": "application/json" } : {}),
+      },
+      body: body ?? undefined,
+      signal: ac.signal,
+    });
+    send(dc, { t: "res", id, status: res.status, ct: res.headers.get("content-type") ?? "" });
+    const reader = res.body!.getReader();
+    const dec = new TextDecoder();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const text = dec.decode(value, { stream: true });
+      for (let i = 0; i < text.length; i += MAX_CHUNK) {
+        send(dc, { t: "data", id, chunk: text.slice(i, i + MAX_CHUNK) });
+      }
+    }
+    send(dc, { t: "end", id });
+  } catch (e) {
+    if ((e as Error).name !== "AbortError") send(dc, { t: "end", id, error: String(e) });
+  } finally {
+    aborts.delete(id);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "scripts": {
     "build": "tsdown",
+    "cf": "bun scripts/cf.ts",
     "build:rs": "cargo install --path rs --features swarm",
     "postbuild": "bun ./ts/postbuild.ts",
     "demo": "bun run build && bun link && claude-yes -- demo",
@@ -92,6 +93,7 @@
     "execa": "^9.6.1",
     "from-node-stream": "^0.2.0",
     "ms": "^2.1.3",
+    "node-datachannel": "^0.32.3",
     "phpdie": "^1.7.0",
     "proper-lockfile": "^4.1.2",
     "sflow": "^1.27.0",
@@ -142,5 +144,7 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "trustedDependencies": []
+  "trustedDependencies": [
+    "node-datachannel"
+  ]
 }

--- a/scripts/cf.ts
+++ b/scripts/cf.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+// Thin wrapper that runs `wrangler` against the SNOLAB Cloudflare account using
+// the API token saved in .env.local — so we never depend on `wrangler login`
+// state (which points at a different account) and never pass the token on the
+// CLI. Usage:  bun scripts/cf.ts <wrangler args...>
+//   e.g.  bun scripts/cf.ts whoami
+//         bun scripts/cf.ts pages deploy ./dist --project-name agent-yes
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, renameSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+// SNOLAB account — agent-yes.com lives here. Account id is not a secret.
+const SNOLAB_ACCOUNT_ID = "0beef4cd2d2da6befa47d8d149d6e157";
+
+const root = path.join(import.meta.dir, "..");
+const env: Record<string, string | undefined> = { ...process.env };
+
+// Load .env.local (bun also auto-loads it, but be explicit so this works from
+// any cwd and is obvious to a reader).
+try {
+  for (const line of readFileSync(path.join(root, ".env.local"), "utf8").split("\n")) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
+    if (m && !(m[1] in env)) env[m[1]] = m[2];
+  }
+} catch {
+  /* no .env.local — fall through to the check below */
+}
+
+if (!env.CLOUDFLARE_API_TOKEN) {
+  console.error("CLOUDFLARE_API_TOKEN is missing — add it to .env.local (see scripts/cf.ts).");
+  process.exit(1);
+}
+env.CLOUDFLARE_ACCOUNT_ID = SNOLAB_ACCOUNT_ID;
+
+// wrangler otherwise prefers a stored OAuth login over CLOUDFLARE_API_TOKEN and
+// pins the OAuth account (Axon), ignoring CLOUDFLARE_ACCOUNT_ID. Two sources to
+// neutralise: the global OAuth config (~/.wrangler) and a project-level account
+// cache (.wrangler/wrangler-account.json) that pins whatever account first
+// deployed. Drop the cache, move the OAuth config aside for the run, restore it.
+rmSync(path.join(root, ".wrangler/wrangler-account.json"), { force: true });
+const oauthCfg = path.join(homedir(), ".wrangler/config/default.toml");
+const oauthBak = oauthCfg + ".cf-bak";
+const hadOauth = existsSync(oauthCfg);
+if (hadOauth) renameSync(oauthCfg, oauthBak);
+try {
+  const r = spawnSync("bunx", ["wrangler", ...process.argv.slice(2)], { stdio: "inherit", env });
+  process.exitCode = r.status ?? 1;
+} finally {
+  if (hadOauth && existsSync(oauthBak)) renameSync(oauthBak, oauthCfg);
+}

--- a/ts/rustBinary.ts
+++ b/ts/rustBinary.ts
@@ -41,10 +41,7 @@ export function getBinaryName(): string {
  */
 export function getBinDir(): string {
   // First check for binaries in the npm package
-  const packageBinDir = path.resolve(
-    import.meta.dirname ?? import.meta.dir,
-    "../bin",
-  );
+  const packageBinDir = path.resolve(import.meta.dirname ?? import.meta.dir, "../bin");
   if (existsSync(packageBinDir)) {
     return packageBinDir;
   }
@@ -61,8 +58,7 @@ export function getBinDir(): string {
   const cacheDir =
     process.env.AGENT_YES_CACHE_DIR ||
     path.join(
-      process.env.XDG_CACHE_HOME ||
-        path.join(process.env.HOME || "/tmp", ".cache"),
+      process.env.XDG_CACHE_HOME || path.join(process.env.HOME || "/tmp", ".cache"),
       "agent-yes",
     );
 
@@ -78,14 +74,8 @@ export function findRustBinary(verbose = false): string | undefined {
   const ext = process.platform === "win32" ? ".exe" : "";
   const searchPaths = [
     // 1. Check relative to this script (in the repo during development)
-    path.resolve(
-      import.meta.dirname ?? import.meta.dir,
-      `../rs/target/release/agent-yes${ext}`,
-    ),
-    path.resolve(
-      import.meta.dirname ?? import.meta.dir,
-      `../rs/target/debug/agent-yes${ext}`,
-    ),
+    path.resolve(import.meta.dirname ?? import.meta.dir, `../rs/target/release/agent-yes${ext}`),
+    path.resolve(import.meta.dirname ?? import.meta.dir, `../rs/target/debug/agent-yes${ext}`),
 
     // 2. Check in npm package bin directory
     path.join(getBinDir(), binaryName),
@@ -149,9 +139,7 @@ export async function downloadBinary(verbose = false): Promise<string> {
 
   const response = await fetch(url);
   if (!response.ok) {
-    throw new Error(
-      `Failed to download binary: ${response.status} ${response.statusText}`,
-    );
+    throw new Error(`Failed to download binary: ${response.status} ${response.statusText}`);
   }
 
   const isWindows = process.platform === "win32";
@@ -243,19 +231,14 @@ function getRustBinaryVersion(binaryPath: string): string | null {
  */
 function autoRebuildIfOutdated(binaryPath: string, verbose: boolean): boolean {
   // Only auto-rebuild for local dev builds (target/release or target/debug)
-  if (
-    !binaryPath.includes("/target/release") &&
-    !binaryPath.includes("/target/debug")
-  ) {
+  if (!binaryPath.includes("/target/release") && !binaryPath.includes("/target/debug")) {
     return true; // not a dev build, skip
   }
 
   const binaryVersion = getRustBinaryVersion(binaryPath);
   const pkgVersion = getInstalledPackage().version;
   if (verbose) {
-    console.log(
-      `[rust] Binary version: ${binaryVersion}, package version: ${pkgVersion}`,
-    );
+    console.log(`[rust] Binary version: ${binaryVersion}, package version: ${pkgVersion}`);
   }
 
   if (binaryVersion === pkgVersion) {
@@ -263,15 +246,9 @@ function autoRebuildIfOutdated(binaryPath: string, verbose: boolean): boolean {
   }
 
   // Find the rs/ directory relative to the binary (binary is at rs/target/release/agent-yes)
-  const rsDir = binaryPath.replace(
-    /\/target\/(release|debug)\/agent-yes.*$/,
-    "",
-  );
+  const rsDir = binaryPath.replace(/\/target\/(release|debug)\/agent-yes.*$/, "");
   if (!existsSync(path.join(rsDir, "Cargo.toml"))) {
-    if (verbose)
-      console.log(
-        `[rust] Cannot find Cargo.toml at ${rsDir}, skipping rebuild`,
-      );
+    if (verbose) console.log(`[rust] Cannot find Cargo.toml at ${rsDir}, skipping rebuild`);
     return true; // can't rebuild, use as-is
   }
 
@@ -299,9 +276,7 @@ function autoRebuildIfOutdated(binaryPath: string, verbose: boolean): boolean {
     process.stderr.write(`\x1b[32m[rust] Rebuild complete\x1b[0m\n`);
     return true;
   } catch {
-    process.stderr.write(
-      `\x1b[31m[rust] Auto-rebuild failed, using outdated binary\x1b[0m\n`,
-    );
+    process.stderr.write(`\x1b[31m[rust] Auto-rebuild failed, using outdated binary\x1b[0m\n`);
     return true; // still usable, just old
   }
 }

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -13,6 +13,7 @@ import {
   writeToIpc,
   type CommonOpts,
 } from "./subcommands.ts";
+import { SUPPORTED_CLIS } from "./SUPPORTED_CLIS.ts";
 
 const DEFAULT_PORT = 7432;
 
@@ -123,6 +124,8 @@ export async function cmdServe(rest: string[]): Promise<number> {
         `  --port N          Port to listen on (default: ${DEFAULT_PORT})\n` +
         `  --host HOST       Interface to bind (default: 127.0.0.1; use 0.0.0.0 to expose)\n` +
         `  --token TOKEN     Auth token (auto-generated and saved if omitted)\n` +
+        `  --share [URL]     Share over WebRTC to agent-yes.com (bare flag mints a room+link)\n` +
+        `  --allow-spawn     Let the shared console launch new agents (asks y/N per request)\n` +
         `  --tls-cert FILE   TLS certificate PEM\n` +
         `  --tls-key  FILE   TLS private key PEM\n\n` +
         `Subcommands:\n` +
@@ -153,6 +156,16 @@ export async function cmdServe(rest: string[]): Promise<number> {
     .option("token", { type: "string", description: "Auth token (auto-generated if omitted)" })
     .option("tls-cert", { type: "string", description: "TLS certificate file (PEM)" })
     .option("tls-key", { type: "string", description: "TLS private key file (PEM)" })
+    .option("share", {
+      type: "string",
+      description:
+        "Share over WebRTC: bare flag mints a room+link, or pass webrtc://room:token@host",
+    })
+    .option("allow-spawn", {
+      type: "boolean",
+      default: false,
+      description: "Allow the shared console to spawn new agents (asks y/N per request on a TTY)",
+    })
     .help(false)
     .version(false)
     .exitProcess(false);
@@ -178,6 +191,26 @@ export async function cmdServe(rest: string[]): Promise<number> {
   }
 
   const token = await loadOrCreateToken(tokenFlag);
+  const allowSpawn = argv["allow-spawn"] === true;
+
+  // Spawn confirmation: launch requests are gated by --allow-spawn AND, on a TTY,
+  // an interactive y/N per request (a leaked launch link can't silently spawn).
+  const spawnQueue: Array<(ok: boolean) => void> = [];
+  let stdinWired = false;
+  const confirmSpawn = (cli: string, cwd: string, prompt: string): Promise<boolean> => {
+    if (!process.stdin.isTTY) return Promise.resolve(true); // flag is the consent when headless
+    if (!stdinWired) {
+      stdinWired = true;
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", (d: string) => spawnQueue.shift()?.(/^y/i.test(d.trim())));
+      process.stdin.resume();
+    }
+    process.stdout.write(
+      `\n⚠ console requests spawn:  ay ${cli}${prompt ? ` -- "${prompt.slice(0, 60)}"` : ""}\n` +
+        `   cwd: ${cwd}\n   allow? [y/N] `,
+    );
+    return new Promise((res) => spawnQueue.push(res));
+  };
 
   const serverOpts: any = {
     hostname: host,
@@ -246,6 +279,9 @@ export async function cmdServe(rest: string[]): Promise<number> {
       const tailM = /^\/api\/tail\/(.+)$/.exec(p);
       if (req.method === "GET" && tailM) {
         const keyword = decodeURIComponent(tailM[1]!);
+        // raw=1 streams the unmodified PTY bytes (ANSI/cursor control intact) so a
+        // browser xterm.js can render the real terminal; default stays ANSI-stripped.
+        const raw = url.searchParams.get("raw") === "1";
         try {
           const record = await resolveOne(keyword, defaultOpts());
           if (!record.log_file)
@@ -259,10 +295,12 @@ export async function cmdServe(rest: string[]): Promise<number> {
                 ctrl.enqueue(enc.encode(`data: ${JSON.stringify(text)}\n\n`));
               const ping = () => ctrl.enqueue(enc.encode(": ping\n\n"));
 
-              // Initial tail
+              // Initial tail. Raw: replay the last ~64 KB of PTY bytes (enough to
+              // contain a recent full-screen redraw so xterm converges fast).
               const initBuf = await readFile(logPath).catch(() => Buffer.alloc(0));
-              const initText = await renderRawLog(initBuf, { mode: "tail", n: 96 });
-              send(initText);
+              if (raw)
+                send(new TextDecoder().decode(initBuf.slice(Math.max(0, initBuf.length - 65536))));
+              else send(await renderRawLog(initBuf, { mode: "tail", n: 96 }));
 
               let offset = initBuf.length;
               let closed = false;
@@ -291,11 +329,15 @@ export async function cmdServe(rest: string[]): Promise<number> {
                   if (full.length <= offset) return;
                   const chunk = full.slice(offset);
                   offset = full.length;
-                  const text = new TextDecoder()
-                    .decode(chunk)
-                    .replace(ansiRe, "")
-                    .replace(ctrlRe, "");
-                  if (text.trim()) send(text.trimStart());
+                  if (raw) {
+                    send(new TextDecoder().decode(chunk));
+                  } else {
+                    const text = new TextDecoder()
+                      .decode(chunk)
+                      .replace(ansiRe, "")
+                      .replace(ctrlRe, "");
+                    if (text.trim()) send(text.trimStart());
+                  }
                 } catch {
                   /* log gone */
                 }
@@ -356,6 +398,74 @@ export async function cmdServe(rest: string[]): Promise<number> {
         }
       }
 
+      // POST /api/resize/:keyword  body {cols, rows} — drive the agent's PTY size.
+      // Mirrors `ay attach`: write ~/.agent-yes/winsize/<pid> then SIGWINCH; the
+      // agent's resize listener picks it up and reflows its TUI to that width.
+      const resizeM = /^\/api\/resize\/(.+)$/.exec(p);
+      if (req.method === "POST" && resizeM) {
+        const keyword = decodeURIComponent(resizeM[1]!);
+        let body: { cols?: number; rows?: number };
+        try {
+          body = await req.json();
+        } catch {
+          return new Response("invalid JSON body", { status: 400 });
+        }
+        const cols = Math.max(1, Math.floor(Number(body.cols) || 0));
+        const rows = Math.max(1, Math.floor(Number(body.rows) || 0));
+        if (!cols || !rows) return new Response("missing cols/rows", { status: 400 });
+        try {
+          const record = await resolveOne(keyword, defaultOpts());
+          const ayHome = process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes");
+          const winsizeDir = path.join(ayHome, "winsize");
+          await mkdir(winsizeDir, { recursive: true });
+          await writeFile(
+            path.join(winsizeDir, String(record.pid)),
+            `${cols} ${rows} ${Date.now()}\n`,
+          );
+          try {
+            process.kill(record.pid, "SIGWINCH");
+          } catch {
+            /* agent gone */
+          }
+          return Response.json({ ok: true, pid: record.pid, cols, rows });
+        } catch (e) {
+          return new Response((e as Error).message, { status: 404 });
+        }
+      }
+
+      // POST /api/spawn  body {cli, cwd, prompt} — launch a new agent (gated)
+      if (req.method === "POST" && p === "/api/spawn") {
+        if (!allowSpawn)
+          return new Response("spawning disabled — start: ay serve --share --allow-spawn", {
+            status: 403,
+          });
+        let body: { cli?: string; cwd?: string; prompt?: string };
+        try {
+          body = await req.json();
+        } catch {
+          return new Response("invalid JSON body", { status: 400 });
+        }
+        const cli = String(body.cli ?? "claude");
+        if (!SUPPORTED_CLIS.includes(cli as never))
+          return new Response(`unsupported cli: ${cli}`, { status: 400 });
+        const cwd = typeof body.cwd === "string" && body.cwd ? body.cwd : process.cwd();
+        const prompt = String(body.prompt ?? "");
+        if (!(await confirmSpawn(cli, cwd, prompt)))
+          return new Response("denied by host", { status: 403 });
+        try {
+          const child = Bun.spawn(["ay", cli, ...(prompt ? ["--", prompt] : [])], {
+            cwd,
+            stdin: "ignore",
+            stdout: "ignore",
+            stderr: "ignore",
+          });
+          child.unref();
+          return Response.json({ ok: true, pid: child.pid, cli, cwd });
+        } catch (e) {
+          return new Response((e as Error).message, { status: 500 });
+        }
+      }
+
       return new Response("Not Found", { status: 404 });
     },
   };
@@ -380,6 +490,27 @@ export async function cmdServe(rest: string[]): Promise<number> {
         `  openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes -subj '/CN=localhost'\n\n`,
     );
   }
+  // --share: bridge this local server to a WebRTC room so the agent-yes.com
+  // console can reach it peer-to-peer. Bare flag mints a room; a webrtc:// value
+  // joins an explicit one.
+  if (argv.share !== undefined) {
+    const shareUrl =
+      typeof argv.share === "string" && argv.share.startsWith("webrtc://") ? argv.share : undefined;
+    try {
+      const { startShare } = await import("./share.ts");
+      const { link } = await startShare({
+        url: shareUrl,
+        apiUrl: `http://127.0.0.1:${port}`,
+        apiToken: token,
+      });
+      process.stdout.write(
+        `\nshared over WebRTC — open this link (the token is eaten from the URL on open):\n  ${link}\n\n`,
+      );
+    } catch (e) {
+      process.stderr.write(`ay serve --share failed: ${(e as Error).message}\n`);
+    }
+  }
+
   process.stdout.write(`(Ctrl-C to stop)\n`);
 
   await new Promise<void>((resolve) => {

--- a/ts/share.ts
+++ b/ts/share.ts
@@ -1,0 +1,190 @@
+// `ay serve --share` host peer: connect to the signaling server as a room host
+// and bridge each browser peer's WebRTC DataChannel to this machine's local
+// `ay serve` HTTP API. The browser (agent-yes.com) thus reaches local agents
+// peer-to-peer — no public port, no tunnel. See lab/ui/cf/worker.ts for the
+// signaling protocol and lab/ui/index.html for the browser side.
+import { randomBytes } from "crypto";
+
+const SUB = "ay-signal-1";
+const ICE = [{ urls: "stun:stun.l.google.com:19302" }];
+const MAX_CHUNK = 15_000; // keep DataChannel messages under the SCTP limit
+const DEFAULT_SIGHOST = "s.agent-yes.com";
+
+export interface ShareOpts {
+  /** webrtc://room:token@host, or undefined to mint a fresh room+token */
+  url?: string;
+  /** signaling host when minting (default s.agent-yes.com) */
+  sighost?: string;
+  /** local ay-serve base URL the channel bridges to */
+  apiUrl: string;
+  /** bearer token for the local ay-serve API */
+  apiToken: string;
+}
+
+function parseShareUrl(s: string): { room: string; token: string; host: string } {
+  const m = /^webrtc:\/\/([^:@/]+):([^@/]+)@(.+)$/.exec(s);
+  if (!m) throw new Error(`bad --share url: ${s} (want webrtc://room:token@host)`);
+  return { room: m[1]!, token: m[2]!, host: m[3]! };
+}
+
+// node-datachannel ships a native addon. Under Bun the module sometimes resolves
+// from the global cache where the prebuilt .node isn't linked; this best-effort
+// shim symlinks it in before we import. In a normal npm/bunx install the binary
+// resolves from node_modules and the first import just works.
+async function importRTC(): Promise<any> {
+  try {
+    return (await import("node-datachannel/polyfill")).RTCPeerConnection;
+  } catch {
+    try {
+      const { existsSync, symlinkSync, mkdirSync, readdirSync } = await import("fs");
+      const path = (await import("path")).default;
+      const { createRequire } = await import("module");
+      const require = createRequire(import.meta.url);
+      const pkg = path.dirname(require.resolve("node-datachannel/package.json"));
+      const bin = path.join(pkg, "build", "Release", "node_datachannel.node");
+      const cacheRoot = path.join((await import("os")).homedir(), ".bun", "install", "cache");
+      if (existsSync(bin) && existsSync(cacheRoot)) {
+        for (const d of readdirSync(cacheRoot)) {
+          if (!d.startsWith("node-datachannel@")) continue;
+          const dst = path.join(cacheRoot, d, "build", "Release");
+          mkdirSync(dst, { recursive: true });
+          const link = path.join(dst, "node_datachannel.node");
+          if (!existsSync(link)) symlinkSync(bin, link);
+        }
+      }
+    } catch {
+      /* fall through — rethrow the original import error below */
+    }
+    return (await import("node-datachannel/polyfill")).RTCPeerConnection;
+  }
+}
+
+/** Start the share bridge. Resolves once signaling is connected; runs until the
+ *  process exits, reconnecting signaling on drop. Returns the shareable link. */
+export async function startShare(opts: ShareOpts): Promise<{ room: string; link: string }> {
+  const minted = !opts.url;
+  const sighost = opts.sighost ?? DEFAULT_SIGHOST;
+  const { room, token, host } = opts.url
+    ? parseShareUrl(opts.url)
+    : {
+        room: "r" + randomBytes(3).toString("hex"),
+        token: randomBytes(32).toString("hex"),
+        host: sighost,
+      };
+
+  const RTCPeerConnection = await importRTC();
+  const wsScheme = host.startsWith("localhost") || host.startsWith("127.") ? "ws" : "wss";
+  const ui = host === "s.agent-yes.com" ? "https://agent-yes.com" : "http://localhost:7778";
+  const suffix = host === "s.agent-yes.com" ? "" : "@" + host;
+  const link = `${ui}/#${room}:${token}${suffix}`;
+
+  type Peer = { pc: any; aborts: Map<number, AbortController> };
+  const peers = new Map<string, Peer>();
+
+  const connectSignaling = (onReady: () => void) => {
+    const ws = new WebSocket(`${wsScheme}://${host}/${room}`, [SUB]);
+    let ready = false;
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "hello", role: "host", token }));
+      ready = true;
+      onReady();
+    };
+    ws.onmessage = async (ev) => {
+      const m = JSON.parse(ev.data as string);
+      if (m.type === "peer-join") startPeer(ws, m.peer);
+      else if (m.type === "answer")
+        await peers.get(m.from)?.pc.setRemoteDescription({ type: "answer", sdp: m.sdp });
+      else if (m.type === "candidate")
+        await peers
+          .get(m.from)
+          ?.pc.addIceCandidate(m.candidate)
+          .catch(() => {});
+      else if (m.type === "peer-leave") closePeer(m.peer);
+    };
+    ws.onclose = () => {
+      // Keep established WebRTC peers; just re-establish the rendezvous so new
+      // browsers can still join. Backoff a little to avoid hot-looping.
+      setTimeout(() => connectSignaling(() => {}), ready ? 1500 : 4000);
+    };
+    ws.onerror = () => {};
+    return ws;
+  };
+
+  function startPeer(ws: WebSocket, peerId: string) {
+    const pc = new RTCPeerConnection({ iceServers: ICE });
+    const aborts = new Map<number, AbortController>();
+    peers.set(peerId, { pc, aborts });
+    pc.onicecandidate = (e: any) => {
+      if (e.candidate)
+        ws.send(JSON.stringify({ type: "candidate", to: peerId, candidate: e.candidate }));
+    };
+    pc.onconnectionstatechange = () => {
+      if (["failed", "closed", "disconnected"].includes(pc.connectionState)) closePeer(peerId);
+    };
+    const dc = pc.createDataChannel("api");
+    dc.onmessage = (e: any) => onReq(dc, aborts, JSON.parse(e.data));
+    pc.createOffer()
+      .then((o: any) => pc.setLocalDescription(o))
+      .then(() =>
+        ws.send(JSON.stringify({ type: "offer", to: peerId, sdp: pc.localDescription.sdp })),
+      );
+  }
+
+  function closePeer(peerId: string) {
+    const p = peers.get(peerId);
+    if (!p) return;
+    for (const a of p.aborts.values()) a.abort();
+    try {
+      p.pc.close();
+    } catch {
+      /* already closed */
+    }
+    peers.delete(peerId);
+  }
+
+  function send(dc: any, obj: object) {
+    if (dc.readyState === "open") dc.send(JSON.stringify(obj));
+  }
+
+  async function onReq(dc: any, aborts: Map<number, AbortController>, req: any) {
+    if (req.t === "abort") {
+      aborts.get(req.id)?.abort();
+      aborts.delete(req.id);
+      return;
+    }
+    if (req.t !== "req") return;
+    const { id, method, path: p, body } = req;
+    const ac = new AbortController();
+    aborts.set(id, ac);
+    try {
+      const res = await fetch(opts.apiUrl + p, {
+        method,
+        headers: {
+          Authorization: `Bearer ${opts.apiToken}`,
+          ...(body ? { "Content-Type": "application/json" } : {}),
+        },
+        body: body ?? undefined,
+        signal: ac.signal,
+      });
+      send(dc, { t: "res", id, status: res.status, ct: res.headers.get("content-type") ?? "" });
+      const reader = res.body!.getReader();
+      const dec = new TextDecoder();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const text = dec.decode(value, { stream: true });
+        for (let i = 0; i < text.length; i += MAX_CHUNK)
+          send(dc, { t: "data", id, chunk: text.slice(i, i + MAX_CHUNK) });
+      }
+      send(dc, { t: "end", id });
+    } catch (e) {
+      if ((e as Error).name !== "AbortError") send(dc, { t: "end", id, error: String(e) });
+    } finally {
+      aborts.delete(id);
+    }
+  }
+
+  await new Promise<void>((resolve) => connectSignaling(resolve));
+  void minted; // (informational) caller decides how to surface the link
+  return { room, link };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -61,6 +61,9 @@ export default defineConfig({
         // running server and network); unit coverage not meaningful here.
         "ts/serve.ts",
         "ts/remotes.ts",
+        // WebRTC share bridge — needs a peer + signaling server; proven e2e, not
+        // unit-testable.
+        "ts/share.ts",
       ],
       thresholds: {
         lines: 90,


### PR DESCRIPTION
Browse and drive your local agents from **agent-yes.com** peer-to-peer over a WebRTC DataChannel — no public port, no tunnel.

## What's in it

- **`ay serve --share`** — mints a room + 64-char token and prints an `agent-yes.com` link; bridges the local HTTP API (ls / read / tail / send / spawn / resize) over a WebRTC DataChannel, reconnecting signaling on drop. `--allow-spawn` gates remote agent launches behind a y/N confirm. (`ts/share.ts`, `ts/serve.ts`)
- **Signaling** — one Cloudflare Worker (`lab/ui/cf`) with Durable Object rooms; the token is carried in the first WS message (Bun mangles long subprotocols). Serves the UI on `agent-yes.com` and signaling on `s.agent-yes.com`.
- **Console** (`lab/ui/index.html`) — agent list + **xterm.js** rendering the raw PTY stream. The browser **drives the agent's PTY size** (`POST /api/resize` → winsize file + SIGWINCH, the same channel `ay attach` uses) so TUIs reflow to the right width; keystrokes / mouse / terminal-query responses are forwarded for full interactivity. `localStorage` rooms manager via the connection badge.

## Security model

- The room token is a credential: **eaten from the URL** on load (kept only in `localStorage`), 64 chars, never logged.
- **attach vs launch split** — attach URLs (`#room:token`) carry the token; **launch URLs (`#launch=<json>`) carry the command only**. The capability to spawn is the *viewer's own cached room* + a host-side `--allow-spawn` confirm, so a public launch link can never spawn on a machine the clicker doesn't already control.

## Notes

- `node-datachannel` moved to `dependencies`; `scripts/cf.ts` deploys wrangler to the SNOLAB account using the token in `.env.local` (`account_id` lives in the wrangler config since wrangler ignores `CLOUDFLARE_ACCOUNT_ID` for some commands).
- `ts/share.ts` is excluded from coverage (WebRTC bridge — proven e2e, not unit-testable), consistent with `ts/serve.ts`.
- Verified end-to-end in a real browser: agent-yes.com → s.agent-yes.com → local `ay serve --share`; live list, xterm tail at matched width, launch-and-attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)