### PR TITLE
fix(codex): map -y to codex's bypass flag so it runs in sandboxed envs

### DIFF
--- a/agent-yes.config.schema.json
+++ b/agent-yes.config.schema.json
@@ -99,6 +99,11 @@
           "items": { "type": "string" },
           "description": "Default arguments to always pass to the CLI"
         },
+        "yesArgs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Arguments appended when -y/--yes is passed: the per-CLI 'yolo' flag (claude: --dangerously-skip-permissions; codex: --dangerously-bypass-approvals-and-sandbox)"
+        },
         "ready": {
           "type": "array",
           "items": { "$ref": "#/definitions/RegexSource" },

--- a/default.config.yaml
+++ b/default.config.yaml
@@ -2,6 +2,9 @@ clis:
   claude:
     promptArg: last-arg
     systemPrompt: --append-system-prompt
+    # yesArgs: appended when `-y` / --yes is passed. The per-CLI "yolo" flag.
+    yesArgs:
+      - --dangerously-skip-permissions
     install:
       powershell: 'powershell -Command "irm https://claude.ai/install.ps1 | iex"'
       bash: "curl -fsSL https://claude.ai/install.sh | bash"
@@ -96,6 +99,18 @@ clis:
 
   codex:
     promptArg: first-arg
+    # yesArgs: `-y` / --yes maps to codex's own "yolo" flag. Codex rejects
+    # claude's --dangerously-skip-permissions outright, and its bwrap sandbox
+    # cannot initialize inside an already-sandboxed/containerized environment
+    # ("bwrap: Failed to make / slave: Permission denied"), blocking command
+    # exec AND apply_patch before they run. --dangerously-bypass-approvals-and
+    # -sandbox skips both the approval prompts and the sandbox wrapper, which is
+    # exactly codex's documented mode for "environments that are externally
+    # sandboxed" (the agent-yes-in-a-container case). Invoke as `ay -y codex
+    # "<task>"` — agent-yes's own `-y` must precede the cli name (everything
+    # after it is forwarded verbatim to codex via trailing_var_arg).
+    yesArgs:
+      - --dangerously-bypass-approvals-and-sandbox
     install:
       npm: "npm install -g @openai/codex@latest"
     updateAvailable:

--- a/rs/src/config.rs
+++ b/rs/src/config.rs
@@ -61,6 +61,12 @@ pub struct CliConfig {
     pub exit_command: Vec<String>,
     /// Default args
     pub default_args: Vec<String>,
+    /// Args appended when `-y` / `--yes` is passed — the per-CLI "yolo" flag.
+    /// claude maps `-y` to `--dangerously-skip-permissions`; codex maps it to
+    /// `--dangerously-bypass-approvals-and-sandbox` (codex rejects the claude
+    /// flag, and its bwrap sandbox can't init inside an already-sandboxed/
+    /// containerized environment).
+    pub yes_args: Vec<String>,
     /// Use cursor-based rendering (no newlines)
     pub no_eol: bool,
 }
@@ -148,6 +154,7 @@ fn build_cli_config(raw: CliConfigOverride) -> Result<CliConfig> {
         restore_args: raw.restore_args.unwrap_or_default(),
         exit_command: raw.exit_commands.unwrap_or_default(),
         default_args: raw.default_args.unwrap_or_default(),
+        yes_args: raw.yes_args.unwrap_or_default(),
         no_eol: raw.no_eol.unwrap_or(false),
     })
 }
@@ -245,6 +252,8 @@ mod tests {
         assert_eq!(config.prompt_arg, "last-arg");
         assert!(!config.ready.is_empty());
         assert!(!config.enter.is_empty());
+        // `-y` maps to claude's own permission-skip flag.
+        assert_eq!(config.yes_args, vec!["--dangerously-skip-permissions"]);
     }
 
     #[test]
@@ -364,6 +373,13 @@ mod tests {
         assert!(config.restart_without_continue.is_empty());
         assert!(config.exit_command.is_empty());
         assert_eq!(config.default_args, vec!["--search"]);
+        // `-y` maps to codex's bypass flag — NOT claude's --dangerously-skip-
+        // permissions (codex rejects it) — and it also skips codex's bwrap
+        // sandbox, which can't init inside an already-sandboxed container.
+        assert_eq!(
+            config.yes_args,
+            vec!["--dangerously-bypass-approvals-and-sandbox"]
+        );
         assert!(config.no_eol);
     }
 

--- a/rs/src/config_loader.rs
+++ b/rs/src/config_loader.rs
@@ -40,6 +40,11 @@ pub struct CliConfigOverride {
     /// Default args
     #[serde(default)]
     pub default_args: Option<Vec<String>>,
+    /// Args appended when `-y` / `--yes` is passed — the per-CLI "yolo" flag
+    /// (claude: `--dangerously-skip-permissions`; codex:
+    /// `--dangerously-bypass-approvals-and-sandbox`).
+    #[serde(default)]
+    pub yes_args: Option<Vec<String>>,
     /// Help URL or hint
     #[serde(default)]
     pub help: Option<String>,
@@ -171,6 +176,7 @@ impl CliConfigOverride {
             version,
             binary,
             default_args,
+            yes_args,
             help,
             bunx,
             system_prompt,
@@ -205,6 +211,9 @@ impl CliConfigOverride {
         }
         if default_args.is_some() {
             self.default_args = default_args;
+        }
+        if yes_args.is_some() {
+            self.yes_args = yes_args;
         }
         if help.is_some() {
             self.help = help;
@@ -616,6 +625,7 @@ logsDir: /custom/logs
                 version: Some("old-version".into()),
                 binary: Some("old-bin".into()),
                 default_args: Some(vec!["old-arg".into()]),
+                yes_args: Some(vec!["--old-yes".into()]),
                 help: Some("old-help".into()),
                 bunx: Some(false),
                 system_prompt: Some("--old-system".into()),
@@ -652,6 +662,7 @@ logsDir: /custom/logs
                 version: Some("new-version".into()),
                 binary: Some("new-bin".into()),
                 default_args: Some(vec!["new-arg".into()]),
+                yes_args: Some(vec!["--new-yes".into()]),
                 help: Some("new-help".into()),
                 bunx: Some(true),
                 system_prompt: Some("--new-system".into()),
@@ -692,6 +703,7 @@ logsDir: /custom/logs
         assert_eq!(t.version, Some("new-version".into()));
         assert_eq!(t.binary, Some("new-bin".into()));
         assert_eq!(t.default_args, Some(vec!["new-arg".into()]));
+        assert_eq!(t.yes_args, Some(vec!["--new-yes".into()]));
         assert_eq!(t.help, Some("new-help".into()));
         assert_eq!(t.bunx, Some(true));
         assert_eq!(t.system_prompt, Some("--new-system".into()));

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -160,13 +160,19 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
         }
     }
 
-    // Add --dangerously-skip-permissions if -y was passed
-    if args.skip_permissions {
-        cmd_args.push("--dangerously-skip-permissions".to_string());
-    }
-
     // Add default args
     cmd_args.extend(cli_config.default_args.iter().cloned());
+
+    // Add the per-CLI "yolo" args if -y was passed. Each CLI declares its own
+    // (claude: --dangerously-skip-permissions; codex:
+    // --dangerously-bypass-approvals-and-sandbox). Codex rejects the claude flag
+    // outright, and its bwrap sandbox fails to init inside an already-sandboxed
+    // container ("bwrap: Failed to make / slave: Permission denied"), so its
+    // bypass flag is the correct escape hatch for those environments.
+    // Appended after default_args (matching the TS fallback in ts/index.ts).
+    if args.skip_permissions {
+        cmd_args.extend(cli_config.yes_args.iter().cloned());
+    }
 
     // Codex session resume: look up stored session ID for this cwd
     if args.continue_session && args.cli == "codex" {

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -44,6 +44,7 @@ export type AgentCliConfig = {
   version?: string; // hint user for version command to check if installed
   binary?: string; // actual binary name if different from cli, e.g. cursor -> cursor-agent
   defaultArgs?: string[]; // function to ensure certain args are present
+  yesArgs?: string[]; // appended when `-y`/--yes is passed: the per-CLI "yolo" flag (claude: --dangerously-skip-permissions; codex: --dangerously-bypass-approvals-and-sandbox)
   help?: string; // documentation/help URL for the CLI
   bunx?: boolean; // metadata for bunx-based launches
   systemPrompt?: string; // flag name for system prompt injection
@@ -115,6 +116,7 @@ export const CLIS_CONFIG = config.clis as Record<
 export default async function agentYes({
   cli,
   cliArgs = [],
+  skipPermissions = false,
   prompt,
   robust = true,
   cwd,
@@ -134,6 +136,7 @@ export default async function agentYes({
 }: {
   cli: keyof typeof CLIS_CONFIG;
   cliArgs?: string[];
+  skipPermissions?: boolean; // if true (`-y`/--yes), append the per-CLI yesArgs ("yolo" flag)
   prompt?: string;
   robust?: boolean;
   cwd?: string;
@@ -216,6 +219,14 @@ export default async function agentYes({
   // Apply CLI specific configurations (moved to CLI_CONFIGURES)
   const cliConf = (CLIS_CONFIG as Record<string, AgentCliConfig>)[cli] || {};
   cliArgs = cliConf.defaultArgs ? [...cliConf.defaultArgs, ...cliArgs] : cliArgs;
+
+  // `-y`/--yes appends the per-CLI "yolo" args. Each CLI declares its own:
+  // claude → --dangerously-skip-permissions; codex →
+  // --dangerously-bypass-approvals-and-sandbox (codex rejects the claude flag,
+  // and its bwrap sandbox can't init inside an already-sandboxed container).
+  if (skipPermissions && cliConf.yesArgs?.length) {
+    cliArgs = [...cliArgs, ...cliConf.yesArgs];
+  }
 
   // If enabled, read SKILL.md header and prepend to the prompt for non-Claude agents
   try {

--- a/ts/parseCliArgs.ts
+++ b/ts/parseCliArgs.ts
@@ -115,7 +115,8 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
     })
     .option("yes", {
       type: "boolean",
-      description: "Pass --dangerously-skip-permissions to the CLI (claude shortcut)",
+      description:
+        "Pass the CLI's 'yolo' flag (claude: --dangerously-skip-permissions; codex: --dangerously-bypass-approvals-and-sandbox)",
       default: false,
       alias: "y",
     })
@@ -292,7 +293,10 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
       (dashIndex !== 0
         ? parsedArgv._[0]?.toString()?.replace?.(/-yes$/, "")
         : undefined)) as string,
-    cliArgs: [...cliArgsForSpawn, ...(parsedArgv.yes ? ["--dangerously-skip-permissions"] : [])],
+    cliArgs: cliArgsForSpawn,
+    // `-y`/--yes: the actual flag is per-CLI (see each CLI's `yesArgs` in
+    // default.config.yaml). agentYes() appends it once the CLI is resolved.
+    skipPermissions: parsedArgv.yes,
     prompt:
       [parsedArgv.prompt, positionalPrompt, dashPrompt].filter(Boolean).join(" ") || undefined,
     install: parsedArgv.install,


### PR DESCRIPTION
## Problem

`ay codex` wraps the OpenAI codex CLI, which sandboxes every command with **bubblewrap (`bwrap`)** on Linux. Inside an already-sandboxed / containerized environment (e.g. another agent's sandbox), bwrap can't initialize:

```
Command failed before execution because the sandbox wrapper could not initialize:
bwrap: Failed to make / slave: Permission denied
```

So command exec **and** `apply_patch` fail before running, and codex falls back to escalated unsandboxed writes. Reported by a `codex-yes` agent running inside a sandboxed peer.

Two bugs combined to make `-y` useless here:
1. `-y`/`--yes` was hardcoded to claude's `--dangerously-skip-permissions` for **every** CLI — codex rejects that flag outright (`unexpected argument`).
2. Even when accepted, claude's flag wouldn't disable codex's bwrap sandbox.

## Fix

Add a per-CLI **`yesArgs`** config field so `-y` maps to each CLI's own "yolo" flag:

| CLI | `-y` maps to |
|-----|--------------|
| claude | `--dangerously-skip-permissions` |
| codex  | `--dangerously-bypass-approvals-and-sandbox` |

The codex flag skips both approval prompts and the bwrap sandbox — exactly codex's documented mode for *"environments that are externally sandboxed"*. Without `-y`, codex's sandbox stays **on** by default (sandboxing remains the wrapped CLI's job).

Usage (agent-yes flags must precede the cli name, since trailing args are forwarded verbatim via `trailing_var_arg`):

```
ay -y codex "<task>"     # ✅  not  `ay codex -y ...`
```

## Implementation

- **Rust runtime:** `yes_args` on `CliConfigOverride`/`CliConfig` (serde camelCase + merge), applied in `main.rs` (replaces the hardcoded push), appended after `default_args`.
- **TS fallback:** `parseCliArgs` now passes `skipPermissions` instead of baking the claude flag; `index.ts` appends `cliConf.yesArgs`.
- **Config + schema:** `default.config.yaml` (source of truth, embedded into the Rust binary), `agent-yes.config.schema.json`.

## Verification

- Reproduced the bwrap failure, then confirmed the spawned codex now launches with `--dangerously-bypass-approvals-and-sandbox` and exec succeeds.
- Rust config tests updated (claude + codex `yes_args` assertions, merge round-trip); `cargo test` green.
- Full TS suite green: **485 passed**, coverage **95%**.
- Codex-reviewed (only cosmetic flag-ordering notes; addressed the one worth fixing — Rust now appends `yesArgs` after `defaultArgs` to match TS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)