### PR TITLE
fix(console): start the raw tail only after the initial size sync

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2958,38 +2958,46 @@
         // and re-assert our size to the agent so the stream always reflows to OUR
         // viewport (see the visibilitychange hook in startPolling). Push-if-different
         // inside fitAndSync keeps an already-matching agent from a redundant SIGWINCH.
+        // Returns the in-flight sync promise so the initial open can await it
+        // before starting the tail (below); tab-reactivation callers ignore it.
         resyncTerm = () => {
           if (sel !== selKey || !term) return;
-          tx.fetchJSON("/api/size/" + encodeURIComponent(pid))
+          return tx
+            .fetchJSON("/api/size/" + encodeURIComponent(pid))
             .then(fitAndSync)
             .catch(() => fitAndSync(null));
         };
-        resyncTerm();
 
-        // True live tail via ay serve's SSE stream. First event is an xterm-rendered
-        // tail snapshot; later events are incremental deltas. We normalise terminal
-        // carriage returns so the stream reads cleanly as HTML, autoscroll while the
-        // viewer is pinned to the bottom, and cap the buffer so it can't grow forever.
-        $("livedot").className = "dot idle";
-        $("livetxt").textContent = "connecting…";
-        const close = tx.subscribe(
-          "/api/tail/" + encodeURIComponent(pid) + "?raw=1",
-          (raw) => {
-            if (term) {
-              term.write(raw);
-              perfNote("out", raw?.length ?? 0);
-            }
-          },
-          () => {
-            $("livedot").className = "dot active";
-            $("livetxt").textContent = "live";
-          },
-          () => {
-            $("livedot").className = "dot stopped";
-            $("livetxt").textContent = "disconnected";
-          },
-        );
-        es = { close };
+        // Start the raw replay only AFTER the initial size sync (fit + resize
+        // push) settles. /api/tail?raw=1 is absolute-cursor-positioned for the
+        // agent's grid; writing it into xterm before fit.fit()/resize would land
+        // the initial snapshot on a wrong-size grid that no later resize can
+        // repair (garbled, overlapping, dim-bleed output). First event is an
+        // xterm-rendered tail snapshot; later events are incremental deltas.
+        const startTail = () => {
+          if (sel !== selKey || !term) return; // switched away during size sync
+          $("livedot").className = "dot idle";
+          $("livetxt").textContent = "connecting…";
+          const close = tx.subscribe(
+            "/api/tail/" + encodeURIComponent(pid) + "?raw=1",
+            (raw) => {
+              if (term) {
+                term.write(raw);
+                perfNote("out", raw?.length ?? 0);
+              }
+            },
+            () => {
+              $("livedot").className = "dot active";
+              $("livetxt").textContent = "live";
+            },
+            () => {
+              $("livedot").className = "dot stopped";
+              $("livetxt").textContent = "disconnected";
+            },
+          );
+          es = { close };
+        };
+        Promise.resolve(resyncTerm()).finally(startTail);
       }
 
       $("list").addEventListener("click", (ev) => {


### PR DESCRIPTION
## Problem

The `/w/` console replays an agent's **raw PTY byte stream** into xterm.js. That stream is **absolute-cursor-positioned** (`ESC[row;colH`) for the agent's PTY grid. On opening an agent the console did:

```js
resyncTerm();              // async: /api/size -> fit.fit() + /api/resize push
... subscribe("/api/tail/<pid>?raw=1", raw => term.write(raw))  // synchronous
```

The subscribe fired **before** the async size-sync settled, so the initial tail snapshot could be written into xterm at the wrong grid size — and absolute-positioned output can't be repaired by a later resize. Result: **garbled, overlapping, dim-bleed** rendering (worst when the agent's PTY is much wider than the viewport — e.g. a 389-col agent into a ~108-col pane).

#59 (`re-assert size on tab re-activation`) reused `resyncTerm` for the visibility hook but **didn't serialize the initial open**, so the race remained.

## Fix

Serialize startup: `resyncTerm()` now **returns its promise**, and the tail subscription starts in `.finally()` — i.e. only after `fit.fit()` + the `/api/resize` push settle. Guarded against a fast agent-switch (`sel !== selKey`). Tab-reactivation callers ignore the return value, so #59 is unaffected.

**No heartbeat** added: a periodic `/api/resize` would `SIGWINCH`-churn the agent every tick (`TIOCSWINSZ` signals unconditionally even for an unchanged size), and #59's `resyncTerm` already re-asserts size on tab re-activation.

## Verification

- Inline JS parses clean (no `SyntaxError`); pre-commit gate green.
- Verified the mechanism end-to-end on a local `ay serve` with the updated UI: selecting an agent pushed a resize on attach (agent reflowed `200→138×60`) and the terminal rendered **cleanly** (vs. the garbled wide-agent capture before the fix).

## Notes

- Depends on the resize path working; on Windows that's #61 (the live-resize watcher). On Linux/macOS the existing `SIGWINCH` path already applies the push.
- Rebased cleanly on top of the upstream `index.html` rewrite (mobile/PWA/#59 etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)