### PR TITLE
perf+feat: low-latency typing, agent-width rendering, auto-reconnect

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -814,10 +814,12 @@
         fit = new FitAddon.FitAddon();
         term.loadAddon(fit);
         term.open(logEl);
-        // Drive the agent's PTY to the browser's terminal size so its TUI reflows to
-        // match what we render (POST /api/resize → winsize file + SIGWINCH on the host).
+        // Adapt: drive the agent's PTY to the browser terminal size (POST
+        // /api/resize → winsize + SIGWINCH) so its TUI reflows to match what we
+        // render. Suppressed while we're merely adopting the agent's OWN size.
+        let adoptingAgentSize = false;
         const pushSize = () => {
-          if (term && sel)
+          if (term && sel && !adoptingAgentSize)
             Conn.post("/api/resize/" + encodeURIComponent(sel), {
               cols: term.cols,
               rows: term.rows,
@@ -834,10 +836,28 @@
         };
         term.onData(fwd);
         term.onBinary(fwd);
-        try {
-          fit.fit();
-        } catch {}
-        pushSize();
+        // Render the existing buffer at the AGENT's current width first so its
+        // wrapping is correct, instead of forcing our viewport width onto stale
+        // content. The user adapts to the window by resizing it (fit → push).
+        const selPid = sel;
+        Conn.fetchJSON("/api/size/" + encodeURIComponent(selPid))
+          .then((sz) => {
+            if (sel !== selPid || !term) return;
+            if (sz && sz.cols && sz.rows) {
+              adoptingAgentSize = true;
+              term.resize(sz.cols, sz.rows);
+              adoptingAgentSize = false;
+            } else {
+              try {
+                fit.fit();
+              } catch {}
+            }
+          })
+          .catch(() => {
+            try {
+              fit.fit();
+            } catch {}
+          });
 
         // True live tail via ay serve's SSE stream. First event is an xterm-rendered
         // tail snapshot; later events are incremental deltas. We normalise terminal
@@ -927,6 +947,9 @@
       async function connectRoom(room, token, host) {
         host = host || SIG_DEFAULT;
         saveRoom(room, token, host); // cache so the badge can list & reconnect later
+        try {
+          localStorage.setItem("ay.lastRoom", room); // reconnect here on a bare open
+        } catch {}
         curRoom = room;
         if (Conn.rtc) {
           try {
@@ -1112,6 +1135,17 @@
         } else if (bare && loadRooms()[bare[1]]) {
           const r = loadRooms()[bare[1]];
           pending = { room: bare[1], token: r.token, host: r.host };
+        } else if (!raw) {
+          // No hash → reconnect to the last-used room (or the most recent saved
+          // one), so opening agent-yes.com brings back your list automatically.
+          const rooms = loadRooms();
+          const names = Object.keys(rooms);
+          if (names.length) {
+            const last = localStorage.getItem("ay.lastRoom");
+            const pick =
+              last && rooms[last] ? last : names.sort((a, b) => rooms[b].ts - rooms[a].ts)[0];
+            pending = { room: pick, token: rooms[pick].token, host: rooms[pick].host };
+          }
         }
         // Render the UI immediately and refresh on a timer; connect to a room (if
         // any) in the BACKGROUND so a dead/slow cached room never blanks the page.

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -625,7 +625,7 @@
             };
             ws.onerror = () => fail(new Error("signaling error"));
             ws.onclose = () => fail(new Error("signaling closed"));
-            setTimeout(() => fail(new Error("connect timeout")), 15000);
+            setTimeout(() => fail(new Error("connect timeout")), 8000);
           });
         }
         _recv(r) {
@@ -824,11 +824,16 @@
             }).catch(() => {});
         };
         term.onResize(pushSize);
-        // Forward keystrokes/mouse typed into the terminal straight to the agent stdin
-        // (raw, no trailing Enter) so it's directly interactive, not just a viewer.
-        term.onData((d) => {
+        // Forward everything the terminal emits to the agent stdin (raw, no
+        // trailing Enter): keystrokes, paste, and — when a TUI enables mouse
+        // tracking — click / drag-motion / wheel as SGR mouse reports. onBinary
+        // covers the UTF-8 mouse encoding (DECSET 1005). Verified end-to-end:
+        // a drag emits \x1b[<0;..M / \x1b[<32;..M / \x1b[<0;..m, wheel \x1b[<64/65..M.
+        const fwd = (d) => {
           if (sel) Conn.post("/api/send", { keyword: sel, msg: d, code: "none" }).catch(() => {});
-        });
+        };
+        term.onData(fwd);
+        term.onBinary(fwd);
         try {
           fit.fit();
         } catch {}
@@ -1093,6 +1098,7 @@
         const h = decodeURIComponent(raw);
         const full = /^([A-Za-z0-9_-]+):([^@]+)(?:@(.+))?$/.exec(h);
         const bare = /^([A-Za-z0-9_-]+)$/.exec(h);
+        let pending = null;
         if (full) {
           const [, room, token, host] = full;
           // SECURITY: strip the token from the URL immediately so it never lingers in
@@ -1102,15 +1108,17 @@
             document.title,
             location.pathname + location.search + "#" + room,
           );
-          await connectRoom(room, token, host);
+          pending = { room, token, host };
         } else if (bare && loadRooms()[bare[1]]) {
           const r = loadRooms()[bare[1]];
-          await connectRoom(bare[1], r.token, r.host);
-        } else {
-          setConn("● local", "var(--muted)");
-          loadList();
+          pending = { room: bare[1], token: r.token, host: r.host };
         }
+        // Render the UI immediately and refresh on a timer; connect to a room (if
+        // any) in the BACKGROUND so a dead/slow cached room never blanks the page.
+        if (!pending) setConn("● local", "var(--muted)");
+        loadList();
         setInterval(loadList, 3000); // refresh statuses / new agents
+        if (pending) connectRoom(pending.room, pending.token, pending.host);
       }
       boot();
     </script>

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -307,6 +307,11 @@ impl AgentContext {
                 initial_size.0, initial_size.1, e
             );
         }
+        crate::pty_spawner::write_current_ptysize(
+            std::process::id(),
+            initial_size.0,
+            initial_size.1,
+        );
         // Keep vterm in sync with the same initial size, otherwise vterm
         // could remain stuck at AgentContext::new() dimensions until the
         // first SIGWINCH fires.
@@ -373,6 +378,7 @@ impl AgentContext {
                         warn!("PTY resize to {}x{} failed: {}", cols, rows, e);
                     }
                     self.vterm.resize(rows, cols);
+                    crate::pty_spawner::write_current_ptysize(std::process::id(), cols, rows);
                 }
 
                 // Stdin data

--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -59,6 +59,18 @@ pub fn read_external_winsize_from(base_dir: &std::path::Path, pid: u32) -> Optio
     parse_winsize_line(content.lines().next()?)
 }
 
+/// Record the agent's CURRENT applied PTY size to `$AGENT_YES_HOME/ptysize/<pid>`
+/// (format: `<cols> <rows>\n`) so `ay serve` / the web console can render the
+/// existing buffer at the agent's real width before adapting to the viewport.
+/// Best-effort; never panics.
+pub fn write_current_ptysize(pid: u32, cols: u16, rows: u16) {
+    if let Some(dir) = crate::log_files::global_dir() {
+        let d = dir.join("ptysize");
+        let _ = std::fs::create_dir_all(&d);
+        let _ = std::fs::write(d.join(pid.to_string()), format!("{} {}\n", cols, rows));
+    }
+}
+
 /// Parse a single `"cols rows timestamp_ms"` line. Extracted for unit tests.
 pub fn parse_winsize_line(line: &str) -> Option<(u16, u16)> {
     let mut parts = line.split_ascii_whitespace();

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -5,6 +5,7 @@ import path from "path";
 import DIE from "phpdie";
 import sflow from "sflow";
 import { XtermProxy } from "./xterm-proxy.ts";
+import { agentYesHome } from "./agentYesHome.ts";
 import {
   extractSessionId,
   getSessionForCwd,
@@ -643,11 +644,26 @@ export default async function agentYes({
     return pendingExitCode.resolve(exitCode);
   });
 
+  // Record the agent's current PTY size to ~/.agent-yes/ptysize/<pid> so `ay serve`
+  // / the web console can render the existing buffer at the agent's real width
+  // before adapting. Mirrors the Rust runtime (rs/src/pty_spawner.rs).
+  const writeCurrentPtysize = (cols: number, rows: number) => {
+    const dir = path.join(agentYesHome(), "ptysize");
+    void mkdir(dir, { recursive: true })
+      .then(() => writeFile(path.join(dir, String(process.pid)), `${cols} ${rows}\n`))
+      .catch(() => null);
+  };
+  {
+    const { cols, rows } = getTerminalDimensions();
+    writeCurrentPtysize(cols, rows);
+  }
+
   // when current tty resized, resize both pty and xterm proxy
   process.stdout.on("resize", () => {
     const { cols, rows } = getTerminalDimensions();
     shell.resize(cols, rows);
     xtermProxy.resize(cols, rows);
+    writeCurrentPtysize(cols, rows);
   });
 
   const isStillWorkingQ = () => {

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -276,6 +276,32 @@ export async function cmdServe(rest: string[]): Promise<number> {
         }
       }
 
+      // GET /api/size/:keyword — the agent's current PTY size, so the console can
+      // render the existing buffer at the agent's real width before adapting.
+      const sizeM = /^\/api\/size\/(.+)$/.exec(p);
+      if (req.method === "GET" && sizeM) {
+        const keyword = decodeURIComponent(sizeM[1]!);
+        try {
+          const record = await resolveOne(keyword, defaultOpts());
+          const ayHome = process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes");
+          let cols: number | null = null;
+          let rows: number | null = null;
+          try {
+            const txt = await readFile(path.join(ayHome, "ptysize", String(record.pid)), "utf-8");
+            const [c, r] = txt.trim().split(/\s+/).map(Number);
+            if (c > 0 && r > 0) {
+              cols = c;
+              rows = r;
+            }
+          } catch {
+            /* no ptysize sidecar (older agent or not yet written) */
+          }
+          return Response.json({ pid: record.pid, cols, rows });
+        } catch (e) {
+          return new Response((e as Error).message, { status: 404 });
+        }
+      }
+
       // GET /api/tail/:keyword  — SSE streaming
       const tailM = /^\/api\/tail\/(.+)$/.exec(p);
       if (req.method === "GET" && tailM) {

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { mkdir, open, readFile, writeFile } from "fs/promises";
+import { watch } from "node:fs";
 import { createHash, randomBytes, timingSafeEqual } from "crypto";
 import { homedir } from "os";
 import path from "path";
@@ -319,34 +320,59 @@ export async function cmdServe(rest: string[]): Promise<number> {
               // eslint-disable-next-line no-control-regex
               const ctrlRe = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
 
-              const poller = setInterval(async () => {
-                if (closed) {
-                  clearInterval(poller);
-                  return;
-                }
+              // Stream only the bytes appended since `offset` (incremental read,
+              // not a full re-read), driven by fs.watch for near-instant echo with
+              // a short fallback poll in case the watcher misses an event. The old
+              // 300 ms full-file poll was the dominant typing-echo latency.
+              const fh = await open(logPath, "r").catch(() => null);
+              let reading = false;
+              const flush = async () => {
+                if (closed || reading || !fh) return;
+                reading = true;
                 try {
-                  const full = await readFile(logPath);
-                  if (full.length <= offset) return;
-                  const chunk = full.slice(offset);
-                  offset = full.length;
-                  if (raw) {
-                    send(new TextDecoder().decode(chunk));
-                  } else {
-                    const text = new TextDecoder()
-                      .decode(chunk)
-                      .replace(ansiRe, "")
-                      .replace(ctrlRe, "");
-                    if (text.trim()) send(text.trimStart());
+                  const { size } = await fh.stat();
+                  if (size < offset) offset = size; // truncated/rotated
+                  if (size > offset) {
+                    const len = size - offset;
+                    const buf = Buffer.allocUnsafe(len);
+                    const { bytesRead } = await fh.read(buf, 0, len, offset);
+                    offset += bytesRead;
+                    const chunk = buf.subarray(0, bytesRead);
+                    if (raw) {
+                      send(new TextDecoder().decode(chunk));
+                    } else {
+                      const text = new TextDecoder()
+                        .decode(chunk)
+                        .replace(ansiRe, "")
+                        .replace(ctrlRe, "");
+                      if (text.trim()) send(text.trimStart());
+                    }
                   }
                 } catch {
                   /* log gone */
+                } finally {
+                  reading = false;
                 }
-              }, 300);
+              };
+
+              let watcher: ReturnType<typeof watch> | null = null;
+              try {
+                watcher = watch(logPath, () => void flush());
+              } catch {
+                /* fs.watch unsupported — the fallback poll below still works */
+              }
+              const poller = setInterval(() => void flush(), 60);
 
               req.signal.addEventListener("abort", () => {
                 closed = true;
                 clearInterval(heartbeat);
                 clearInterval(poller);
+                try {
+                  watcher?.close();
+                } catch {
+                  /* already closed */
+                }
+                void fh?.close().catch(() => {});
                 try {
                   ctrl.close();
                 } catch {


### PR DESCRIPTION
Follow-ups to the agent-yes.com remote console (#47), driven by real usage.

## Typing & responsiveness
- **Near-instant echo.** Keystrokes already travel over the WebRTC DataChannel, but the echo returns via the tail stream — and `/api/tail` re-read the *entire* log every 300 ms. It now streams incrementally (only bytes appended since the last offset) driven by `fs.watch`, with a 60 ms fallback poll. Echo latency drops from up to +300 ms to ~one round-trip.
- **Render-first boot.** A dead/slow cached room used to block `boot()` for 15 s and blank the page. It now renders immediately and connects in the background; connect timeout cut 15 s → 8 s.

## Terminal fidelity
- **Render at the agent's real PTY width.** Each agent writes `~/.agent-yes/ptysize/<pid>` (`<cols> <rows>`) on spawn + every SIGWINCH, in **both runtimes** (Rust default + TS fallback). `ay serve` exposes `GET /api/size/:pid`; on select the console sizes xterm to the agent so existing content wraps correctly, instead of forcing the viewport width onto stale output. **Adopt-only** — it doesn't push the size back, so the agent and your local terminal are undisturbed. Resizing the browser window adapts (fit → `/api/resize`).
- **Mouse + binary input forwarded.** `onData` *and* `onBinary` are forwarded, so SGR mouse reports (click / drag-motion / wheel) and the UTF-8 mouse encoding reach mouse-tracking TUIs. Verified end-to-end.

## Sessions
- **Auto-reconnect on open.** Opening agent-yes.com with no hash reconnects to your last-used room (or the most recent saved one), so your agent list comes back automatically. `connectRoom` records `localStorage["ay.lastRoom"]`.

Verified: 100×42 agent renders at 100×42 with correct layout and no push-back; bare open of agent-yes.com restores the list; live tail/echo confirmed in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)