### PR TITLE
docs(claude): put scratch/debug/temp scripts in ./tmp/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # agent-yes
 
+## Scratch / debug / temp scripts → `./tmp/`
+
+Put throwaway debug, probe, capture, and scratch scripts (and their output —
+screenshots, logs) under `./tmp/` at the repo root. It's already gitignored
+(see `.gitignore`). Do **not** scatter them in `scripts/` (that dir ships in the
+npm package), in `$HOME` / `%USERPROFILE%`, or in the system `%TEMP%` / msys
+`/tmp`. Clean them up when the task is done.
+
 ## After making changes, always rebuild and relink
 
 **TypeScript changes:**


### PR DESCRIPTION
Documents a convention: throwaway debug/probe/capture/scratch scripts (and their output) go under the gitignored `./tmp/` at the repo root — not in `scripts/` (ships in the npm package), `$HOME`/`%USERPROFILE%`, or the system `%TEMP%`/msys `/tmp`.

Docs-only (CLAUDE.md). Committed from a clean worktree off `main` to avoid entangling a concurrent agent's unrelated uncommitted change in the shared working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)