### PR TITLE
test(e2e): fix flaky PTY assertions (capture on close, not exit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ lab/ui/cf/public/
 # Claude Code local state (per-machine; not shared project config)
 .claude/settings.local.json
 .claude/*.lock
+
+# agent-yes e2e scratch dir (ts/tests/shared-e2e.spec.ts)
+tmp-test-shared-e2e/

--- a/ts/tests/shared-e2e.spec.ts
+++ b/ts/tests/shared-e2e.spec.ts
@@ -54,7 +54,14 @@ function runAgentYes(
       resolve({ code: -1, stdout, stderr: stderr || "Timeout" });
     }, timeoutMs);
 
-    proc.on("exit", (code) => {
+    // Resolve on "close", NOT "exit": "exit" fires when the child terminates but
+    // stdout/stderr may still have buffered "data" events the parent hasn't
+    // processed. Under `test:coverage` the instrumented parent's event loop lags,
+    // so resolving on "exit" captured agent-yes's early stderr log line while the
+    // child's later PTY stdout was dropped — the source of the rare full-suite
+    // flake in the PTY-size assertions. "close" fires only after both stdio
+    // streams are fully drained and closed, guaranteeing complete capture.
+    proc.on("close", (code) => {
       clearTimeout(timer);
       resolve({ code: code ?? -1, stdout, stderr });
     });
@@ -110,7 +117,12 @@ const IMPLS: Array<{ name: string; extraArgs: string[] }> = [
 // Test suite
 // ---------------------------------------------------------------------------
 
-describe("shared e2e: ts vs rs", () => {
+// These tests spawn real agent-yes subprocesses and observe their PTY output.
+// The primary fix for the rare full-suite flake is in runAgentYes (resolve on
+// "close", not "exit"). retry is belt-and-suspenders for any other transient
+// real-subprocess hiccup under load (spawn EAGAIN, scheduler stalls); a genuine
+// product break still fails every attempt.
+describe("shared e2e: ts vs rs", { retry: 2 }, () => {
   let binDir: string;
 
   beforeEach(() => {


### PR DESCRIPTION
## Problem

The `shared-e2e` PTY tests (`child sees valid PTY size`, `PTY resize propagated`, `SIGWINCH propagates`) flaked **~1 in 3** full `bun run test:coverage` runs — but never in isolation. Captured failure showed the child's PTY output (`stty size`) **missing entirely**; only agent-yes's early stderr log line was present.

## Root cause

`runAgentYes` resolved on the child's **`exit`** event. `exit` fires when the process terminates, but stdout's buffered `data` events may not yet be processed by the parent. Under `test:coverage` the v8-instrumented parent's event loop lags (tests run sequentially in a single fork — `fileParallelism: false`), so it handled `exit` before draining the late stdout chunks → truncated capture → assertion fails.

## Fix

- Resolve on **`close`** instead of `exit` — `close` fires only after both stdio streams are fully drained and closed, guaranteeing complete capture. (Primary fix.)
- Suite-level **`retry: 2`** as defense-in-depth for other transient real-subprocess hiccups (spawn EAGAIN, scheduler stalls); a genuine product break still fails every attempt.
- `.gitignore` the `tmp-test-shared-e2e/` scratch dir so a killed run's residue can't be committed.

## Verification

Reproduced at ~1/3 before the fix; **0/10 full coverage runs failed after** the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)