### PR TITLE
fix(ui): re-assert terminal size to the agent on tab re-activation

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1368,6 +1368,13 @@
       let es = null; // live-tail subscription closer
       let term = null; // xterm.js Terminal rendering the raw PTY stream
       let fit = null;
+      // Re-fit the open terminal and re-assert its size to the agent's PTY. Set per
+      // selection in select(); invoked on open AND whenever the tab is re-activated.
+      // A backgrounded tab can miss window resizes, and another viewer may have
+      // resized the shared PTY while we were away — either leaves our stream
+      // rendering at the wrong width/height until something nudges it. null when no
+      // agent is open.
+      let resyncTerm = null;
       // Terminal font size (px) — adjustable from the ⋯ menu, persisted across
       // reloads, applied live to the open terminal and used by every new one.
       let termFontSize = 12;
@@ -2947,9 +2954,17 @@
           }
           suppressPush = false;
         };
-        tx.fetchJSON("/api/size/" + encodeURIComponent(pid))
-          .then(fitAndSync)
-          .catch(() => fitAndSync(null));
+        // Fit + sync now, and on every later tab re-activation: re-measure our pane
+        // and re-assert our size to the agent so the stream always reflows to OUR
+        // viewport (see the visibilitychange hook in startPolling). Push-if-different
+        // inside fitAndSync keeps an already-matching agent from a redundant SIGWINCH.
+        resyncTerm = () => {
+          if (sel !== selKey || !term) return;
+          tx.fetchJSON("/api/size/" + encodeURIComponent(pid))
+            .then(fitAndSync)
+            .catch(() => fitAndSync(null));
+        };
+        resyncTerm();
 
         // True live tail via ay serve's SSE stream. First event is an xterm-rendered
         // tail snapshot; later events are incremental deltas. We normalise terminal
@@ -3719,6 +3734,11 @@
           if (document.visibilityState === "visible") {
             lastActivity = Date.now();
             loadList();
+            // Re-assert our viewport size to the open agent: while we were away the
+            // window may have resized (a hidden tab can miss it) or another viewer
+            // may have resized the shared PTY, so the stream could be rendering at
+            // the wrong width/height. fit + push-if-different brings it back.
+            resyncTerm?.();
           }
         });
         watchVersion();


### PR DESCRIPTION
## What

When you return to a backgrounded console tab, the live terminal could keep rendering at the **wrong width/height**. The `visibilitychange` handler only refreshed the agent list — it never re-fit the terminal or re-asserted our size to the agent's PTY.

Two ways this diverged while a tab was away:
- a backgrounded tab can miss window `resize` events, and
- **another viewer** (phone/second browser) can resize the *shared* PTY.

Either left the stream boxed-in/clipped until something else nudged it.

## Fix

Add a per-selection `resyncTerm()` that re-fits the terminal and re-asserts our size to the agent — **push-only-if-different**, so an already-matching agent isn't poked with a redundant SIGWINCH. It's wired into both the initial open (reusing the existing fit+sync path) and `visibilitychange`→visible.

## Verification

Drove the live console in headless Chromium over WebRTC and selected a real agent:

| reactivation (pure tab switch) | `resyncRuns` | `resizePushes` |
|---|---|---|
| before | 0 → 0 (nothing) | 1 → 1 |
| after  | 1 → **2** (resync fires) | 1 → 1 (no redundant SIGWINCH) |

The same `fitAndSync` proved it *does* push when sizes diverge (initial open resized the agent 228×80 → 100×53). Console theme e2e passes (pre-push gate). codex review: no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)