### PR TITLE
feat(console): show agent status glyph (●/○/✗) in the tab title

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -462,9 +462,16 @@ export function fitTransform(gridW, gridH, paneW, paneH) {
   return s > 0.985 && s < 1.04 ? "none" : "scale(" + s.toFixed(4) + ")";
 }
 
-// Browser-tab title: "<selected agent title> - agent-yes", or the bare console
-// title when nothing is selected (blank/whitespace name).
-export function docTitle(name) {
+// Browser-tab title: "<glyph> <selected agent title> - agent-yes", or the bare
+// console title when nothing is selected (blank/whitespace name). The leading
+// glyph mirrors the agent's status dot — ● active, ○ idle, ✗ exited — so the tab
+// shows liveness at a glance; an unknown status adds no glyph.
+export function statusGlyph(status) {
+  return status === "active" ? "●" : status === "idle" ? "○" : status === "exited" ? "✗" : "";
+}
+export function docTitle(name, status) {
   const n = name && String(name).trim();
-  return n ? n + " - agent-yes" : "agent-yes · console";
+  if (!n) return "agent-yes · console";
+  const g = statusGlyph(status);
+  return (g ? g + " " : "") + n + " - agent-yes";
 }

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -3161,6 +3161,7 @@
         }
         renderRoomsIfOpen();
         renderList();
+        refreshDocTitle(); // poll may have changed the selected agent's status
         if (autoPid && entries.some((x) => matchSel(x, autoPid))) {
           const tok = autoPid;
           autoPid = null;
@@ -3183,8 +3184,14 @@
       // $("rname") — set on select() and again on the agent's OSC title sequence —
       // so the tab tracks renames in realtime. Reverts to the default when nothing
       // is selected.
-      function setDocTitle(name) {
-        document.title = docTitle(name); // pure formatter in console-logic.js (tested)
+      // Tab title = status glyph + the live header name + " - agent-yes". Reads the
+      // currently-displayed name ($("rname"), kept fresh by select + onTitleChange)
+      // and the selected entry's status (refreshed by the poll via mergeRender), so
+      // both renames AND active→idle→exited transitions show in realtime.
+      function refreshDocTitle() {
+        const e = sel ? entries.find((x) => x._key === sel) : null;
+        const name = e ? $("rname").textContent : "";
+        document.title = docTitle(name, e && e.status); // pure formatter (tested)
       }
 
       function select(keyOrPid) {
@@ -3229,7 +3236,7 @@
         $("rdot").className = "dot " + e.status;
         const rname = e.title || cliLabel(e) || ident(e) || "agent";
         $("rname").textContent = rname;
-        setDocTitle(rname); // tab title follows the selected agent
+        refreshDocTitle(); // tab title follows the selected agent (name + status)
         $("rpid").textContent = "pid " + e.pid;
 
         // Render the agent's native TUI with xterm.js by feeding it the raw PTY
@@ -3278,7 +3285,7 @@
           const title = t && t.trim();
           if (sel !== e._key || !title) return;
           $("rname").textContent = title;
-          setDocTitle(title); // realtime rename → update the browser tab too
+          refreshDocTitle(); // realtime rename → update the browser tab too
           // Keep the left panel in lockstep with the terminal header. The row
           // title otherwise only refreshes on the 3s /api/ls poll, so it visibly
           // lagged the live terminal. Patch the current entry (entries is

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -28,6 +28,7 @@ import {
   selSegments,
   fitTransform,
   docTitle,
+  statusGlyph,
 } from "../../lab/ui/console-logic.js";
 
 const agent = (over = {}) => ({
@@ -593,15 +594,32 @@ describe("fitTransform", () => {
   });
 });
 
+describe("statusGlyph", () => {
+  it("maps status → glyph", () => {
+    expect(statusGlyph("active")).toBe("●");
+    expect(statusGlyph("idle")).toBe("○");
+    expect(statusGlyph("exited")).toBe("✗");
+  });
+  it("is empty for unknown/missing status", () => {
+    expect(statusGlyph(undefined as any)).toBe("");
+    expect(statusGlyph("whatever" as any)).toBe("");
+  });
+});
+
 describe("docTitle", () => {
-  it("suffixes the selected agent's title", () => {
+  it("suffixes the selected agent's title (no status → no glyph)", () => {
     expect(docTitle("fix the bug")).toBe("fix the bug - agent-yes");
   });
-  it("trims whitespace", () => {
-    expect(docTitle("  build  ")).toBe("build - agent-yes");
+  it("prefixes the status glyph when given", () => {
+    expect(docTitle("fix the bug", "active")).toBe("● fix the bug - agent-yes");
+    expect(docTitle("fix the bug", "idle")).toBe("○ fix the bug - agent-yes");
+    expect(docTitle("fix the bug", "exited")).toBe("✗ fix the bug - agent-yes");
   });
-  it("falls back to the bare console title when empty", () => {
-    expect(docTitle("")).toBe("agent-yes · console");
+  it("trims whitespace", () => {
+    expect(docTitle("  build  ", "active")).toBe("● build - agent-yes");
+  });
+  it("falls back to the bare console title when empty (regardless of status)", () => {
+    expect(docTitle("", "active")).toBe("agent-yes · console");
     expect(docTitle("   ")).toBe("agent-yes · console");
     expect(docTitle(null as any)).toBe("agent-yes · console");
     expect(docTitle(undefined as any)).toBe("agent-yes · console");


### PR DESCRIPTION
Follow-up to #84 — the tab title now leads with the selected agent's **status glyph**: **●** active, **○** idle, **✗** exited (e.g. `● ✳ Debug Chatwork… - agent-yes`). Unknown status adds no glyph.

- `docTitle(name, status)` prefixes `statusGlyph(status)` — both pure and unit-tested (browser-free).
- `setDocTitle` → **`refreshDocTitle()`**: derives the live name (`$("rname")`) + the selected entry's status, and is called on select, on the OSC title sequence (`onTitleChange`), **and from `mergeRender`** (every poll/delta) — so an `active → idle → exited` transition retitles the tab in realtime, no re-select needed.

76 ui-logic tests pass; page loads clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)