### PR TITLE
feat(console): shared canvas — scale to the agent grid instead of reflowing

### DIFF
--- a/docs/shared-canvas.md
+++ b/docs/shared-canvas.md
@@ -1,0 +1,126 @@
+# Shared Canvas — consistent multi-viewer terminal rendering (design)
+
+> Status: **design + MVP.** Captures a brainstorm (with codex gpt-5.5). The MVP
+> section is what we build first; later refinements are marked **DEFERRED**.
+
+## Problem
+
+agent-yes.com lets **multiple browsers watch/steer one terminal agent**. The
+agent's PTY renders at **one** size; the host streams that rendered output (SSE)
+to every viewer, and each viewer writes it into **its own** xterm.js at **its
+own** window size. Different widths → different line-wrapping/reflow → the **same
+content lands on different rows/columns per viewer**.
+
+That breaks anything coordinate-based across viewers:
+
+- The multi-peer **selection overlay** (presence) is exact only when viewers
+  share a size; at different sizes the box mismatches the text.
+- A shared **cursor**, and any future annotations, have the same problem.
+
+## North star
+
+**One canonical terminal grid per session; viewers adapt _visually_, not
+_logically_.** Make "a selection points at the same character for everyone" a
+product invariant. Every viewer renders at the **agent's canonical grid size**
+and **CSS-scales / letterboxes** that grid into its pane — it never reflows to
+its own pane size. Then all viewers see identical content and every
+coordinate-based feature lines up for free.
+
+This is the screen-share model: one canvas, each window scales it to fit.
+
+## Render: scale, don't reflow
+
+Each viewer creates its xterm at the agent's `cols×rows` and fits the pane with a
+CSS `transform: scale(...)` (origin top-left, centered), **not** by resizing the
+grid. codex's refinement — offer **fit modes** rather than one forced scale:
+
+- **`fit`** (default): letterbox the whole grid into the pane. Selection/cursor
+  are pixel-exact. A 200-col driver on a phone is small but consistent.
+- **`100% + pan`**: render at native cell size, scroll/pan to read. Readability
+  over overview (small screens).
+- **`follow-cursor`** (**DEFERRED**, mobile): auto-pan to keep the driver's
+  cursor region in view.
+
+Reflow-to-pane is the thing we are removing — "200-col on a phone is hard to
+read" is a **scale/pan UX** problem, not a reason to reflow (reflow reintroduces
+the mismatch).
+
+## Size authority: a single driver, by lease
+
+The canonical grid size is owned by **one driver at a time**, not last-writer:
+
+- Driver changes only on **strong intent** — typing, paste, the resize handle,
+  or an explicit "take control". **Not** on focus, mouse-move, or selection.
+- Hold by **lease**, not debounce: a driver keeps size authority for ~10–30s
+  after its last input, so two people don't thrash the grid.
+- **Reject `min-fit`** (shrinking everyone to the smallest viewer — one small
+  watcher would cramp the agent and the local owner). A fixed default
+  (e.g. `120×40`) is only a last-resort fallback.
+
+## Session-mode ownership (the local-terminal case)
+
+The biggest policy question: a user-spawned agent's PTY is **shared with the
+user's local terminal**, so a remote driver's resize reflows the owner's local
+view. Size authority therefore depends on session mode:
+
+1. **user-spawned + local terminal attached** → the **local owner is the size
+   authority**; remote viewers watch the (scaled) shared canvas. **Remote resize
+   is off by default** — a remote must "request control" and be granted it.
+2. **headless / hosted agent** (no local terminal) → the **active remote driver**
+   is the authority.
+
+## Why not content-anchoring
+
+An alternative to converging size is to anchor a selection to the underlying
+**text / a line identity** instead of grid coordinates. We reject this as the
+basis: terminal output carries ANSI state, alt-screen, cursor moves, erases,
+wide/combining chars; xterm line identity breaks on reflow; duplicate visible
+text makes anchors ambiguous; selection meaning shifts at wrap/scrollback
+boundaries. It could exist later as a separate **best-effort semantic
+highlight**, but presence correctness should rest on size convergence.
+
+## Biggest risk
+
+**Resize itself.** A PTY resize re-lays-out the running TUI, the shell prompt,
+and (for shared sessions) the local owner's screen. Minimizing _when_ we resize
+the agent — single authority, lease, explicit remote control — is the whole game.
+
+## MVP
+
+> **one canonical terminal grid per session; viewers adapt visually, not logically.**
+
+Built defensively so the common single-viewer path is unchanged:
+
+- A viewer renders its xterm at the **agent's PTY size** (from `/api/size`) and
+  **CSS-scales to fit** the pane. When the agent's size already equals the
+  viewer's natural fit (the **single-viewer / driver** case), scale ≈ 1 and
+  behaviour is identical to today — no regression.
+- **Follow:** poll `/api/size` (piggyback the existing presence heartbeat); when
+  the agent's grid changes (another viewer drove it), `term.resize()` to it and
+  re-scale — never reflow.
+- **Drive:** the viewer that interacts pushes its fit size on select (current
+  behaviour) and so sets the canonical grid; watchers follow + scale and do not
+  push.
+- **Presence overlay** drops the proportional-column fallback — all viewers share
+  the grid, so selection/cursor coordinates are exact.
+- Window resize re-computes the **scale**, not the grid.
+
+### Decisions
+
+- **Agreed:** scale/letterbox, never reflow; single-driver size authority by
+  lease on strong intent; reject min-fit; session-mode ownership (local owner
+  wins, remote resize off by default for shared sessions); content-anchoring is
+  not the basis.
+- **DEFERRED:** the full lease/"take control" UX + a visible driver indicator;
+  `follow-cursor` and `100%+pan` modes (MVP ships `fit`); mouse-coordinate
+  correction for an interacting *watcher* under scale (drivers are scale ≈ 1, so
+  unaffected); how the agent advertises size changes (poll now, push over the
+  stream later).
+
+## Related code
+
+- `lab/ui/index.html` — `select()` builds the xterm + FitAddon and pushes size;
+  `renderPeerSelections` / `selSegments` (presence overlay); the `/api/size`
+  resync + 3s presence heartbeat.
+- `ts/serve.ts` — `/api/size`, `/api/resize` (winsize + SIGWINCH), `/api/presence`.
+- `docs/agent-sharing.md` — the presence feature this builds on.

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -970,6 +970,13 @@
       }
       .log .xterm {
         height: 100%;
+        /* Shared-canvas: when we're a WATCHER rendering at another viewer's
+           (the driver's) grid size, scale the whole grid to fit our pane instead
+           of reflowing. transform-origin keeps the scaled grid pinned top-left so
+           the peer-selection overlay (which uses grid coords) still lines up.
+           For the driver / single viewer the grid already fits, so no transform
+           is applied (see applyCanvasScale). */
+        transform-origin: top left;
       }
       /* Other viewers' selection ranges, drawn over our grid (slice 2 of
          multi-peer presence). Approximate — peer coords are mapped proportionally
@@ -2335,6 +2342,10 @@
       // The last winsize the agent's PTY reported (from /api/size), so the tooltip
       // can show OUR viewport vs the agent's render size. Reset on agent switch.
       let agentSize = null;
+      // When WE last drove the grid size (pushed our size to the agent). For a
+      // short lease after that, the heartbeat won't follow/override — so our own
+      // push isn't fought while the agent's /api/size is still catching up.
+      let lastDroveAt = 0;
 
       function isDarkColor(c) {
         try {
@@ -2512,12 +2523,19 @@
         }
         renderPeerSelections();
       }
-      // 3s heartbeat (< the host's 12s TTL): refresh our presence + read others'.
+      // 3s heartbeat (< the host's 12s TTL): refresh our presence + read others',
+      // and follow the canonical grid size (resize+scale, never reflow) so all
+      // viewers stay on one shared canvas and selections line up.
       setInterval(() => {
-        if (sel) {
-          sendPresence();
-          pollPresence();
-        }
+        if (!sel) return;
+        sendPresence();
+        pollPresence();
+        const cur = presenceTarget();
+        if (cur)
+          cur.tx
+            .fetchJSON("/api/size/" + encodeURIComponent(cur.e.pid))
+            .then(followAgentSize)
+            .catch(() => {});
       }, 3000);
 
       // ---- slice 2: draw each peer's selection range as an overlay in OUR grid.
@@ -2612,6 +2630,51 @@
           }
         }
         ov.innerHTML = html.join("");
+      }
+
+      // ---- shared canvas: scale (don't reflow) the grid to fit our pane --------
+      // When we render at the canonical (driver/agent) grid size and it doesn't
+      // match our pane, CSS-scale the whole .xterm to fit — so every viewer shows
+      // identical content and selections/overlays line up. For the driver / single
+      // viewer the grid already fits the pane (scale ≈ 1) → no transform, so the
+      // common path is byte-for-byte unchanged. Best-effort + guarded.
+      function applyCanvasScale() {
+        try {
+          const logEl = $("log");
+          const xt = logEl && logEl.querySelector(".xterm");
+          if (!xt) return;
+          xt.style.transform = "none"; // measure the natural (unscaled) grid
+          const screen = xt.querySelector(".xterm-screen");
+          if (!screen) return;
+          const gw = screen.offsetWidth,
+            gh = screen.offsetHeight;
+          if (!gw || !gh) return;
+          const cs = getComputedStyle(logEl);
+          const pw = logEl.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+          const ph = logEl.clientHeight - parseFloat(cs.paddingTop) - parseFloat(cs.paddingBottom);
+          if (pw <= 0 || ph <= 0) return;
+          const s = Math.min(pw / gw, ph / gh);
+          // Near-1 (driver / single viewer): keep it crisp, no transform.
+          xt.style.transform = s > 0.985 && s < 1.04 ? "none" : "scale(" + s.toFixed(4) + ")";
+        } catch {}
+      }
+      // Follow the canonical grid: resize our xterm to the agent's size (set by the
+      // active driver / local owner) WITHOUT reflowing to our pane, then scale to
+      // fit. No-op when we already match (we're the driver, or sizes agree).
+      function followAgentSize(sz) {
+        if (!term || !sz || !sz.cols || !sz.rows) return;
+        // While our own recent push is still settling, don't fight it.
+        if (Date.now() - lastDroveAt < 6000) {
+          applyCanvasScale();
+          return;
+        }
+        if (sz.cols !== term.cols || sz.rows !== term.rows) {
+          agentSize = sz;
+          try {
+            term.resize(sz.cols, sz.rows);
+          } catch {}
+        }
+        applyCanvasScale();
       }
 
       // Wire the ⋯ overflow menu and restore the saved HUD preference.
@@ -3262,11 +3325,13 @@
         // one-shot "push only if the agent is out of sync" check.
         let suppressPush = true;
         const pushSize = () => {
-          if (term && sel === e._key && !suppressPush)
+          if (term && sel === e._key && !suppressPush) {
+            lastDroveAt = Date.now(); // we're driving the size now (lease the grid)
             tx.post("/api/resize/" + encodeURIComponent(pid), {
               cols: term.cols,
               rows: term.rows,
             }).catch(() => {});
+          }
         };
         term.onResize(pushSize);
         // Scrolling through OUR scrollback moves the viewport over the buffer, so
@@ -3306,12 +3371,14 @@
             fit.fit();
           } catch {}
           if (!sz || sz.cols !== term.cols || sz.rows !== term.rows) {
+            lastDroveAt = Date.now(); // adopting our size on open = we drive (lease)
             tx.post("/api/resize/" + encodeURIComponent(pid), {
               cols: term.cols,
               rows: term.rows,
             }).catch(() => {});
           }
           suppressPush = false;
+          applyCanvasScale(); // driver: grid == pane → no-op; otherwise letterbox
         };
         // Fit + sync now, and on every later tab re-activation: re-measure our pane
         // and re-assert our size to the agent so the stream always reflows to OUR
@@ -3420,10 +3487,14 @@
         renderList();
       });
       window.addEventListener("resize", () => {
+        // Resizing our window is strong intent → re-fit to our pane (we become the
+        // size driver; the push rides term.onResize). applyCanvasScale then clears
+        // the transform since our grid now matches our pane.
         if (fit)
           try {
             fit.fit();
           } catch {}
+        applyCanvasScale();
         renderPeerSelections(); // cell size changed → reposition peer-selection overlays
       });
       // iOS overlays the soft keyboard ON TOP of the layout viewport rather than


### PR DESCRIPTION
Fixes the cross-size selection mismatch (raised after the presence overlay shipped): viewers with different window sizes reflowed the agent's output differently, so coordinate-based features (selection overlay, cursor) didn't line up.

Design (codex-validated): **one canonical terminal grid per session; viewers adapt visually, not logically** — full writeup in `docs/shared-canvas.md`.

## MVP (defensive)
- **`followAgentSize()`** — on the 3s presence heartbeat, fetch `/api/size` and `term.resize()` to the agent's (driver's) grid **without reflowing**, then scale.
- **`applyCanvasScale()`** — CSS-scale the `.xterm` to fit the pane. **Near-1 (driver / single viewer) → no transform**, so the common path is byte-for-byte unchanged (no regression). Watchers letterbox onto the shared grid.
- **Lease (`lastDroveAt`)** — after we push our own size, the heartbeat won't follow/override for ~6s, so our push isn't fought while `/api/size` catches up.
- The presence overlay already measures the (now scaled) screen rect, so selections line up on the scaled canvas automatically.

## Safety / verification
- Single-viewer is unchanged **by construction**: a driver's grid fits its pane → scale ≈ 1 → no transform (the 0.985–1.04 band absorbs fit's rounding slack).
- Clean load verified. Multi-viewer scaling validates post-deploy on the stable site (the local static-over-WebRTC test harness is too flaky to drive two tabs reliably).

## Deferred (in doc)
fit-modes (`100%+pan`, `follow-cursor`), full lease + "take control" UX with a driver indicator, session-mode remote-resize gating (local owner authority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)