### PR TITLE
feat(console): Cmd+K omnibox — search agents (title→output) + spawn here

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -475,3 +475,21 @@ export function docTitle(name, status) {
   const g = statusGlyph(status);
   return (g ? g + " " : "") + n + " - agent-yes";
 }
+
+// Relevance score for the Cmd+K omnibox — higher ranks first. Title hits beat
+// cwd/prompt hits so the "quick title match" surfaces at the top; 0 means no
+// title/cwd/prompt hit (such an agent only appears via a tail-content match,
+// which the caller scores separately and ranks below these).
+export function omniScore(e, query) {
+  const q = String(query || "")
+    .trim()
+    .toLowerCase();
+  if (!q) return 0;
+  const title = (e.title || "").toLowerCase();
+  if (title === q) return 100;
+  if (title.startsWith(q)) return 80;
+  if (title.includes(q)) return 60;
+  if ((e.cwd || "").toLowerCase().includes(q)) return 40;
+  if ((e.prompt || "").toLowerCase().includes(q)) return 20;
+  return 0;
+}

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -545,6 +545,102 @@
         align-items: center;
         justify-content: center;
       }
+      /* Cmd/Ctrl+K omnibox */
+      .omni {
+        position: fixed;
+        inset: 0;
+        z-index: 30;
+        background: rgba(2, 6, 12, 0.6);
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        padding-top: 12vh;
+      }
+      .omnibox {
+        width: min(680px, 92vw);
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+        overflow: hidden;
+        font-family: var(--mono);
+      }
+      #omni-input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 14px 16px;
+        border: 0;
+        border-bottom: 1px solid var(--line);
+        background: transparent;
+        color: var(--fg);
+        font: 15px var(--mono);
+        outline: none;
+      }
+      .omni-results {
+        max-height: 52vh;
+        overflow-y: auto;
+      }
+      .omni-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 14px;
+        cursor: pointer;
+        border-left: 2px solid transparent;
+      }
+      .omni-row.sel {
+        background: color-mix(in srgb, var(--accent) 16%, transparent);
+        border-left-color: var(--accent);
+      }
+      .omni-main {
+        flex: 1;
+        min-width: 0;
+      }
+      .omni-title {
+        color: var(--fg);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .omni-sub {
+        color: var(--muted);
+        font-size: 11px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .omni-snip {
+        color: var(--muted);
+        font-size: 11px;
+        opacity: 0.85;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .omni-snip b {
+        color: var(--amber);
+        font-weight: 600;
+      }
+      .omni-spawn {
+        border-top: 1px solid var(--line);
+      }
+      .omni-spawn .omni-title {
+        color: var(--green);
+      }
+      .omni-empty {
+        padding: 14px;
+        color: var(--muted);
+      }
+      .omni-foot {
+        padding: 8px 14px;
+        border-top: 1px solid var(--line);
+        color: var(--muted);
+        font-size: 11px;
+      }
+      .omni-foot b {
+        color: var(--fg);
+        font-weight: 600;
+      }
       .lcard {
         background: var(--panel);
         border: 1px solid var(--line);
@@ -1380,6 +1476,24 @@
     <div class="launchoverlay" id="launch" style="display: none"></div>
     <div class="launchoverlay" id="newform" style="display: none"></div>
 
+    <!-- Cmd/Ctrl+K omnibox: search agents by title (instant) then output (tail),
+         or spawn a new agent in the highlighted agent's cwd with the typed prompt. -->
+    <div class="omni" id="omni" style="display: none">
+      <div class="omnibox">
+        <input
+          id="omni-input"
+          placeholder="Search agents by title, then output…"
+          spellcheck="false"
+          autocapitalize="off"
+          autocomplete="off"
+        />
+        <div class="omni-results" id="omni-results"></div>
+        <div class="omni-foot">
+          <span><b>↑↓</b> move &nbsp; <b>⏎</b> open &nbsp; <b>⌘⏎</b> spawn here &nbsp; <b>esc</b> close</span>
+        </div>
+      </div>
+    </div>
+
     <script type="module">
       // Pure list/identity/filter helpers live in a sibling module so they can be
       // unit-tested (tests/ui-logic/console-logic.spec.ts) without a DOM. This
@@ -1407,6 +1521,7 @@
         selSegments,
         fitTransform,
         docTitle,
+        omniScore,
       } from "./console-logic.js";
       import {
         MARKER as E2E_MARKER,
@@ -1953,6 +2068,9 @@
         async fetchJSON(path) {
           return (await fetch(withTok(path))).json();
         },
+        async fetchText(path) {
+          return (await fetch(withTok(path))).text();
+        },
         async post(path, bodyObj) {
           const r = await fetch(withTok(path), {
             method: "POST",
@@ -1973,6 +2091,9 @@
         return {
           async fetchJSON(path) {
             return JSON.parse((await rtc.req("GET", path)).text);
+          },
+          async fetchText(path) {
+            return (await rtc.req("GET", path)).text;
           },
           async post(path, bodyObj) {
             const r = await rtc.req("POST", path, JSON.stringify(bodyObj));
@@ -3523,11 +3644,196 @@
       window.addEventListener(
         "keydown",
         (e) => {
+          if (omniOpen()) return; // omnibox owns the keyboard while open
           const mod = IS_MAC ? e.metaKey : e.altKey;
           if (!mod || (e.key !== "ArrowDown" && e.key !== "ArrowUp")) return;
           e.preventDefault();
           e.stopPropagation();
           stepSelection(e.key === "ArrowDown" ? 1 : -1);
+        },
+        true,
+      );
+
+      // ---- Cmd/Ctrl+K omnibox: search agents (title → output) or spawn here ----
+      let omniRows = []; // [{kind:'agent', entry, snippet?} | {kind:'spawn'}]
+      let omniIdx = 0;
+      let omniTailTimer = null;
+      let omniTailSeq = 0;
+      const omniOpen = () => $("omni").style.display !== "none";
+
+      function openOmni() {
+        $("omni").style.display = "flex";
+        const inp = $("omni-input");
+        inp.value = "";
+        inp.focus();
+        runOmni();
+      }
+      function closeOmni() {
+        if (omniTailTimer) clearTimeout(omniTailTimer);
+        omniTailSeq++; // cancel any in-flight tail search
+        $("omni").style.display = "none";
+      }
+
+      // The agent the spawn action is anchored to: the highlighted agent row, else
+      // the first agent result, else whatever's open in the console.
+      function omniAnchor() {
+        const hi = omniRows[omniIdx];
+        if (hi && hi.kind === "agent") return hi.entry;
+        const first = omniRows.find((r) => r.kind === "agent");
+        return first ? first.entry : entries.find((x) => x._key === sel) || null;
+      }
+
+      function renderOmni() {
+        const q = $("omni-input").value.trim();
+        if (omniIdx >= omniRows.length) omniIdx = Math.max(0, omniRows.length - 1);
+        const anchor = omniAnchor();
+        const html = omniRows
+          .map((r, i) => {
+            const sc = i === omniIdx ? " sel" : "";
+            if (r.kind === "spawn") {
+              return `<div class="omni-row omni-spawn${sc}" data-i="${i}">
+                <span class="dot active"></span>
+                <div class="omni-main">
+                  <div class="omni-title">✦ Spawn new ${esc(anchor?.cli || "claude")} agent here</div>
+                  <div class="omni-sub">${esc(anchor?.cwd || "(host default)")} &nbsp;·&nbsp; prompt: ${esc(q || "(empty)")}</div>
+                </div></div>`;
+            }
+            const e = r.entry;
+            const snip = r.snippet ? `<div class="omni-snip">…${r.snippet}…</div>` : "";
+            return `<div class="omni-row${sc}" data-i="${i}">
+              <span class="dot ${esc(e.status)}"></span>
+              <div class="omni-main">
+                <div class="omni-title">${esc(e.title || cliLabel(e) || ident(e) || "agent")}</div>
+                <div class="omni-sub">${esc((e.cli || "") + " · " + (e.cwd || ""))}</div>
+                ${snip}
+              </div></div>`;
+          })
+          .join("");
+        $("omni-results").innerHTML = html || `<div class="omni-empty">no matches</div>`;
+        const selrow = $("omni-results").querySelector(".omni-row.sel");
+        if (selrow) selrow.scrollIntoView({ block: "nearest" });
+      }
+
+      function runOmni() {
+        const q = $("omni-input").value.trim();
+        const toks = q.split(/\s+/).filter(Boolean);
+        // Tier 1 — instant title/identity match, ranked title-first then by recency.
+        const hits = entries
+          .filter((e) => (toks.length ? matches(e, toks) : true))
+          .sort(
+            (a, b) =>
+              omniScore(b, q) - omniScore(a, q) || (b.started_at || 0) - (a.started_at || 0),
+          )
+          .slice(0, 30);
+        omniRows = hits.map((entry) => ({ kind: "agent", entry }));
+        if (q) omniRows.push({ kind: "spawn" });
+        omniIdx = 0;
+        renderOmni();
+        // Tier 2 — debounced output (tail) search for alive agents not already shown.
+        if (omniTailTimer) clearTimeout(omniTailTimer);
+        if (q.length >= 2) omniTailTimer = setTimeout(() => omniTailSearch(q), 320);
+      }
+
+      async function omniTailSearch(q) {
+        const seq = ++omniTailSeq;
+        const have = new Set(omniRows.filter((r) => r.kind === "agent").map((r) => r.entry._key));
+        const ql = q.toLowerCase();
+        const cands = entries.filter((e) => !have.has(e._key) && e.status !== "exited").slice(0, 20);
+        await Promise.all(
+          cands.map(async (e) => {
+            const src = srcFor(e);
+            if (!src?.tx?.fetchText) return;
+            let text = "";
+            try {
+              text = await src.tx.fetchText(
+                "/api/read/" + encodeURIComponent(e.pid) + "?mode=tail&n=120",
+              );
+            } catch {
+              return;
+            }
+            if (seq !== omniTailSeq) return; // superseded or closed
+            const idx = text.toLowerCase().indexOf(ql);
+            if (idx < 0) return;
+            const raw = text
+              .slice(Math.max(0, idx - 24), idx + q.length + 24)
+              .replace(/\s+/g, " ")
+              .trim();
+            const li = raw.toLowerCase().indexOf(ql);
+            const snippet =
+              li >= 0
+                ? esc(raw.slice(0, li)) +
+                  "<b>" +
+                  esc(raw.slice(li, li + q.length)) +
+                  "</b>" +
+                  esc(raw.slice(li + q.length))
+                : esc(raw);
+            const at = omniRows.findIndex((r) => r.kind === "spawn");
+            const row = { kind: "agent", entry: e, snippet };
+            if (at >= 0) omniRows.splice(at, 0, row);
+            else omniRows.push(row);
+          }),
+        );
+        if (seq === omniTailSeq) renderOmni();
+      }
+
+      function omniMove(d) {
+        if (!omniRows.length) return;
+        omniIdx = (omniIdx + d + omniRows.length) % omniRows.length;
+        renderOmni();
+      }
+      async function omniActivate(forceSpawn) {
+        const q = $("omni-input").value.trim();
+        const row = omniRows[omniIdx];
+        if (forceSpawn || (row && row.kind === "spawn")) {
+          const anchor = omniAnchor();
+          closeOmni();
+          await spawnAndSelect(
+            { cli: anchor?.cli || "claude", cwd: anchor?.cwd || undefined, prompt: q || undefined },
+            anchor?._room,
+          );
+          return;
+        }
+        if (row && row.kind === "agent") {
+          closeOmni();
+          select(row.entry._key);
+        }
+      }
+
+      $("omni-input").addEventListener("input", runOmni);
+      $("omni-results").addEventListener("click", (ev) => {
+        const r = ev.target.closest(".omni-row");
+        if (!r) return;
+        omniIdx = +r.dataset.i;
+        omniActivate(false);
+      });
+      $("omni").addEventListener("mousedown", (ev) => {
+        if (ev.target === $("omni")) closeOmni(); // backdrop click closes
+      });
+      $("omni-input").addEventListener("keydown", (ev) => {
+        if (ev.key === "Escape") {
+          ev.preventDefault();
+          closeOmni();
+        } else if (ev.key === "ArrowDown") {
+          ev.preventDefault();
+          omniMove(1);
+        } else if (ev.key === "ArrowUp") {
+          ev.preventDefault();
+          omniMove(-1);
+        } else if (ev.key === "Enter") {
+          ev.preventDefault();
+          omniActivate(ev.metaKey || ev.ctrlKey);
+        }
+      });
+      // Cmd+K (Mac) / Ctrl+K (others) toggles the omnibox. Capture phase so it beats
+      // xterm's textarea handler and isn't forwarded to the agent as a keystroke.
+      window.addEventListener(
+        "keydown",
+        (e) => {
+          if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+            e.preventDefault();
+            e.stopPropagation();
+            omniOpen() ? closeOmni() : openOmni();
+          }
         },
         true,
       );

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -29,6 +29,7 @@ import {
   fitTransform,
   docTitle,
   statusGlyph,
+  omniScore,
 } from "../../lab/ui/console-logic.js";
 
 const agent = (over = {}) => ({
@@ -623,5 +624,30 @@ describe("docTitle", () => {
     expect(docTitle("   ")).toBe("agent-yes · console");
     expect(docTitle(null as any)).toBe("agent-yes · console");
     expect(docTitle(undefined as any)).toBe("agent-yes · console");
+  });
+});
+
+describe("omniScore", () => {
+  const e = (over: any) => ({ title: "", cwd: "", prompt: "", ...over });
+  it("ranks title hits above cwd/prompt hits", () => {
+    expect(omniScore(e({ title: "fix login" }), "fix")).toBeGreaterThan(
+      omniScore(e({ cwd: "/x/fix" }), "fix"),
+    );
+    expect(omniScore(e({ cwd: "/x/fix" }), "fix")).toBeGreaterThan(
+      omniScore(e({ prompt: "fix it" }), "fix"),
+    );
+  });
+  it("exact > startsWith > includes for titles", () => {
+    expect(omniScore(e({ title: "deploy" }), "deploy")).toBe(100);
+    expect(omniScore(e({ title: "deploy the app" }), "deploy")).toBe(80);
+    expect(omniScore(e({ title: "please deploy" }), "deploy")).toBe(60);
+  });
+  it("is case-insensitive and trims the query", () => {
+    expect(omniScore(e({ title: "Deploy" }), "  DEPLOY  ")).toBe(100);
+  });
+  it("returns 0 for no hit or empty query", () => {
+    expect(omniScore(e({ title: "abc" }), "xyz")).toBe(0);
+    expect(omniScore(e({ title: "abc" }), "")).toBe(0);
+    expect(omniScore(e({ title: "abc" }), "   ")).toBe(0);
   });
 });


### PR DESCRIPTION
**Cmd/Ctrl+K** opens an omnibox over the console.

## Search
- **Tier 1 (instant)** — match by title / identity / cwd / prompt (existing `matches()`), ranked **title-first** via the new pure `omniScore()`.
- **Tier 2 (debounced ~320ms)** — **output search**: fetch each alive candidate's tail (`/api/read?mode=tail&n=120`) via the new `tx.fetchText` and substring-match, appending results with a highlighted snippet. Degrades gracefully where a transport lacks `fetchText` (e.g. codehost).
- `↑↓` navigate · `⏎` open the highlighted agent · `esc`/backdrop close.

## Spawn here
A **`✦ Spawn new <cli> agent here`** row (and **`⌘⏎`** anywhere) spawns via the existing `spawnAndSelect` in the **highlighted agent's cwd**, using the **typed text as the prompt** — find a repo, launch a sibling task in one keystroke.

## Tests / verification
`omniScore` is pure + unit-tested (**80 ui-logic tests pass**). Verified live on a real room: Cmd+K opens; title + **output** matches render (query "serve" matched inside "server-authoritative"); the spawn row shows the anchor cwd + prompt. Clean load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)