### PR TITLE
fix(console): stop eager per-focus PTY re-assert that glitched shared agents

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1387,12 +1387,11 @@
       let es = null; // live-tail subscription closer
       let term = null; // xterm.js Terminal rendering the raw PTY stream
       let fit = null;
-      // Re-fit the open terminal and re-assert its size to the agent's PTY. Set per
-      // selection in select(); invoked on open AND whenever the tab is re-activated.
-      // A backgrounded tab can miss window resizes, and another viewer may have
-      // resized the shared PTY while we were away — either leaves our stream
-      // rendering at the wrong width/height until something nudges it. null when no
-      // agent is open.
+      // One-shot on OPEN (select): fit the terminal to our pane, then adopt — push
+      // our size to the agent's PTY so its TUI reflows to match what we render.
+      // Set per selection in select(); null when no agent is open. NOT re-run on
+      // tab re-activation (that eager re-push fought a shared PTY and reflowed the
+      // stream on every focus); the visibilitychange hook does a local re-fit only.
       let resyncTerm = null;
       // Terminal font size (px) — adjustable from the ⋯ menu, persisted across
       // reloads, applied live to the open terminal and used by every new one.
@@ -3883,11 +3882,19 @@
           if (document.visibilityState === "visible") {
             lastActivity = Date.now();
             loadList();
-            // Re-assert our viewport size to the open agent: while we were away the
-            // window may have resized (a hidden tab can miss it) or another viewer
-            // may have resized the shared PTY, so the stream could be rendering at
-            // the wrong width/height. fit + push-if-different brings it back.
-            resyncTerm?.();
+            // Re-FIT our pane locally in case the window resized while this tab was
+            // hidden (a backgrounded tab can miss window 'resize'). A genuine size
+            // change then propagates to the agent via term.onResize → pushSize.
+            // We deliberately do NOT force-re-assert our size to the agent on every
+            // focus: for a shared PTY (a user-spawned agent attached to a local
+            // terminal of a different size) that re-push fights the local terminal
+            // and reflows the stream on every tab switch — the glitch the eager
+            // per-focus resync introduced. The one-shot adopt still runs on select.
+            if (term && fit) {
+              try {
+                fit.fit();
+              } catch {}
+            }
           }
         });
         watchVersion();


### PR DESCRIPTION
**Item 0** of the header-diagnostics work: the console felt flaky/glitchy after recent changes. Traced to **#59** ("re-assert terminal size on tab re-activation").

## Cause

#59 re-ran the full size resync (`fetch /api/size` + `fit` + push-if-different) on **every** tab re-activation. For a **shared PTY** — a user-spawned agent attached to a local terminal of a different size — our pushed size never sticks (the local terminal owns it), so each focus re-pushed our size → the agent reflowed → the stream visibly glitched on every tab switch.

## Fix

On `visibilitychange`, re-**fit** our pane locally only. A genuine window resize missed while the tab was hidden still propagates to the agent via `term.onResize → pushSize`; we just no longer force-re-claim our size on every focus. The one-shot adopt-on-open (`resyncTerm` in `select`) is unchanged.

## Investigation

Instrumented `pushSize`/`fitAndSync` against the live fleet (served the modified UI into the real WebRTC room):
- **No idle resize loop** — 0 pushes over 10s idle.
- **No force-push on refocus** for size-matched agents.
- The churn is specific to **shared-PTY agents** whose pushed size won't stick.

A continuous single-viewer loop was ruled out; this removes the eager per-focus re-push that caused the shared-PTY reflow churn. (Built in an isolated worktree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)