### PR TITLE
fix(setup): brace ${RT} so the ellipsis isn't slurped into the var name

### DIFF
--- a/docs/shared-canvas.md
+++ b/docs/shared-canvas.md
@@ -113,7 +113,7 @@ Built defensively so the common single-viewer path is unchanged:
   not the basis.
 - **DEFERRED:** the full lease/"take control" UX + a visible driver indicator;
   `follow-cursor` and `100%+pan` modes (MVP ships `fit`); mouse-coordinate
-  correction for an interacting *watcher* under scale (drivers are scale ≈ 1, so
+  correction for an interacting _watcher_ under scale (drivers are scale ≈ 1, so
   unaffected); how the agent advertises size changes (poll now, push over the
   stream later).
 

--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -440,7 +440,7 @@ export function selSegments(sel, myLast, vy, myRows, peerCols, myCols) {
     rB = myLast - sel.fb,
     cA = sel.ca,
     cB = sel.cb;
-  if (rA > rB) ([rA, rB] = [rB, rA]), ([cA, cB] = [cB, cA]); // rA = top row
+  if (rA > rB) (([rA, rB] = [rB, rA]), ([cA, cB] = [cB, cA])); // rA = top row
   const segs = [];
   const from = Math.max(rA, vy),
     to = Math.min(rB, vy + myRows - 1);

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1489,7 +1489,10 @@
         />
         <div class="omni-results" id="omni-results"></div>
         <div class="omni-foot">
-          <span><b>↑↓</b> move &nbsp; <b>⏎</b> open &nbsp; <b>⌘⏎</b> spawn here &nbsp; <b>esc</b> close</span>
+          <span
+            ><b>↑↓</b> move &nbsp; <b>⏎</b> open &nbsp; <b>⌘⏎</b> spawn here &nbsp;
+            <b>esc</b> close</span
+          >
         </div>
       </div>
     </div>
@@ -2699,9 +2702,17 @@
           const sel = parseSel(p.sel);
           if (!sel) continue;
           const hue = hashHue(p.viewer);
-          const tag = esc(String(p.viewer).slice(0, 4)) + " " + (p.cols || "?") + "×" + (p.rows || "?");
+          const tag =
+            esc(String(p.viewer).slice(0, 4)) + " " + (p.cols || "?") + "×" + (p.rows || "?");
           let tagged = false;
-          for (const seg of selSegments(sel, myLast, vy, term.rows, p.cols || term.cols, term.cols)) {
+          for (const seg of selSegments(
+            sel,
+            myLast,
+            vy,
+            term.rows,
+            p.cols || term.cols,
+            term.cols,
+          )) {
             const vr = seg.row - vy; // our buffer row → our viewport row
             if (vr < 0 || vr > term.rows - 1) continue; // safety (selSegments already clips)
             const left = ox + seg.a * cw;
@@ -3740,7 +3751,9 @@
         const seq = ++omniTailSeq;
         const have = new Set(omniRows.filter((r) => r.kind === "agent").map((r) => r.entry._key));
         const ql = q.toLowerCase();
-        const cands = entries.filter((e) => !have.has(e._key) && e.status !== "exited").slice(0, 20);
+        const cands = entries
+          .filter((e) => !have.has(e._key) && e.status !== "exited")
+          .slice(0, 20);
         await Promise.all(
           cands.map(async (e) => {
             const src = srcFor(e);

--- a/lab/ui/setup.sh
+++ b/lab/ui/setup.sh
@@ -32,7 +32,7 @@ else
 fi
 
 # --- install ----------------------------------------------------------------
-say "Installing agent-yes with $RT…"
+say "Installing agent-yes with ${RT}…"
 # shellcheck disable=SC2086
 $PM agent-yes
 


### PR DESCRIPTION
Fixes the installer aborting with `RT?: unbound variable` (`?` = the terminal's rendering of `…`) when run via `curl https://agent-yes.com/setup.sh | bash` in a fresh shell.

## Cause
Line 35 had the raw multibyte ellipsis `…` (bytes `e2 80 a6`) immediately after `$RT`. In a non-UTF-8 / C locale — common in a fresh `curl | bash` shell — bash treats those high bytes as part of the identifier, looks up the unset var `RT…`, and aborts under `set -eu`.

## Fix
Brace the expansion (`${RT}…`) so the variable name is delimited. Reproduced the failure and verified the fix locally; the live `agent-yes.com/setup.sh` was already redeployed with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
