### PR TITLE
feat(rs): non-TTY rendering + cross-platform terminal sizing + Windows live-resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "build": "tsdown",
     "check:e2e": "bun scripts/check-e2e.ts",
     "cf": "bun scripts/cf.ts",
-    "build:rs": "cargo install --path rs --features swarm",
+    "build:rs": "bun ./scripts/build-rs.ts",
     "postbuild": "bun ./ts/postbuild.ts",
     "demo": "bun run build && bun link && claude-yes -- demo",
     "dev": "bun ts/index.ts",

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -32,6 +32,10 @@ pub struct CliArgs {
     pub skip_permissions: bool,
     /// Working directory to run the agent in. None = use process current_dir.
     pub cwd: Option<String>,
+    /// Force raw TUI passthrough even when stdout is not a TTY.
+    pub force_tty: bool,
+    /// Force plain rendered text output even when stdout is a TTY.
+    pub no_tty: bool,
     /// Swarm mode: None = disabled, Some(value) = enabled with optional config
     /// Value can be: topic name, room code (XXX-XXX), ay:// URL, or multiaddr
     pub swarm: Option<String>,
@@ -109,6 +113,14 @@ struct Args {
     /// Working directory for the agent (default: current directory)
     #[arg(long)]
     cwd: Option<String>,
+
+    /// Force raw TUI passthrough even when stdout is not a TTY (piped/redirected)
+    #[arg(long = "force-tty", default_value = "false")]
+    force_tty: bool,
+
+    /// Force plain rendered text output even when stdout is a TTY
+    #[arg(long = "no-tty", default_value = "false")]
+    no_tty: bool,
 
     /// Enable swarm mode for multi-agent P2P networking
     ///
@@ -216,6 +228,8 @@ fn resolve_args(args: Args, exe_name: &str) -> Result<CliArgs> {
         use_skills: args.use_skills,
         skip_permissions: args.yes,
         cwd: args.cwd,
+        force_tty: args.force_tty,
+        no_tty: args.no_tty,
         swarm,
         experimental_swarm: args.experimental_swarm,
         swarm_listen: args.swarm_listen,
@@ -505,6 +519,8 @@ mod tests {
             use_skills: false,
             yes: false,
             cwd: None,
+            force_tty: false,
+            no_tty: false,
             swarm: None,
             experimental_swarm: false,
             swarm_listen: None,

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -5,7 +5,7 @@ use crate::config::CliConfig;
 use crate::idle_waiter::IdleWaiter;
 use crate::log_files::LogWriter;
 use crate::messaging::{send_ctrl_c, send_text, MessageContext};
-use crate::pty_spawner::{get_terminal_size, get_terminal_size_from_tty, PtyContext};
+use crate::pty_spawner::{get_terminal_size, PtyContext};
 use crate::ready_manager::ReadyManager;
 use crate::utils::sleep_ms;
 use crate::vterm::VTermProxy;
@@ -113,6 +113,11 @@ pub struct AgentContext {
     // dump_scrollback() reconstructs only the normal buffer, so when this is
     // set the raw log must NOT be replaced by the rendered log on exit.
     used_alt_screen: bool,
+
+    // When false, stdout is not a TTY (or --no-tty was passed): suppress raw
+    // PTY passthrough and emit plain rendered text on exit instead.
+    render_plain: bool,
+    non_tty_renderer: crate::non_tty_renderer::NonTtyRenderer,
 }
 
 impl AgentContext {
@@ -126,6 +131,7 @@ impl AgentContext {
         pid: u32,
         term_rows: u16,
         term_cols: u16,
+        render_plain: bool,
     ) -> Self {
         Self {
             cli,
@@ -156,6 +162,8 @@ impl AgentContext {
             cwd,
             stdin_line_buffer: String::new(),
             codex_session_found: false,
+            render_plain,
+            non_tty_renderer: crate::non_tty_renderer::NonTtyRenderer::new(),
             last_action_screen_hash: None,
             last_checked_screen_hash: None,
             used_alt_screen: false,
@@ -341,8 +349,8 @@ impl AgentContext {
         // first SIGWINCH fires.
         self.vterm.resize(initial_size.1, initial_size.0);
 
-        // Suppress unused-variable warning on non-unix where resize_tx is never moved
-        #[cfg(not(unix))]
+        // Suppress unused-variable warning on platforms with no resize source.
+        #[cfg(not(any(unix, windows)))]
         let _ = &resize_tx;
 
         // Spawn SIGWINCH listener — updates the watch whenever terminal is resized
@@ -369,9 +377,48 @@ impl AgentContext {
                     // back to the local TTY keeps the existing in-terminal
                     // workflow working.
                     let size = crate::pty_spawner::read_external_winsize(my_pid)
-                        .unwrap_or_else(get_terminal_size_from_tty);
+                        .unwrap_or_else(|| crate::pty_spawner::console_size().unwrap_or((80, 24)));
                     if resize_tx.send(size).is_err() {
                         break;
+                    }
+                }
+            })
+        };
+
+        // Windows has no SIGWINCH, so poll instead. Same source priority as the
+        // unix handler: an external winsize file (web console / `ay attach`,
+        // which can't deliver a signal here) first, then the live console size
+        // (a raw cmd-window resize). The resize_rx arm below applies whatever
+        // changes. `last` avoids re-sending an unchanged size every tick.
+        #[cfg(windows)]
+        let _resize_poll_handle = {
+            let my_pid = std::process::id();
+            let mut last = initial_size;
+            tokio::spawn(async move {
+                let mut tick = tokio::time::interval(Duration::from_millis(250));
+                loop {
+                    tick.tick().await;
+                    // The run loop dropped resize_rx (agent exiting) — stop
+                    // instead of polling forever. The send() below only fires
+                    // on a size change, so without this an idle task would
+                    // never notice closure, and robust restarts would pile up
+                    // orphaned pollers.
+                    if resize_tx.is_closed() {
+                        break;
+                    }
+                    // External winsize file (web console / `ay attach`) first,
+                    // then the live console. None = no reliable source this
+                    // tick (piped/MSYS) -> leave the size untouched.
+                    let Some(size) = crate::pty_spawner::read_external_winsize(my_pid)
+                        .or_else(crate::pty_spawner::console_size)
+                    else {
+                        continue;
+                    };
+                    if size != last {
+                        last = size;
+                        if resize_tx.send(size).is_err() {
+                            break;
+                        }
                     }
                 }
             })
@@ -525,6 +572,20 @@ impl AgentContext {
         drop(stdout_tx);
         let _ = tokio::time::timeout(Duration::from_millis(500), stdout_handle).await;
 
+        // Plain (non-TTY) mode: nothing was forwarded during the run, so emit
+        // the final rendered screen now as clean plain text. Writing here
+        // (after the raw stdout writer has drained) keeps it from interleaving
+        // with anything else.
+        if self.render_plain {
+            let rendered = self.non_tty_renderer.finalize(&self.vterm);
+            if !rendered.is_empty() {
+                use std::io::Write as _;
+                let mut out = std::io::stdout();
+                let _ = out.write_all(rendered.as_bytes());
+                let _ = out.flush();
+            }
+        }
+
         // Print final newline
         if self.is_user_abort {
             eprintln!("\r\nUser aborted: SIGINT\r");
@@ -540,23 +601,30 @@ impl AgentContext {
         msg_ctx: &mut MessageContext,
         stdout_tx: &mpsc::Sender<String>,
     ) -> Result<()> {
+        // Forward raw PTY bytes to stdout only in TTY passthrough mode. In
+        // plain (non-TTY) mode we suppress the raw stream and emit rendered
+        // text on exit instead — see `non_tty_renderer` and the final flush
+        // at the end of `run_with_fifo`.
+        //
         // Send to background stdout writer (never blocks main loop).
         // If the channel is full (~10MB buffered), drop the output —
         // agent operation is more important than display completeness.
-        match stdout_tx.try_send(output.to_string()) {
-            Ok(_) => {}
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                self.stdout_drop_count += 1;
-                // Warn on first drop, then every 100 drops to avoid log spam
-                if self.stdout_drop_count == 1 || self.stdout_drop_count % 100 == 0 {
-                    warn!(
-                        "stdout channel full, dropped output ({} total drops)",
-                        self.stdout_drop_count
-                    );
+        if !self.render_plain {
+            match stdout_tx.try_send(output.to_string()) {
+                Ok(_) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    self.stdout_drop_count += 1;
+                    // Warn on first drop, then every 100 drops to avoid log spam
+                    if self.stdout_drop_count == 1 || self.stdout_drop_count % 100 == 0 {
+                        warn!(
+                            "stdout channel full, dropped output ({} total drops)",
+                            self.stdout_drop_count
+                        );
+                    }
                 }
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                // Channel closed, receiver gone — nothing to do
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    // Channel closed, receiver gone — nothing to do
+                }
             }
         }
 
@@ -571,6 +639,13 @@ impl AgentContext {
         // Latch alt-screen usage so finalize_log knows whether the rendered
         // scrollback can safely stand in for the raw byte log.
         self.used_alt_screen |= self.vterm.alternate_screen();
+
+        // In plain (non-TTY) mode, let the renderer observe the screen so it
+        // can capture alt-screen contents before the agent restores the
+        // normal screen on exit.
+        if self.render_plain {
+            self.non_tty_renderer.observe(&self.vterm);
+        }
 
         // Write back any terminal query responses (DSR, DA) to child process.
         // Lock once and batch all responses to keep them atomic w.r.t. other writers.

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -9,6 +9,7 @@ mod installer;
 mod log_files;
 mod logger;
 mod messaging;
+mod non_tty_renderer;
 mod pid_store;
 mod pty_spawner;
 mod ready_manager;
@@ -191,6 +192,16 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
 
     let pid = std::process::id();
 
+    // Decide TTY vs plain rendering once. When stdout is piped/redirected (or
+    // --no-tty / NO_COLOR / CI), emit plain rendered text instead of the raw
+    // TUI byte stream. See docs/non-tty-output.md.
+    let stdout_is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    let render_plain =
+        crate::non_tty_renderer::should_render_plain(args.force_tty, args.no_tty, stdout_is_tty);
+    if render_plain {
+        info!("stdout is not a TTY (or --no-tty): emitting plain rendered text on exit");
+    }
+
     // Clean up stale PID records on startup
     let pid_store = PidStore::new();
     pid_store.prune_old_logs();
@@ -233,6 +244,7 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
             pid,
             term_rows,
             term_cols,
+            render_plain,
         );
 
         // Create per-pid FIFO for `cy send <keyword> <msg>`. Best-effort —

--- a/rs/src/non_tty_renderer.rs
+++ b/rs/src/non_tty_renderer.rs
@@ -1,0 +1,300 @@
+//! Non-TTY output rendering.
+//!
+//! When `cy`'s stdout is not a TTY (piped, redirected to a file, or a
+//! non-PTY SSH channel), forwarding the inner agent's raw PTY byte stream
+//! produces unreadable output: cursor moves, screen clears, alt-screen
+//! switches, and spinner redraws layer on top of one another and the escape
+//! sequences appear as literal text.
+//!
+//! In that case we suppress the raw passthrough and instead emit **plain
+//! rendered text** — the semantic content the user would have seen on a TTY.
+//! See `docs/non-tty-output.md` for the full design.
+//!
+//! v1 is exit-only: we don't stream mid-session. The renderer observes the
+//! vterm after every chunk so it can capture the alt-screen contents before
+//! they vanish (alt-screen TUIs restore the normal screen on exit, which
+//! would otherwise leave us with a blank screen at flush time), then emits
+//! the final rendered screen once on process exit.
+
+use crate::vterm::VTermProxy;
+
+/// Decide whether stdout should receive plain rendered text instead of raw
+/// PTY passthrough.
+///
+/// Priority (highest first):
+///   1. `--force-tty` / `CY_FORCE_TTY=1`  → raw passthrough (returns false)
+///   2. `--no-tty`                         → plain text (returns true)
+///   3. `NO_COLOR` / `CI=true`             → plain text (returns true)
+///   4. autodetect: stdout is not a TTY    → plain text (returns true)
+pub fn should_render_plain(force_tty: bool, no_tty: bool, stdout_is_tty: bool) -> bool {
+    if force_tty {
+        return false;
+    }
+    if no_tty {
+        return true;
+    }
+    let env_truthy = |k: &str| {
+        std::env::var(k)
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    };
+    if env_truthy("CY_FORCE_TTY") {
+        return false;
+    }
+    if std::env::var_os("NO_COLOR").is_some() || env_truthy("CI") {
+        return true;
+    }
+    !stdout_is_tty
+}
+
+/// Tracks alt-screen state across chunks and produces the final plain-text
+/// transcript on exit.
+#[derive(Default)]
+pub struct NonTtyRenderer {
+    in_alt: bool,
+    /// Last alt-screen contents seen while alt screen was active. Preserved
+    /// after the agent leaves the alt screen (which clears the live screen),
+    /// so a clean exit still surfaces the conversation.
+    captured_alt: Option<String>,
+}
+
+impl NonTtyRenderer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Call after every `vterm.process(chunk)`. Snapshots the alt-screen
+    /// contents while it is active so they survive the eventual restore.
+    pub fn observe(&mut self, vterm: &VTermProxy) {
+        let now_alt = vterm.alternate_screen();
+        if now_alt {
+            self.captured_alt = Some(vterm.contents());
+        }
+        self.in_alt = now_alt;
+    }
+
+    /// Produce the final plain-text transcript to write to stdout on exit.
+    ///
+    /// Prefers the current live screen when it has content (covers both
+    /// normal-screen agents like Codex and alt-screen agents that exit while
+    /// still on the alt screen). Falls back to the last captured alt-screen
+    /// contents when the agent restored an empty normal screen before exiting.
+    pub fn finalize(&self, vterm: &VTermProxy) -> String {
+        let current = vterm.contents();
+        if !current.trim().is_empty() {
+            return trim_screen(&current);
+        }
+        match &self.captured_alt {
+            Some(alt) => trim_screen(alt),
+            None => trim_screen(&current),
+        }
+    }
+}
+
+/// Trim a rendered screen to readable plain text: right-trim every line,
+/// drop leading and trailing blank lines, and drop a trailing input-prompt
+/// row when one is obvious. Internal blank lines are preserved.
+pub fn trim_screen(screen: &str) -> String {
+    let mut lines: Vec<&str> = screen.lines().map(|l| l.trim_end()).collect();
+
+    // Drop trailing prompt/blank rows. Conservative: only strip rows that are
+    // blank or an unambiguous input-prompt marker, never real content.
+    while let Some(last) = lines.last() {
+        if last.is_empty() || is_prompt_line(last) {
+            lines.pop();
+        } else {
+            break;
+        }
+    }
+    // Drop leading blank rows (alt screens often start with the cursor parked
+    // at the top, leaving empty rows above the first real line).
+    while let Some(first) = lines.first() {
+        if first.is_empty() {
+            lines.remove(0);
+        } else {
+            break;
+        }
+    }
+
+    let mut out = lines.join("\n");
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
+/// Heuristic: is this row input-box chrome rather than real content?
+/// Covers the agent's prompt row, the hint line, and the horizontal divider
+/// rows that frame the input box.
+fn is_prompt_line(line: &str) -> bool {
+    let t = line.trim();
+    if t.is_empty() {
+        return true;
+    }
+    // A lone prompt glyph, optionally with a placeholder hint.
+    if matches!(t, ">" | "❯" | "│ >" | "> │")
+        || t == "? for shortcuts"
+        || t.starts_with("? for shortcuts")
+    {
+        return true;
+    }
+    // A horizontal divider row framing the input box: made up only of
+    // box-drawing dashes (with optional trailing prompt glyph / borders /
+    // spaces), and containing at least one dash. Real conversation lines are
+    // never all-dashes, and mid-transcript dividers are left alone because
+    // trim only pops from the bottom.
+    let mut saw_dash = false;
+    let only_chrome = t.chars().all(|c| match c {
+        '─' | '━' | '┄' | '┅' | '┈' | '┉' | '╌' | '╍' => {
+            saw_dash = true;
+            true
+        }
+        ' ' | '>' | '❯' | '│' => true,
+        _ => false,
+    });
+    only_chrome && saw_dash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vt(seq: &[u8]) -> VTermProxy {
+        let mut v = VTermProxy::new(24, 80);
+        v.process(seq);
+        v
+    }
+
+    #[test]
+    fn test_should_render_plain_force_tty_wins() {
+        // force_tty beats no_tty and a non-tty stdout
+        assert!(!should_render_plain(true, true, false));
+    }
+
+    #[test]
+    fn test_should_render_plain_no_tty_flag() {
+        assert!(should_render_plain(false, true, true));
+    }
+
+    #[test]
+    fn test_should_render_plain_autodetect() {
+        // No flags/env: follow stdout tty-ness.
+        // (CI is set in many test environments; only assert the not-a-tty case
+        // when CI/NO_COLOR aren't forcing plain anyway — both force plain too.)
+        assert!(should_render_plain(false, false, false));
+    }
+
+    #[test]
+    fn test_trim_screen_strips_trailing_blanks() {
+        let input = "hello\nworld\n\n\n";
+        assert_eq!(trim_screen(input), "hello\nworld\n");
+    }
+
+    #[test]
+    fn test_trim_screen_strips_leading_blanks() {
+        let input = "\n\nhello\nworld";
+        assert_eq!(trim_screen(input), "hello\nworld\n");
+    }
+
+    #[test]
+    fn test_trim_screen_preserves_internal_blanks() {
+        let input = "a\n\nb";
+        assert_eq!(trim_screen(input), "a\n\nb\n");
+    }
+
+    #[test]
+    fn test_trim_screen_drops_trailing_prompt() {
+        let input = "● Done.\n\n>\n";
+        assert_eq!(trim_screen(input), "● Done.\n");
+    }
+
+    #[test]
+    fn test_trim_screen_empty() {
+        assert_eq!(trim_screen("   \n\n"), "");
+    }
+
+    #[test]
+    fn test_trim_screen_drops_trailing_divider_rows() {
+        // Claude's input box: two horizontal divider rows (one ends in the
+        // prompt glyph) framing the prompt. Both are chrome, not content.
+        let bar = "─".repeat(40);
+        let input = format!("● Done.\n\n{bar}\n{bar} ❯\n");
+        assert_eq!(trim_screen(&input), "● Done.\n");
+    }
+
+    #[test]
+    fn test_trim_screen_preserves_internal_divider() {
+        // A divider in the middle of the transcript is real content (trim only
+        // pops from the bottom, stopping at the first non-chrome row).
+        let bar = "─".repeat(20);
+        let input = format!("intro\n{bar}\nbody text");
+        assert_eq!(trim_screen(&input), format!("intro\n{bar}\nbody text\n"));
+    }
+
+    #[test]
+    fn test_is_prompt_line_divider_vs_content() {
+        assert!(is_prompt_line(&"─".repeat(80)));
+        assert!(is_prompt_line(&format!("{} ❯", "─".repeat(60))));
+        // Real content with a dash in it must not be mistaken for a divider.
+        assert!(!is_prompt_line("see rs/src/cli.rs — non_tty work"));
+        assert!(!is_prompt_line("● Hello"));
+    }
+
+    #[test]
+    fn test_finalize_normal_screen() {
+        // Codex-style: plain content on the normal screen, no alt screen.
+        let mut r = NonTtyRenderer::new();
+        let v = vt(b"Hello from codex\r\nsecond line\r\n");
+        r.observe(&v);
+        assert!(!v.alternate_screen());
+        let out = r.finalize(&v);
+        assert!(out.contains("Hello from codex"));
+        assert!(out.contains("second line"));
+        assert!(!out.contains("\x1b"));
+    }
+
+    #[test]
+    fn test_finalize_exits_in_alt_screen() {
+        // Claude-style: enter alt screen, draw conversation, exit while still
+        // on the alt screen → finalize emits the live (alt) screen.
+        let mut r = NonTtyRenderer::new();
+        let v = vt(b"\x1b[?1049h\x1b[2J\x1b[HHELLO FROM ALT\r\nresponse body\r\n");
+        assert!(v.alternate_screen());
+        r.observe(&v);
+        let out = r.finalize(&v);
+        assert!(out.contains("HELLO FROM ALT"), "got: {:?}", out);
+        assert!(out.contains("response body"), "got: {:?}", out);
+    }
+
+    #[test]
+    fn test_finalize_captures_alt_before_restore() {
+        // Draw on alt screen, observe, then leave the alt screen (which
+        // restores an empty normal screen). finalize must fall back to the
+        // captured alt contents rather than emitting a blank screen.
+        let mut r = NonTtyRenderer::new();
+
+        let mut v = VTermProxy::new(24, 80);
+        v.process(b"\x1b[?1049h\x1b[2J\x1b[HAGENT FINAL ANSWER\r\n");
+        r.observe(&v); // capture while in alt screen
+        assert!(v.alternate_screen());
+
+        // Leave alt screen — vt100 restores the (blank) normal screen.
+        v.process(b"\x1b[?1049l");
+        r.observe(&v);
+        assert!(!v.alternate_screen());
+
+        let out = r.finalize(&v);
+        assert!(out.contains("AGENT FINAL ANSWER"), "got: {:?}", out);
+    }
+
+    #[test]
+    fn test_finalize_no_ansi_in_output() {
+        let mut r = NonTtyRenderer::new();
+        let v = vt(b"\x1b[31mred text\x1b[0m\r\n\x1b[1mbold\x1b[0m\r\n");
+        r.observe(&v);
+        let out = r.finalize(&v);
+        assert!(out.contains("red text"));
+        assert!(out.contains("bold"));
+        assert!(!out.contains('\x1b'), "ANSI leaked: {:?}", out);
+    }
+}

--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -24,13 +24,28 @@ fn ioctl_terminal_size() -> Option<(u16, u16)> {
     }
 }
 
-/// Terminal size from ioctl only — use in SIGWINCH handler where COLUMNS/LINES are stale.
-pub fn get_terminal_size_from_tty() -> (u16, u16) {
+/// Live console size if stdout is a real console/tty, else None. No env var,
+/// no default — callers choose the fallback. Crucial for the resize watchers:
+/// "no console" (piped / MSYS pty) must mean "don't change the size", not
+/// "assume 80x24" (which would clobber an env- or attach-derived size).
+pub fn console_size() -> Option<(u16, u16)> {
     #[cfg(unix)]
-    if let Some(size) = ioctl_terminal_size() {
-        return size;
+    {
+        ioctl_terminal_size()
     }
-    (80, 24)
+    // Windows has no ioctl; read the console screen buffer. Err when stdout
+    // isn't a console (piped/redirected/MSYS pty) -> None.
+    #[cfg(windows)]
+    {
+        match crossterm::terminal::size() {
+            Ok((cols, rows)) if cols > 0 && rows > 0 => Some((cols.max(20), rows)),
+            _ => None,
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        None
+    }
 }
 
 /// Max age of an externally-supplied winsize before we ignore it. After this,
@@ -91,18 +106,17 @@ pub fn parse_winsize_line(line: &str) -> Option<(u16, u16)> {
 }
 
 /// Terminal size for initial PTY spawn: COLUMNS/LINES env vars first (useful in
-/// non-TTY/pipe/CI contexts), then ioctl, then (80, 24).
+/// non-TTY/pipe/CI contexts), then the OS console size (ioctl on Unix, the
+/// console screen buffer on Windows), then (80, 24).
 pub fn get_terminal_size() -> (u16, u16) {
     if let (Ok(cols), Ok(rows)) = (std::env::var("COLUMNS"), std::env::var("LINES")) {
         if let (Ok(cols), Ok(rows)) = (cols.parse::<u16>(), rows.parse::<u16>()) {
             return (cols.max(20), rows);
         }
     }
-    #[cfg(unix)]
-    if let Some(size) = ioctl_terminal_size() {
-        return size;
-    }
-    (80, 24)
+    // OS console size (ioctl on Unix, screen buffer on Windows). None when
+    // stdout isn't a console (piped/redirected) -> fall through to 80x24.
+    console_size().unwrap_or((80, 24))
 }
 
 /// PTY process context

--- a/rs/src/vterm.rs
+++ b/rs/src/vterm.rs
@@ -142,9 +142,12 @@ impl VTermProxy {
         self.parser.screen().cursor_position()
     }
 
-    /// True if the terminal is currently showing the alternate screen buffer.
-    /// Used to detect alt-screen TUIs, whose content is NOT retained in the
-    /// normal-buffer scrollback that `dump_scrollback` reconstructs.
+    /// True if the terminal is currently showing the alternate screen buffer
+    /// (DECSET 1049 / 47 / 1047). Alt-screen TUIs (e.g. Claude) keep their
+    /// entire UI here, so nothing scrolls into the normal-buffer scrollback
+    /// that `dump_scrollback` reconstructs — both the exit-time raw-log guard
+    /// and the non-TTY renderer rely on this to know when to capture the live
+    /// screen.
     pub fn alternate_screen(&self) -> bool {
         self.parser.screen().alternate_screen()
     }
@@ -188,6 +191,11 @@ impl VTermProxy {
             lines.pop();
         }
         lines.join("\n")
+    }
+
+    /// Screen dimensions as (rows, cols).
+    pub fn size(&self) -> (u16, u16) {
+        self.parser.screen().size()
     }
 
     /// Resize the virtual terminal. Dimensions are clamped to at least 1×1

--- a/rs/tests/integration_tests.rs
+++ b/rs/tests/integration_tests.rs
@@ -1,9 +1,16 @@
 //! Integration tests for agent-yes Rust implementation
 
 use assert_cmd::cargo::cargo_bin_cmd;
+// The Unix-only imports below back the bash-mock / chmod / SIGWINCH tests. On
+// Windows those tests are #[cfg(unix)]-gated out, so gate the imports too —
+// otherwise they're unused and the `-D warnings` pre-commit gate fails.
+#[cfg(unix)]
 use std::fs::{self, File};
+#[cfg(unix)]
 use std::io::Write;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
 use tempfile::tempdir;
 
 /// Full SIGWINCH chain test using a shell helper script.
@@ -375,6 +382,7 @@ fn test_unknown_cli() {
 }
 
 /// Create a mock CLI that prints its working directory
+#[cfg(unix)]
 fn create_cwd_printing_cli(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
     let script_path = dir.join(name);
     let mut file = File::create(&script_path).unwrap();
@@ -399,6 +407,7 @@ exit 0
     script_path
 }
 
+#[cfg(unix)] // relies on a bash mock CLI (chmod +x, `:` PATH separator)
 #[test]
 fn test_cwd_is_preserved() {
     // Create a temp directory with a unique subdirectory
@@ -449,6 +458,7 @@ fn test_cwd_is_preserved() {
     );
 }
 
+#[cfg(unix)] // relies on a bash mock CLI (chmod +x, `:` PATH separator)
 #[test]
 fn test_cwd_flag_overrides_current_dir() {
     // Verify that --cwd <path> makes the agent run in <path>, even when
@@ -507,6 +517,7 @@ fn test_cwd_flag_overrides_current_dir() {
     );
 }
 
+#[cfg(unix)] // relies on a bash mock CLI (chmod +x, `:` PATH separator)
 #[test]
 fn test_cwd_flag_rejects_missing_directory() {
     // --cwd pointing at a nonexistent path should make agent-yes fail fast.

--- a/scripts/build-rs.ts
+++ b/scripts/build-rs.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env bun
+// Build + install the Rust binary.
+//
+// On Windows a running `agent-yes.exe` holds its own image file locked, so
+// `cargo install` fails with "Access is denied" when it tries to remove/
+// overwrite the old binary. Windows DOES permit *renaming* a running .exe
+// (the live process keeps using the renamed image), so we move any locked
+// binary aside as `agent-yes.old-<ts>.exe` before building and let cargo write
+// a fresh one. This makes rebuilds lock-free without killing live sessions.
+//
+// On macOS/Linux a running binary can be replaced directly, so this is a no-op
+// there and we just run cargo.
+import { spawnSync } from "child_process";
+import { existsSync, readdirSync, renameSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const cargoHome = process.env.CARGO_HOME || path.join(os.homedir(), ".cargo");
+
+// Both binaries cargo touches: the build output and the installed copy.
+const targets = [
+  path.join(repoRoot, "rs", "target", "release", "agent-yes.exe"),
+  path.join(cargoHome, "bin", "agent-yes.exe"),
+];
+
+function moveLockedBinariesAside(): Array<{ original: string; aside: string }> {
+  const moved: Array<{ original: string; aside: string }> = [];
+  for (const exe of targets) {
+    const dir = path.dirname(exe);
+    if (!existsSync(dir)) continue;
+    const base = path.basename(exe, ".exe");
+
+    // Sweep stale .old- files from earlier rebuilds. Any still locked by a
+    // live process will fail to delete — that's fine, skip and move on.
+    for (const f of readdirSync(dir)) {
+      if (f.startsWith(`${base}.old-`) && f.endsWith(".exe")) {
+        try {
+          rmSync(path.join(dir, f));
+        } catch {
+          /* still running — leave it */
+        }
+      }
+    }
+
+    // Move the current (possibly locked) binary aside so cargo can write fresh.
+    if (existsSync(exe)) {
+      const aside = path.join(dir, `${base}.old-${Date.now()}.exe`);
+      try {
+        renameSync(exe, aside);
+        moved.push({ original: exe, aside });
+        console.log(`[build-rs] moved locked binary aside: ${path.basename(aside)}`);
+      } catch {
+        // Not locked (or rename unsupported) — try a plain delete instead.
+        try {
+          rmSync(exe);
+        } catch (e) {
+          console.warn(`[build-rs] WARNING: could not free ${exe}: ${e}`);
+        }
+      }
+    }
+  }
+  return moved;
+}
+
+const moved = process.platform === "win32" ? moveLockedBinariesAside() : [];
+
+const args = ["install", "--path", "rs", "--features", "swarm", ...process.argv.slice(2)];
+console.log(`[build-rs] cargo ${args.join(" ")}`);
+const result = spawnSync("cargo", args, { cwd: repoRoot, stdio: "inherit" });
+
+// On failure cargo never wrote the fresh originals, so restore anything we
+// moved aside — otherwise a build error would leave agent-yes.exe missing
+// from PATH until the next successful build.
+if (result.status !== 0) {
+  for (const { original, aside } of moved) {
+    if (!existsSync(original) && existsSync(aside)) {
+      try {
+        renameSync(aside, original);
+        console.warn(`[build-rs] build failed — restored ${path.basename(original)}`);
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## What

Brings the agent's terminal handling to parity on **Windows** (the `rs/` engine), plus a lock-free Windows rebuild path. All new code — `origin/main` had no Windows resize watcher and no `console_size`, and `non_tty_renderer.rs` is a new file (rebased cleanly onto `1.128.0`, zero conflicts).

- **non-TTY plain rendering** (`non_tty_renderer.rs`): when stdout isn't a TTY (pipe/redirect/CI, `--no-tty`/`--force-tty`, `NO_COLOR`), emit a clean final-screen snapshot instead of the raw cursor-addressed byte stream. Trims trailing input-box divider rows.
- **Cross-platform terminal sizing** (`pty_spawner.rs`): `console_size()` reads the real console (ioctl on Unix, `crossterm` screen buffer on Windows). Previously Windows always fell back to 80×24 when `COLUMNS`/`LINES` were unset.
- **Windows live-resize watcher** (`context.rs`): Windows has no `SIGWINCH`, so a 250 ms poll of the `winsize` file + console size feeds the existing resize channel. Covers cmd-window resize, web-console `/api/resize`, and `ay attach`. Breaks when the channel closes so `--robust` restarts don't accumulate orphaned pollers.
- **vterm**: expose `size()`; document alt-screen detection.
- **tests**: gate the Unix-only integration tests (bash mock / chmod / SIGWINCH) behind `cfg(unix)` so the suite compiles on Windows and the cross-platform tests actually run there.
- **build** (`scripts/build-rs.ts`): lock-free Windows rebuilds — Windows can't overwrite a running `.exe` but *can* rename it, so move any locked binary aside before `cargo install`; restore it on a failed build. No-op on macOS/Linux.

## Verification

- `cargo fmt --check` + `cargo check --workspace --all-targets -D warnings` green on Windows.
- Pre-commit gate (build + full `vitest --coverage` + cargo checks) green.
- Live: drove a real resize through the winsize path — agent reflowed `215→200→73`; and via the local `ay serve` console an agent reflowed `200→138×60` on attach and rendered cleanly.

## Notes

- Reviewed independently by Codex; its findings (watcher self-termination on channel close, build restore-on-failure) are folded in.
- The **web-console startup-race + heartbeat fix** is intentionally **not** in this PR — `lab/ui/index.html` was heavily rewritten upstream (incl. #59 "re-assert size on tab re-activation"), so that fix will be reconciled against the new console in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)