### PR TITLE
fix(console): right-align the live/conn badge in the terminal header

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -215,7 +215,10 @@
       /* ⋯ overflow menu in the terminal header + its dropdown. */
       .rmenu {
         position: relative;
-        margin-left: auto;
+        /* No margin-left:auto here: `.rhead .live` already carries the single
+           auto-margin that pushes the live/ctype/⋯ cluster right. A second
+           auto-margin would split the free space and strand the live+ctype
+           badge in the center of the header. */
       }
       .rmenubtn {
         background: none;


### PR DESCRIPTION
The terminal-header `[●] live [lan]` badge floated at **center** instead of the right.

**Cause:** both `.rhead .live` and `.rmenu` carried `margin-left:auto`. Two auto-margins in a flex row split the free space, so the `live`+`ctype` badge got stranded mid-header while `.rmenu` pinned to the far right (a ~600px gap between them).

**Fix:** drop `.rmenu`'s `margin-left:auto` — the single one on `.rhead .live` now pushes the `live`+`ctype`+`⋯` cluster right as one contiguous group.

Verified in-browser: live/ctype/⋯ measured contiguous at the right edge (1868→1996px, pane ends 2016).

(First of the header-diagnostics items tracked locally in TODO.md; the rest — traffic I/O sparkline, xterm capabilities, viewport sizes, multi-peer presence — follow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)