### PR TITLE
feat(openrouter): orcy alias + default GLM 5.2 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,10 @@ ZAI_API_KEY=... glm-yes -- help me with this code
 
 # Use OpenRouter directly — runs Claude Code against OpenRouter's
 # Anthropic-compatible endpoint. Set OPENROUTER_API_KEY first
-# (https://openrouter.ai/keys).
-OPENROUTER_API_KEY=... openrouter-yes -- help me with this code
+# (https://openrouter.ai/keys). `orcy` is the short alias
+# (openrouter-claude-yes) and defaults to the z-ai/glm-5.2 model
+# (override via ANTHROPIC_DEFAULT_*_MODEL or ~/.claude/settings.json).
+OPENROUTER_API_KEY=... orcy -- help me with this code
 
 # Use Pi directly — minimal multi-provider coding agent
 # (https://github.com/earendil-works/pi)

--- a/default.config.yaml
+++ b/default.config.yaml
@@ -169,6 +169,13 @@ clis:
       ANTHROPIC_BASE_URL: https://openrouter.ai/api
       ANTHROPIC_AUTH_TOKEN: ${OPENROUTER_API_KEY}
       ANTHROPIC_API_KEY: ""
+      # Default to GLM 5.2 (verified to work through OpenRouter's Anthropic skin).
+      # `${VAR:-default}` keeps it overridable: export ANTHROPIC_DEFAULT_*_MODEL or
+      # ANTHROPIC_MODEL (or set them in ~/.claude/settings.json) to use another
+      # OpenRouter slug. Reachable as `orcy` (openrouter-claude-yes).
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${ANTHROPIC_DEFAULT_SONNET_MODEL:-z-ai/glm-5.2}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${ANTHROPIC_DEFAULT_OPUS_MODEL:-z-ai/glm-5.2}
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: ${ANTHROPIC_DEFAULT_HAIKU_MODEL:-z-ai/glm-5.2}
     promptArg: last-arg
     systemPrompt: --append-system-prompt
     yesArgs:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "opencode-yes": "./dist/opencode-yes.js",
     "qwen-yes": "./dist/qwen-yes.js",
     "pi-yes": "./dist/pi-yes.js",
-    "openrouter-yes": "./dist/openrouter-yes.js"
+    "openrouter-yes": "./dist/openrouter-yes.js",
+    "orcy": "./dist/orcy.js"
   },
   "directories": {
     "doc": "docs"

--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -12,6 +12,8 @@ use tracing::{debug, info};
 /// Expand `${VAR}` references in `raw` against the current process environment.
 /// Sets `*unresolved = true` if any referenced variable is unset or empty, so
 /// callers can choose to skip the assignment rather than emit a blank value.
+/// `${VAR:-default}` falls back to `default` when VAR is unset/empty (and never
+/// marks the entry unresolved) — used for overridable defaults like the model.
 fn expand_env_vars(raw: &str, unresolved: &mut bool) -> String {
     let mut out = String::with_capacity(raw.len());
     let mut rest = raw;
@@ -19,10 +21,17 @@ fn expand_env_vars(raw: &str, unresolved: &mut bool) -> String {
         out.push_str(&rest[..start]);
         let after = &rest[start + 2..];
         if let Some(end) = after.find('}') {
-            let name = &after[..end];
+            let expr = &after[..end];
+            let (name, fallback) = match expr.split_once(":-") {
+                Some((n, d)) => (n, Some(d)),
+                None => (expr, None),
+            };
             match std::env::var(name) {
                 Ok(v) if !v.is_empty() => out.push_str(&v),
-                _ => *unresolved = true,
+                _ => match fallback {
+                    Some(d) => out.push_str(d),
+                    None => *unresolved = true,
+                },
             }
             rest = &after[end + 1..];
         } else {
@@ -446,6 +455,20 @@ mod tests {
         // Unterminated ${ is emitted literally and doesn't flag unresolved.
         let mut unresolved = false;
         assert_eq!(expand_env_vars("${oops", &mut unresolved), "${oops");
+        assert!(!unresolved);
+
+        // ${VAR:-default}: set var wins, unset var falls back, never unresolved.
+        let mut unresolved = false;
+        assert_eq!(
+            expand_env_vars("${AY_TEST_KEY:-fallback}", &mut unresolved),
+            "secret"
+        );
+        assert!(!unresolved);
+        let mut unresolved = false;
+        assert_eq!(
+            expand_env_vars("${AY_TEST_MISSING:-z-ai/glm-5.2}", &mut unresolved),
+            "z-ai/glm-5.2"
+        );
         assert!(!unresolved);
 
         std::env::remove_var("AY_TEST_KEY");

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -376,14 +376,21 @@ export default async function agentYes({
   // Inject per-CLI env (e.g. glm → Z.AI endpoint). Expand ${VAR} against the
   // launching env; skip entries whose vars are unset so we never blank out an
   // inherited value (e.g. ANTHROPIC_AUTH_TOKEN when ZAI_API_KEY isn't exported).
+  // `${VAR:-default}` falls back to `default` when VAR is unset/empty — used for
+  // overridable defaults like the model (openrouter → z-ai/glm-5.2).
   if (cliConf?.env) {
     for (const [key, raw] of Object.entries(cliConf.env)) {
       let unresolved = false;
-      const value = raw.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, name) => {
-        const v = ptyEnv[name];
-        if (v === undefined || v === "") unresolved = true;
-        return v ?? "";
-      });
+      const value = raw.replace(
+        /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g,
+        (_, name, fallback) => {
+          const v = ptyEnv[name];
+          if (v !== undefined && v !== "") return v;
+          if (fallback !== undefined) return fallback;
+          unresolved = true;
+          return "";
+        },
+      );
       if (unresolved) continue;
       ptyEnv[key] = value;
     }

--- a/ts/invokedCli.ts
+++ b/ts/invokedCli.ts
@@ -11,7 +11,8 @@
  */
 
 // Short aliases → target CLI. Must match the alias wrappers postbuild.ts emits.
-export const CLI_ALIASES: Record<string, string> = { cy: "claude" };
+// orcy = "openrouter-claude-yes" (claude binary routed through OpenRouter).
+export const CLI_ALIASES: Record<string, string> = { cy: "claude", orcy: "openrouter" };
 
 /**
  * The agent CLI implied by argv[1] (cy / claude-yes → "claude", codex-yes →

--- a/ts/postbuild.ts
+++ b/ts/postbuild.ts
@@ -13,7 +13,7 @@ const cliNames = [...Object.keys(CLIS_CONFIG), "agent"];
 const suffixes = ["-yes"];
 
 // Short aliases: maps alias name → target CLI name (alias resolves in parseCliArgs.ts)
-const shortAliases: Record<string, string> = { cy: "claude" };
+const shortAliases: Record<string, string> = { cy: "claude", orcy: "openrouter" };
 
 // Under Bun (dev via `bun link`), run TypeScript source directly — no build needed.
 // Under Node (published install or CI), use the compiled dist/cli.js.


### PR DESCRIPTION
Follow-up to #95 (clean branch off main).

- **`orcy`** (openrouter-claude-yes) short alias for the openrouter CLI — wired in `postbuild.ts` (bin wrapper) and `invokedCli.ts` (`CLI_ALIASES`), mirroring how `cy` aliases claude.
- **openrouter defaults to `z-ai/glm-5.2`** for the sonnet/opus/haiku tiers (verified to round-trip through OpenRouter's Anthropic-compatible endpoint).
- Per-CLI env expander gains **`${VAR:-default}`** syntax so the model is an *overridable* default: the user's own `ANTHROPIC_DEFAULT_*_MODEL` (or `~/.claude/settings.json`) wins, else glm-5.2. Implemented in both runtimes (`ts/index.ts` + `rs/src/pty_spawner.rs`) with unit tests.

## Verification
- `expand_env_vars` unit test covers `${VAR:-default}` (set wins / unset falls back).
- Live: `orcy` resolves to `--cli=openrouter`; injected env shows `ANTHROPIC_BASE_URL=https://openrouter.ai/api`, `ANTHROPIC_API_KEY=` (blanked), `ANTHROPIC_DEFAULT_{SONNET,OPUS}_MODEL=z-ai/glm-5.2`; a user-set `ANTHROPIC_DEFAULT_SONNET_MODEL` overrides while opus stays glm-5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)