### PR TITLE
feat(serve): emit the WebRTC share URL on `ay serve install`

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -276,6 +276,24 @@ function portFromArgs(args: string[]): number {
   return m ? Number(m[1]) : DEFAULT_PORT;
 }
 
+// An explicit webrtc:// URL passed to --webrtc/--share in the daemon's serve args,
+// or undefined for a bare flag (which mints a persisted room instead). Mirrors how
+// cmdServe resolves argv.webrtc/argv.share, but over the raw arg list install holds
+// (oxmgr splits the command on whitespace → `--webrtc url`; pm2/`=` → `--webrtc=url`).
+function explicitWebrtcUrl(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    for (const flag of ["--webrtc", "--share"]) {
+      if (a === flag && args[i + 1]?.startsWith("webrtc://")) return args[i + 1];
+      if (a.startsWith(`${flag}=`)) {
+        const v = a.slice(flag.length + 1);
+        if (v.startsWith("webrtc://")) return v;
+      }
+    }
+  }
+  return undefined;
+}
+
 // Ask the live daemon its version over the local HTTP API. null if it's not
 // listening (webrtc-only) or too old to expose /api/version — both of which we
 // treat as "outdated" so a re-install rolls it forward.
@@ -314,19 +332,68 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
     const effArgs = args.length ? args : (priorArgs ?? []);
     const current = getInstalledPackage().version;
 
+    // WebRTC daemon: resolve the share link up front so we can print it on every
+    // install path (fresh install, roll-forward, and the already-up-to-date no-op).
+    // The link is a pure transform of the room URL, so the foreground install
+    // command can show it even though the background daemon is what runs the bridge.
+    // Resolve (and persist, when auto-minting) the room BEFORE spawning, so the
+    // daemon reads the SAME ~/.agent-yes/.share-room and can't race us into minting
+    // a divergent one. We print the link directly — the install receipt already
+    // prints the bearer token, so the operator's terminal is the right trust scope
+    // for a secret-bearing link (unlike the daemon's persisted logs, which omit it).
+    const webrtcDaemon = effArgs.some((a) => a.startsWith("--webrtc") || a.startsWith("--share"));
+    let shareLink: string | null = null;
+    let shareLinkMinted = false; // auto-minted (persisted/rotatable) vs explicit URL
+    if (webrtcDaemon) {
+      try {
+        const { loadOrCreateShareRoom, shareLinkFromRoomUrl } = await import("./share.ts");
+        const explicit = explicitWebrtcUrl(effArgs);
+        shareLink = shareLinkFromRoomUrl(explicit ?? (await loadOrCreateShareRoom()));
+        shareLinkMinted = !explicit;
+      } catch {
+        /* best effort — fall back to the .share-link file hint in emitShareLink */
+      }
+    }
+    const emitShareLink = () => {
+      if (!webrtcDaemon) return;
+      if (shareLink)
+        process.stdout.write(
+          `\nshared over WebRTC — open this link (the token is eaten from the URL on open):\n` +
+            `  ${shareLink}\n` +
+            (shareLinkMinted
+              ? `  (persistent room — same link across restarts; delete ~/.agent-yes/.share-room to rotate)\n`
+              : ``),
+        );
+      else
+        process.stdout.write(
+          `\nthe WebRTC share link carries a secret, so the daemon does NOT log it —\n` +
+            `read it from ~/.agent-yes/.share-link (mode 0600). The room persists in\n` +
+            `~/.agent-yes/.share-room, so the link survives restarts.\n`,
+        );
+    };
+
     if (priorArgs !== null) {
-      // A daemon already exists — only disturb it if it's actually outdated.
+      // A daemon already exists. Treat this as a no-op only when it's BOTH current
+      // AND already running the requested config — otherwise a config change (e.g.
+      // `install --webrtc` over an --http daemon, which the version probe still
+      // reaches on the default port) would be silently ignored, and we'd print a
+      // share link for a WebRTC bridge that isn't actually running. A bare re-run
+      // passes no args, so effArgs === priorArgs and this stays a no-op as before.
+      const sameConfig = JSON.stringify(effArgs) === JSON.stringify(priorArgs);
       const runningVer = await fetchDaemonVersion(portFromArgs(effArgs), token);
-      if (runningVer === current) {
+      if (runningVer === current && sameConfig) {
         await ensureBootAutostart(mgr);
         process.stdout.write(`'${DAEMON_NAME}' already running v${current} (up to date)\n`);
+        emitShareLink();
         return 0;
       }
-      // Outdated (or unreachable/too-old to report) → graceful roll-forward.
-      // `stop` sends SIGTERM, which cmdServe handles cleanly (closing share
-      // peers so browsers reconnect fast), then we re-create with the new binary.
+      // Outdated, unreachable, or reconfigured → graceful roll-forward. `stop` sends
+      // SIGTERM, which cmdServe handles cleanly (closing share peers so browsers
+      // reconnect fast), then we re-create with the new binary/args.
       process.stdout.write(
-        `rolling '${DAEMON_NAME}' ${runningVer ? `v${runningVer}` : "(unknown)"} → v${current}…\n`,
+        runningVer === current
+          ? `reconfiguring '${DAEMON_NAME}' (serve args changed)…\n`
+          : `rolling '${DAEMON_NAME}' ${runningVer ? `v${runningVer}` : "(unknown)"} → v${current}…\n`,
       );
       await spawnExit([mgr.bin, "stop", DAEMON_NAME]);
       await spawnExit([mgr.bin, "delete", DAEMON_NAME]);
@@ -340,7 +407,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
     // freeze the JS event loop (host answers nobody, no in-process timer can
     // recover it), so an EXTERNAL probe of the serve heartbeat is the only thing
     // that can detect+restart it. 15s stale + 3 misses at 10s ≈ 45s to auto-recover.
-    const webrtcDaemon = effArgs.some((a) => a.startsWith("--webrtc") || a.startsWith("--share"));
+    // (webrtcDaemon resolved above, where we also derive the share link.)
     const oxmgrHealth =
       webrtcDaemon && mgr.id === "oxmgr"
         ? [
@@ -389,7 +456,6 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
       const onBoot = await ensureBootAutostart(mgr);
       const port = portFromArgs(effArgs);
       // Mirror cmdServe's mode resolution: webrtc-only daemons open no HTTP port.
-      const webrtcish = effArgs.some((a) => a.startsWith("--webrtc") || a.startsWith("--share"));
       const httpish =
         effArgs.some((a) => a.startsWith("--http") || a.startsWith("--share")) ||
         !effArgs.some((a) => a.startsWith("--webrtc"));
@@ -421,13 +487,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
       }
       process.stdout.write(`  ay serve logs                # view server logs\n`);
       process.stdout.write(`  ay serve uninstall           # remove daemon\n`);
-      if (webrtcish) {
-        process.stdout.write(
-          `\nthe WebRTC share link carries a secret, so the daemon does NOT log it —\n` +
-            `read it from ~/.agent-yes/.share-link (mode 0600). The room persists in\n` +
-            `~/.agent-yes/.share-room, so the link survives restarts.\n`,
-        );
-      }
+      emitShareLink();
     }
     return code ?? 1;
   }

--- a/ts/share.spec.ts
+++ b/ts/share.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { shareLinkFromRoomUrl } from "./share.ts";
+import { MARKER } from "../lab/ui/e2e.js";
+
+const S = "a".repeat(64); // a valid 64-hex room secret
+const TOK = `${MARKER}${S}`; // encrypted-room token (v2)
+
+// shareLinkFromRoomUrl turns a persisted/explicit webrtc://room:token@host room
+// into the browser console link `ay serve install` prints — it MUST match the
+// link startShare announces from the same room (both go through formatShareLink).
+describe("shareLinkFromRoomUrl", () => {
+  it("derives the prod console link (no host suffix; secret rides in the fragment)", () => {
+    const link = shareLinkFromRoomUrl(`webrtc://r1a2b3c:${TOK}@s.agent-yes.com`);
+    expect(link).toBe(`https://agent-yes.com/w/#r1a2b3c:${MARKER}${S}`);
+  });
+
+  it("derives a dev/self-hosted link carrying the signaling host in the fragment", () => {
+    const link = shareLinkFromRoomUrl(`webrtc://r1a2b3c:${TOK}@localhost:7778`);
+    expect(link).toBe(`http://localhost:7778/w/#r1a2b3c:${MARKER}${S}@localhost:7778`);
+  });
+
+  it("round-trips room + token in the fragment the browser splits back out", () => {
+    const link = shareLinkFromRoomUrl(`webrtc://room0:${TOK}@s.agent-yes.com`);
+    expect(link.split("#")[1]).toBe(`room0:${TOK}`);
+  });
+
+  it("refuses a legacy (unencrypted) room — operator must rotate to an encrypted link", () => {
+    expect(() => shareLinkFromRoomUrl(`webrtc://room0:${S}@s.agent-yes.com`)).toThrow(
+      /unencrypted/,
+    );
+  });
+
+  it("rejects a malformed room url", () => {
+    expect(() => shareLinkFromRoomUrl("not-a-webrtc-url")).toThrow(/webrtc:\/\//);
+  });
+});

--- a/ts/share.ts
+++ b/ts/share.ts
@@ -160,6 +160,33 @@ function parseShareUrl(s: string): { room: string; token: string; host: string }
   return { room: m[1]!, token: m[2]!, host: m[3]! };
 }
 
+// The browser console URL for a room — what the operator opens to reach the host.
+// Pure function of (room, secret S, signaling host): S rides in the URL fragment
+// (never sent to any server) and is eaten by the page on open. Single source of
+// truth for the link format, shared by startShare's live announce and by
+// shareLinkFromRoomUrl (so `ay serve install` prints the exact link the daemon serves).
+function formatShareLink(room: string, S: string, host: string): string {
+  // The console web-app is served under /w/ (landing page lives at /). A non-prod
+  // signaling host targets the local dev UI and carries the host in the fragment.
+  const ui = host === "s.agent-yes.com" ? "https://agent-yes.com/w" : "http://localhost:7778/w";
+  const suffix = host === "s.agent-yes.com" ? "" : "@" + host;
+  return `${ui}/#${room}:${MARKER}${S}${suffix}`;
+}
+
+// Derive the shareable console link from a persisted/explicit webrtc://room:token@host
+// URL WITHOUT starting a bridge, so `ay serve install` can print the same link the
+// background daemon will serve. Throws on a legacy (unencrypted) room, mirroring
+// startShare's refusal to host one.
+export function shareLinkFromRoomUrl(url: string): string {
+  const { room, token, host } = parseShareUrl(url);
+  const { s, v2 } = parseSecret(token);
+  if (!v2)
+    throw new Error(
+      "refusing to derive a link for an unencrypted room — delete ~/.agent-yes/.share-room to rotate to an encrypted link",
+    );
+  return formatShareLink(room, s, host);
+}
+
 // node-datachannel ships a native addon. Under Bun the module sometimes resolves
 // from the global cache where the prebuilt .node isn't linked; this best-effort
 // shim symlinks it in before we import. In a normal npm/bunx install the binary
@@ -280,10 +307,7 @@ export async function startShare(
   let S = firstS;
 
   const wsScheme = host.startsWith("localhost") || host.startsWith("127.") ? "ws" : "wss";
-  // The console web-app is served under /w/ (landing page lives at /).
-  const ui = host === "s.agent-yes.com" ? "https://agent-yes.com/w" : "http://localhost:7778/w";
-  const suffix = host === "s.agent-yes.com" ? "" : "@" + host;
-  const mkLink = () => `${ui}/#${room}:${MARKER}${S}${suffix}`;
+  const mkLink = () => formatShareLink(room, S, host);
   let authToken = await deriveAuthToken(S, room, host);
   let link = mkLink();
 


### PR DESCRIPTION
## What

When the daemon is webrtc-enabled, `ay serve install` now prints the **actual share link** — not just a pointer to `~/.agent-yes/.share-link`:

```
shared over WebRTC — open this link (the token is eaten from the URL on open):
  https://agent-yes.com/w/#r2d058f:e1.15c8…
  (persistent room — same link across restarts; delete ~/.agent-yes/.share-room to rotate)
```

Printed on every install path (fresh install, roll-forward, already-up-to-date). The link is a pure transform of the persisted room URL, so the foreground install command shows it even though the background daemon runs the bridge. Consistent with the receipt already printing the bearer token; the daemon still omits the link from its persisted logs.

## How

- **`share.ts`**: extract `formatShareLink()` + export `shareLinkFromRoomUrl()` (pure derivation); reuse it in `startShare`'s `mkLink` (single source of truth).
- **`serve.ts`**: resolve + persist the room **before** spawning (so the daemon reads the same `~/.agent-yes/.share-room`, no mint race), derive the link, and emit it. Add `explicitWebrtcUrl()` to parse an explicit `webrtc://` URL from the daemon args.
- **`serve.ts`**: the "already up to date" no-op now also requires the requested args to match the running daemon's — otherwise `install --webrtc` over an `--http` daemon would silently no-op and print a link for a bridge that isn't running. Mismatched args roll forward (reconfigure). *(addresses a codex-review finding)*
- **`share.spec.ts`**: unit tests for the link derivation.

## Verification

- Derived link matches the live daemon's actual announced link exactly; all `--webrtc`/`--share`/`=`/bare arg forms parse correctly.
- Full suite green (469 passing, coverage gate ≥90%); codex review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)