### PR TITLE
feat(console): browser tab title follows the selected agent (realtime)

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -461,3 +461,10 @@ export function fitTransform(gridW, gridH, paneW, paneH) {
   const s = Math.min(paneW / gridW, paneH / gridH);
   return s > 0.985 && s < 1.04 ? "none" : "scale(" + s.toFixed(4) + ")";
 }
+
+// Browser-tab title: "<selected agent title> - agent-yes", or the bare console
+// title when nothing is selected (blank/whitespace name).
+export function docTitle(name) {
+  const n = name && String(name).trim();
+  return n ? n + " - agent-yes" : "agent-yes · console";
+}

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1406,6 +1406,7 @@
         parseSel,
         selSegments,
         fitTransform,
+        docTitle,
       } from "./console-logic.js";
       import {
         MARKER as E2E_MARKER,
@@ -3178,6 +3179,14 @@
         }
       }
 
+      // Reflect the selected agent's title in the browser tab, live. Mirrors
+      // $("rname") — set on select() and again on the agent's OSC title sequence —
+      // so the tab tracks renames in realtime. Reverts to the default when nothing
+      // is selected.
+      function setDocTitle(name) {
+        document.title = docTitle(name); // pure formatter in console-logic.js (tested)
+      }
+
       function select(keyOrPid) {
         const e =
           entries.find((x) => x._key === keyOrPid) ||
@@ -3218,7 +3227,9 @@
         document.querySelector(".app").classList.add("show-detail");
         $("rhead").style.display = "flex";
         $("rdot").className = "dot " + e.status;
-        $("rname").textContent = e.title || cliLabel(e) || ident(e) || "agent";
+        const rname = e.title || cliLabel(e) || ident(e) || "agent";
+        $("rname").textContent = rname;
+        setDocTitle(rname); // tab title follows the selected agent
         $("rpid").textContent = "pid " + e.pid;
 
         // Render the agent's native TUI with xterm.js by feeding it the raw PTY
@@ -3267,6 +3278,7 @@
           const title = t && t.trim();
           if (sel !== e._key || !title) return;
           $("rname").textContent = title;
+          setDocTitle(title); // realtime rename → update the browser tab too
           // Keep the left panel in lockstep with the terminal header. The row
           // title otherwise only refreshes on the 3s /api/ls poll, so it visibly
           // lagged the live terminal. Patch the current entry (entries is

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -27,6 +27,7 @@ import {
   parseSel,
   selSegments,
   fitTransform,
+  docTitle,
 } from "../../lab/ui/console-logic.js";
 
 const agent = (over = {}) => ({
@@ -589,5 +590,20 @@ describe("fitTransform", () => {
   it("guards bad dimensions", () => {
     expect(fitTransform(0, 480, 800, 480)).toBe("none");
     expect(fitTransform(800, 480, 0, 480)).toBe("none");
+  });
+});
+
+describe("docTitle", () => {
+  it("suffixes the selected agent's title", () => {
+    expect(docTitle("fix the bug")).toBe("fix the bug - agent-yes");
+  });
+  it("trims whitespace", () => {
+    expect(docTitle("  build  ")).toBe("build - agent-yes");
+  });
+  it("falls back to the bare console title when empty", () => {
+    expect(docTitle("")).toBe("agent-yes · console");
+    expect(docTitle("   ")).toBe("agent-yes · console");
+    expect(docTitle(null as any)).toBe("agent-yes · console");
+    expect(docTitle(undefined as any)).toBe("agent-yes · console");
   });
 });


### PR DESCRIPTION
The tab was always `agent-yes · console`. Now it reads **`<selected agent title> - agent-yes`**, updated live.

- `setDocTitle()` is called wherever `$("rname")` is set — on `select()` (initial) and on the agent's OSC 0/2 title sequence (`term.onTitleChange`) — so a rename retitles the tab in realtime, exactly like the header name.
- The pure formatter **`docTitle(name)`** lives in `console-logic.js` (adds the ` - agent-yes` suffix; blank/whitespace → bare `agent-yes · console`) and is **unit-tested** — browser-free, per the testability refactor.

73 ui-logic tests pass; page loads clean (default title when nothing is selected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)