### PR TITLE
feat(console): multi-peer presence — viewers + viewports per agent (slice 1)

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2386,11 +2386,26 @@
         const traffic =
           `<div class="ctip-traf"><span class="ctip-k">i/o</span>${sparkSvg(traf.hist, 96, 22) || "—"}</div>` +
           `<div><span class="ctip-k"></span>↓ ${fmtBytes(last.o)}/s&nbsp;&nbsp;↑ ${fmtBytes(last.i)}/s</div>`;
+        const viewers = presenceHtml();
         return (
           `<div class="ctip-sec">${vp}</div>` +
           `<div class="ctip-sec">${capHtml}</div>` +
-          `<div class="ctip-sec">${traffic}</div>`
+          `<div class="ctip-sec">${traffic}</div>` +
+          (viewers ? `<div class="ctip-sec">${viewers}</div>` : "")
         );
+      }
+      // Other viewers watching THIS agent (we exclude ourselves) + their viewports.
+      function presenceHtml() {
+        const others = presencePeers;
+        if (!others.length) return "";
+        const head = `<div><span class="ctip-k">viewers</span>👁 ${others.length + 1}&nbsp;<span style="color:var(--muted)">(you + ${others.length})</span></div>`;
+        const list = others
+          .map(
+            (v) =>
+              `<div><span class="ctip-k"></span>${esc((v.cols || "?") + "×" + (v.rows || "?"))}${v.sel ? " · sel" : ""}</div>`,
+          )
+          .join("");
+        return head + list;
       }
       // Always-on: sample the I/O ring every second and, while an agent is open,
       // repaint the badge so its hover tooltip (sparkline + caps + sizes) stays live.
@@ -2400,6 +2415,71 @@
         traf.cin = traf.cout = 0;
         if (sel) paintHeaderBadge();
       }, 1000);
+
+      // ---- multi-peer presence: report which agent we're watching + our viewport
+      // to the host, and read back the OTHER viewers, so the badge can show how many
+      // peers look at the same agent and at what size. Cosmetic; the host's
+      // /api/presence blackboard TTLs entries (hosts on an older `ay serve` just 404
+      // → we degrade to no viewers). Keyed by a per-tab viewer id so switching agents
+      // moves our single entry rather than stacking up.
+      const myViewerId = (() => {
+        try {
+          let v = sessionStorage.getItem("ay.viewer");
+          if (!v) {
+            v = Math.random().toString(36).slice(2, 10);
+            sessionStorage.setItem("ay.viewer", v);
+          }
+          return v;
+        } catch {
+          return Math.random().toString(36).slice(2, 10);
+        }
+      })();
+      let presencePeers = []; // others watching the SELECTED agent: [{cols,rows,sel}]
+      function presenceTarget() {
+        const e = sel ? entries.find((x) => x._key === sel) : null;
+        const src = e ? srcFor(e) : null;
+        return e && src && src.tx ? { e, tx: src.tx } : null;
+      }
+      function sendPresence() {
+        const cur = presenceTarget();
+        if (!cur || !term) return;
+        let selR = null;
+        try {
+          const s = term.getSelectionPosition && term.getSelectionPosition();
+          if (s) selR = `${s.startRow},${s.startColumn}-${s.endRow},${s.endColumn}`;
+        } catch {}
+        cur.tx
+          .post("/api/presence", {
+            viewer: myViewerId,
+            agent: cur.e.pid,
+            cols: term.cols,
+            rows: term.rows,
+            sel: selR,
+          })
+          .catch(() => {});
+      }
+      async function pollPresence() {
+        const cur = presenceTarget();
+        if (!cur) {
+          presencePeers = [];
+          return;
+        }
+        try {
+          const all = await cur.tx.fetchJSON("/api/presence");
+          presencePeers = (Array.isArray(all) ? all : []).filter(
+            (v) => String(v.agent) === String(cur.e.pid) && v.viewer !== myViewerId,
+          );
+        } catch {
+          presencePeers = [];
+        }
+      }
+      // 3s heartbeat (< the host's 12s TTL): refresh our presence + read others'.
+      setInterval(() => {
+        if (sel) {
+          sendPresence();
+          pollPresence();
+        }
+      }, 3000);
 
       // Wire the ⋯ overflow menu and restore the saved HUD preference.
       // Recovery actions for the SELECTED agent, both confirmed first (destructive):
@@ -2955,6 +3035,8 @@
         // and the remembered agent winsize so the badge tooltip doesn't show stale data.
         trafReset();
         agentSize = null;
+        presencePeers = []; // clear other-viewer list until the next poll for this agent
+        sendPresence(); // announce we're now watching this agent (host TTLs the prior one)
         paintHeaderBadge();
         // Remember the selection so a refresh re-opens this agent (see boot/autoPid).
         try {

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -942,6 +942,15 @@ export async function cmdServe(rest: string[]): Promise<number> {
     tasks: r.status === "exited" ? null : await logTasks(r.log_file),
   });
 
+  // Multi-peer presence blackboard: viewerId -> what that viewer is watching +
+  // its viewport/selection. Purely cosmetic ("who else is looking at this agent"),
+  // never a security surface — viewers self-report. Pruned by TTL on read.
+  const presence = new Map<
+    string,
+    { viewer: string; agent: string; cols: number; rows: number; sel: string | null; ts: number }
+  >();
+  const PRESENCE_TTL_MS = 12_000;
+
   // The whole API as a plain handler: served over HTTP by Bun.serve (--http)
   // and called in-process by the WebRTC bridge (--webrtc) — the latter needs
   // no TCP port at all.
@@ -1373,6 +1382,46 @@ export async function cmdServe(rest: string[]): Promise<number> {
       } catch (e) {
         return new Response((e as Error).message, { status: 404 });
       }
+    }
+
+    // POST /api/presence  body {viewer, agent, cols, rows, sel?} — a viewer
+    // self-reports which agent it's watching + its viewport (agent=null clears).
+    if (req.method === "POST" && p === "/api/presence") {
+      let b: {
+        viewer?: string;
+        agent?: string | number | null;
+        cols?: number;
+        rows?: number;
+        sel?: string;
+      };
+      try {
+        b = (await req.json()) as typeof b;
+      } catch {
+        return new Response("invalid JSON body", { status: 400 });
+      }
+      const viewer = String(b.viewer ?? "").slice(0, 64);
+      if (!viewer) return new Response("missing viewer", { status: 400 });
+      if (b.agent == null) presence.delete(viewer);
+      else
+        presence.set(viewer, {
+          viewer,
+          agent: String(b.agent),
+          cols: Math.max(0, Math.floor(Number(b.cols) || 0)),
+          rows: Math.max(0, Math.floor(Number(b.rows) || 0)),
+          sel: typeof b.sel === "string" ? b.sel.slice(0, 200) : null,
+          ts: Date.now(),
+        });
+      return new Response(null, { status: 204 });
+    }
+    // GET /api/presence — all live viewers (TTL-pruned), for "who's watching".
+    if (req.method === "GET" && p === "/api/presence") {
+      const now = Date.now();
+      const live: unknown[] = [];
+      for (const [k, v] of presence) {
+        if (now - v.ts > PRESENCE_TTL_MS) presence.delete(k);
+        else live.push(v);
+      }
+      return Response.json(live);
     }
 
     // POST /api/spawn  body {cli, cwd, prompt} — launch a new agent


### PR DESCRIPTION
**TODO item 5 (slice 1).** Show how many people are watching the same agent and at what size.

## Host — `ts/serve.ts` (presence blackboard)
- `POST /api/presence {viewer, agent, cols, rows, sel?}` — a viewer self-reports which agent it's watching + its viewport (`agent: null` clears).
- `GET /api/presence` — all live viewers, **TTL-pruned (12s)**.
- Cosmetic only, never a security surface — viewers self-report a per-tab id.

## UI — `lab/ui/index.html`
- On select + a **3s heartbeat**, POST our presence to the selected agent's host and read back the others.
- The badge tooltip (from #75) gains a **`viewers 👁 N (you + k)`** line listing each other viewer's **viewport size** (+ a `· sel` marker when they have a selection).
- Keyed by a per-tab viewer id so switching agents moves our single entry. Hosts on an older `ay serve` return 404 → **graceful degrade** to no viewers.

## Verification
- Host blackboard **POST/GET/clear lifecycle curl-verified** against a live 17-agent serve (two viewers listed, clear removes one).
- UI loads clean (no JS errors); presence code reuses the same `srcFor(e).tx` path as the verified `/api/size`/`/api/resize` calls and the #75 tooltip.
- Full 2-viewer live render verifies post-deploy (needs the new `ay serve` released + two browsers).

## Deferred — slice 2
Rendering a peer's **selection range as an overlay** in our grid (coordinate-mapping across different viewport sizes) is the larger follow-up.

Built in an isolated worktree. Note: this touches the host, so it needs an `ay serve` release to fully light up; the UI degrades gracefully until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)