### PR TITLE
fix(console): read xterm 5.x selection shape so peer-selection overlay works

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2474,8 +2474,12 @@
         if (!cur || !term) return;
         let selR = null;
         try {
+          // xterm 5.x: getSelectionPosition() returns { start:{x,y}, end:{x,y} }
+          // (x=column, y=buffer row), NOT the old startColumn/startRow shape. We
+          // emit "row,col-row,col" so the receiver's mapPeerSel regex matches.
           const s = term.getSelectionPosition && term.getSelectionPosition();
-          if (s) selR = `${s.startRow},${s.startColumn}-${s.endRow},${s.endColumn}`;
+          if (s && s.start && s.end)
+            selR = `${s.start.y},${s.start.x}-${s.end.y},${s.end.x}`;
         } catch {}
         cur.tx
           .post("/api/presence", {


### PR DESCRIPTION
The peer-selection overlay (presence slice 2, #78) never showed for a **real** mouse selection — only for manually-injected `sel` values.

## Cause
`sendPresence` read `getSelectionPosition()` as `{startColumn, startRow, endColumn, endRow}` — the **old** xterm API. xterm 5.x returns `{ start: {x, y}, end: {x, y} }` (x=column, y=buffer row). So every field was `undefined` → `sel` = `"undefined,undefined-undefined,undefined"` → the receiver's `mapPeerSel` regex `(\d+),(\d+)-(\d+),(\d+)` never matched → no box.

## Fix
Emit `"row,col-row,col"` from `s.start.y/x` + `s.end.y/x`.

## Verified (via rech against the live xterm)
- `getSelectionPosition()` confirmed to return `{start:{x,y}, end:{x,y}}`.
- A real selection (cols 5–17, row 0 of a 40-col grid) now yields `"0,5-0,17"`, which `mapPeerSel` maps to `{r0:0,c0:10,r1:0,c1:34}` in an 80×24 grid. ✓

Render side was already correct (injected sels rendered fine) — this was purely the capture shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)