### PR TITLE
feat(remote): CLI WebRTC client — ay remote over E2E DataChannel (#90)

### DIFF
--- a/ts/remotes.ts
+++ b/ts/remotes.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
 import yaml from "yaml";
+import { isWebrtcSpec } from "./webrtcLink.ts";
 
 function remotesPath(): string {
   const dir = process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes");
@@ -81,7 +82,6 @@ export function parseDirectRemoteSpec(
 export async function resolveRemoteSpec(spec: string): Promise<ResolvedRemote | null> {
   // Inline WebRTC share link: `ay ls webrtc://…` or `ay ls https://…/w/#room:token`.
   // These carry their own secret and have no keyword (use an alias to add one).
-  const { isWebrtcSpec } = await import("./webrtcRemote.ts");
   if (isWebrtcSpec(spec)) return resolveWebrtc(spec, undefined);
 
   const direct = parseDirectRemoteSpec(spec);
@@ -166,7 +166,6 @@ export async function cmdRemote(rest: string[]): Promise<number> {
       return 1;
     }
     // WebRTC share links carry their own secret — store verbatim (token in the link).
-    const { isWebrtcSpec } = await import("./webrtcRemote.ts");
     if (isWebrtcSpec(rawUrl)) {
       await writeRemoteAlias(alias, { url: rawUrl, token: "" });
       process.stdout.write(`remote '${alias}' added → ${rawUrl} (webrtc)\n`);

--- a/ts/remotes.ts
+++ b/ts/remotes.ts
@@ -79,6 +79,11 @@ export function parseDirectRemoteSpec(
  * Returns null if the spec doesn't match any remote.
  */
 export async function resolveRemoteSpec(spec: string): Promise<ResolvedRemote | null> {
+  // Inline WebRTC share link: `ay ls webrtc://…` or `ay ls https://…/w/#room:token`.
+  // These carry their own secret and have no keyword (use an alias to add one).
+  const { isWebrtcSpec } = await import("./webrtcRemote.ts");
+  if (isWebrtcSpec(spec)) return resolveWebrtc(spec, undefined);
+
   const direct = parseDirectRemoteSpec(spec);
   if (direct) {
     return { url: direct.baseUrl, token: direct.token, keyword: direct.keyword };
@@ -92,7 +97,20 @@ export async function resolveRemoteSpec(spec: string): Promise<ResolvedRemote | 
   const remotes = await readRemotes();
   const cfg = remotes.get(alias);
   if (!cfg) return null;
+  // A saved alias may point at a WebRTC link; bridge it just like an inline one.
+  if (isWebrtcSpec(cfg.url)) return resolveWebrtc(cfg.url, keyword);
   return { url: cfg.url, token: cfg.token, keyword };
+}
+
+/**
+ * Start a local HTTP↔WebRTC bridge for a share link and present it as an
+ * ordinary http remote, so every fetch-based remote command works unchanged.
+ * The bridge lives for the rest of the process (torn down on `process.exit`).
+ */
+async function resolveWebrtc(link: string, keyword?: string): Promise<ResolvedRemote> {
+  const { startWebrtcBridge } = await import("./webrtcRemote.ts");
+  const bridge = await startWebrtcBridge(link);
+  return { url: bridge.baseUrl, token: bridge.token, keyword };
 }
 
 // ---------------------------------------------------------------------------
@@ -108,7 +126,9 @@ export async function cmdRemote(rest: string[]): Promise<number> {
         `Manage saved remote server aliases.\n\n` +
         `Subcommands:\n` +
         `  ay remote ls                                           list configured remotes\n` +
-        `  ay remote add <alias> http://<token>@<host>:<port>    add a remote\n` +
+        `  ay remote add <alias> http://<token>@<host>:<port>    add an http remote\n` +
+        `  ay remote add <alias> webrtc://<room>:<token>@<host>  add a WebRTC share remote\n` +
+        `  ay remote add <alias> https://agent-yes.com/w/#<room>:<token>   (share link form)\n` +
         `  ay remote rm <alias>                                   remove a remote\n\n` +
         `Once added, use the alias anywhere a keyword is accepted:\n` +
         `  ay ls   <alias>\n` +
@@ -144,6 +164,14 @@ export async function cmdRemote(rest: string[]): Promise<number> {
         "  example: ay remote add work-mac http://mytoken123@192.168.1.5:7432\n",
       );
       return 1;
+    }
+    // WebRTC share links carry their own secret — store verbatim (token in the link).
+    const { isWebrtcSpec } = await import("./webrtcRemote.ts");
+    if (isWebrtcSpec(rawUrl)) {
+      await writeRemoteAlias(alias, { url: rawUrl, token: "" });
+      process.stdout.write(`remote '${alias}' added → ${rawUrl} (webrtc)\n`);
+      process.stderr.write(`\n  ay ls ${alias}            # list agents on ${alias}\n`);
+      return 0;
     }
     let url: string, token: string;
     try {

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -32,6 +32,7 @@ import { invokedCliName } from "./invokedCli.ts";
 import type { AgentCliConfig } from "./index.ts";
 import yargs from "yargs";
 import { type ResolvedRemote, readRemotes, resolveRemoteSpec } from "./remotes.ts";
+import { isWebrtcSpec } from "./webrtcLink.ts";
 
 // ---------------------------------------------------------------------------
 // notes store  (~/.agent-yes/notes.jsonl)
@@ -868,10 +869,10 @@ async function fetchRemoteRecordsRaw(
   // WebRTC remotes have no http port — bridge them, then fetch the loopback URL.
   let bridge: { baseUrl: string; token: string; close: () => void } | null = null;
   try {
-    const { isWebrtcSpec, startWebrtcBridge } = await import("./webrtcRemote.ts");
     let base = url;
     let bearer = token;
     if (isWebrtcSpec(url)) {
+      const { startWebrtcBridge } = await import("./webrtcRemote.ts");
       bridge = await startWebrtcBridge(url);
       base = bridge.baseUrl;
       bearer = bridge.token;

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -865,15 +865,27 @@ async function fetchRemoteRecordsRaw(
   if (opts.all) params.set("all", "1");
   if (opts.active) params.set("active", "1");
   if (opts.keyword) params.set("keyword", opts.keyword);
+  // WebRTC remotes have no http port — bridge them, then fetch the loopback URL.
+  let bridge: { baseUrl: string; token: string; close: () => void } | null = null;
   try {
-    const res = await fetch(`${url}/api/ls?${params}`, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(5000),
+    const { isWebrtcSpec, startWebrtcBridge } = await import("./webrtcRemote.ts");
+    let base = url;
+    let bearer = token;
+    if (isWebrtcSpec(url)) {
+      bridge = await startWebrtcBridge(url);
+      base = bridge.baseUrl;
+      bearer = bridge.token;
+    }
+    const res = await fetch(`${base}/api/ls?${params}`, {
+      headers: { Authorization: `Bearer ${bearer}` },
+      signal: AbortSignal.timeout(8000),
     });
     if (!res.ok) return [];
     return (await res.json()) as any[];
   } catch {
     return [];
+  } finally {
+    bridge?.close();
   }
 }
 

--- a/ts/webrtcLink.spec.ts
+++ b/ts/webrtcLink.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SIGHOST, isWebrtcSpec, parseWebrtcLink } from "./webrtcLink.ts";
+
+// A representative v2 share secret (e1.<64 hex>); parseSecret keeps the hex `s`.
+const SECRET = "e1.982610a3034f065bfe9700037b306a6afeb7dc48567064058e6c4bbc09e502c2";
+
+describe("isWebrtcSpec", () => {
+  it("accepts webrtc:// links", () => {
+    expect(isWebrtcSpec(`webrtc://r1:${SECRET}@s.agent-yes.com`)).toBe(true);
+  });
+  it("accepts https share links (have a # fragment)", () => {
+    expect(isWebrtcSpec(`https://agent-yes.com/w/#r1:${SECRET}`)).toBe(true);
+    expect(isWebrtcSpec(`http://localhost:8080/w/#r1:${SECRET}`)).toBe(true);
+  });
+  it("rejects http remotes and bare aliases", () => {
+    expect(isWebrtcSpec("token@192.168.1.5:7432")).toBe(false);
+    expect(isWebrtcSpec("work-mac")).toBe(false);
+    expect(isWebrtcSpec("work-mac:claude")).toBe(false);
+    expect(isWebrtcSpec("http://192.168.1.5:7432")).toBe(false); // no fragment
+  });
+});
+
+describe("parseWebrtcLink", () => {
+  it("parses webrtc://room:token@host", () => {
+    const r = parseWebrtcLink(`webrtc://r223104:${SECRET}@example.com`);
+    expect(r).toEqual({ room: "r223104", s: expect.any(String), host: "example.com" });
+    expect(r!.s.length).toBeGreaterThan(0);
+  });
+
+  it("parses an https share link and defaults the signaling host", () => {
+    const r = parseWebrtcLink(`https://agent-yes.com/w/#r223104:${SECRET}`);
+    expect(r).toMatchObject({ room: "r223104", host: DEFAULT_SIGHOST });
+  });
+
+  it("honors an explicit @sighost in the fragment", () => {
+    const r = parseWebrtcLink(`https://agent-yes.com/w/#r1:${SECRET}@sig.example.com`);
+    expect(r).toMatchObject({ room: "r1", host: "sig.example.com" });
+  });
+
+  it("returns null for non-share strings and malformed fragments", () => {
+    expect(parseWebrtcLink("token@host:7432")).toBeNull();
+    expect(parseWebrtcLink("just-an-alias")).toBeNull();
+    expect(parseWebrtcLink("https://agent-yes.com/w/#noColonHere")).toBeNull();
+  });
+});

--- a/ts/webrtcLink.ts
+++ b/ts/webrtcLink.ts
@@ -1,0 +1,45 @@
+// Pure parsing/detection for WebRTC share links. Kept free of node-datachannel
+// (the native WebRTC dep) so callers — and resolveRemoteSpec on every remote
+// command — can detect/parse a link without loading the native module, and so
+// the helpers stay unit-testable. The actual connection lives in webrtcRemote.ts.
+import { parseSecret } from "../lab/ui/e2e.js";
+
+export const SIGNAL_SUBPROTOCOL = "ay-signal-1";
+export const DEFAULT_SIGHOST = "s.agent-yes.com";
+
+export interface WebrtcLink {
+  room: string;
+  s: string;
+  host: string;
+}
+
+/**
+ * Parse a share link into { room, secret, signaling-host }. Accepts:
+ *   webrtc://<room>:<token>@<host>
+ *   https://<anyhost>/w/#<room>:<token>            (signaling host defaults to s.agent-yes.com)
+ *   https://<anyhost>/w/#<room>:<token>@<sighost>  (explicit signaling host)
+ * Returns null if the string isn't a recognizable share link.
+ */
+export function parseWebrtcLink(link: string): WebrtcLink | null {
+  const wr = /^webrtc:\/\/([^:]+):([^@]+)@(.+)$/.exec(link);
+  if (wr) {
+    const { s } = parseSecret(wr[2]!);
+    return { room: wr[1]!, s, host: wr[3]! };
+  }
+  if (/^https?:\/\//.test(link) && link.includes("#")) {
+    const frag = link.split("#")[1] ?? "";
+    const at = frag.split("@");
+    const host = at[1] || DEFAULT_SIGHOST;
+    const seg = at[0]!;
+    const i = seg.indexOf(":");
+    if (i < 0) return null;
+    const { s } = parseSecret(seg.slice(i + 1));
+    return { room: seg.slice(0, i), s, host };
+  }
+  return null;
+}
+
+/** True if `spec` looks like a WebRTC share link (vs. an http remote or alias). */
+export function isWebrtcSpec(spec: string): boolean {
+  return spec.startsWith("webrtc://") || (/^https?:\/\//.test(spec) && spec.includes("#"));
+}

--- a/ts/webrtcRemote.ts
+++ b/ts/webrtcRemote.ts
@@ -17,51 +17,15 @@ import {
   open as e2eOpen,
   packEnvelope,
   unpackEnvelope,
-  parseSecret,
   randomHex,
   FLAG_CONFIRM,
 } from "../lab/ui/e2e.js";
+import { SIGNAL_SUBPROTOCOL as SUB, parseWebrtcLink, type WebrtcLink } from "./webrtcLink.ts";
 
-const SUB = "ay-signal-1";
-const DEFAULT_SIGHOST = "s.agent-yes.com";
+export { isWebrtcSpec, parseWebrtcLink } from "./webrtcLink.ts";
+export type { WebrtcLink } from "./webrtcLink.ts";
+
 const CONNECT_TIMEOUT_MS = 25_000;
-
-export interface WebrtcLink {
-  room: string;
-  s: string;
-  host: string;
-}
-
-/**
- * Parse a share link into { room, secret, signaling-host }. Accepts:
- *   webrtc://<room>:<token>@<host>
- *   https://<anyhost>/w/#<room>:<token>            (signaling host defaults to s.agent-yes.com)
- *   https://<anyhost>/w/#<room>:<token>@<sighost>  (explicit signaling host)
- * Returns null if the string isn't a recognizable share link.
- */
-export function parseWebrtcLink(link: string): WebrtcLink | null {
-  const wr = /^webrtc:\/\/([^:]+):([^@]+)@(.+)$/.exec(link);
-  if (wr) {
-    const { s } = parseSecret(wr[2]!);
-    return { room: wr[1]!, s, host: wr[3]! };
-  }
-  if (/^https?:\/\//.test(link) && link.includes("#")) {
-    const frag = link.split("#")[1] ?? "";
-    const at = frag.split("@");
-    const host = at[1] || DEFAULT_SIGHOST;
-    const seg = at[0]!;
-    const i = seg.indexOf(":");
-    if (i < 0) return null;
-    const { s } = parseSecret(seg.slice(i + 1));
-    return { room: seg.slice(0, i), s, host };
-  }
-  return null;
-}
-
-/** True if `spec` looks like a WebRTC share link (vs. an http remote or alias). */
-export function isWebrtcSpec(spec: string): boolean {
-  return spec.startsWith("webrtc://") || (/^https?:\/\//.test(spec) && spec.includes("#"));
-}
 
 interface PendingReq {
   onRes: (status: number, ct: string) => void;

--- a/ts/webrtcRemote.ts
+++ b/ts/webrtcRemote.ts
@@ -1,0 +1,316 @@
+// CLI WebRTC remote: dial an `ay serve --share` room as a CLIENT peer over an
+// end-to-end-encrypted WebRTC DataChannel, then expose it as a local HTTP
+// endpoint (the "bridge") so every existing fetch-based remote command — ls,
+// send, status, and streaming `tail -f` — works unchanged against a remote host
+// that has no reachable HTTP port.
+//
+// The host side lives in ts/share.ts; this is its inverse. The host offers and
+// responds; we answer and request. Crypto is reused verbatim from lab/ui/e2e.js
+// so the AES-GCM / transcript-hash handshake is byte-identical to the browser
+// console and the host.
+import { RTCPeerConnection } from "node-datachannel/polyfill";
+import {
+  deriveAuthToken,
+  deriveDirKeys,
+  computeTranscriptHash,
+  seal as e2eSeal,
+  open as e2eOpen,
+  packEnvelope,
+  unpackEnvelope,
+  parseSecret,
+  randomHex,
+  FLAG_CONFIRM,
+} from "../lab/ui/e2e.js";
+
+const SUB = "ay-signal-1";
+const DEFAULT_SIGHOST = "s.agent-yes.com";
+const CONNECT_TIMEOUT_MS = 25_000;
+
+export interface WebrtcLink {
+  room: string;
+  s: string;
+  host: string;
+}
+
+/**
+ * Parse a share link into { room, secret, signaling-host }. Accepts:
+ *   webrtc://<room>:<token>@<host>
+ *   https://<anyhost>/w/#<room>:<token>            (signaling host defaults to s.agent-yes.com)
+ *   https://<anyhost>/w/#<room>:<token>@<sighost>  (explicit signaling host)
+ * Returns null if the string isn't a recognizable share link.
+ */
+export function parseWebrtcLink(link: string): WebrtcLink | null {
+  const wr = /^webrtc:\/\/([^:]+):([^@]+)@(.+)$/.exec(link);
+  if (wr) {
+    const { s } = parseSecret(wr[2]!);
+    return { room: wr[1]!, s, host: wr[3]! };
+  }
+  if (/^https?:\/\//.test(link) && link.includes("#")) {
+    const frag = link.split("#")[1] ?? "";
+    const at = frag.split("@");
+    const host = at[1] || DEFAULT_SIGHOST;
+    const seg = at[0]!;
+    const i = seg.indexOf(":");
+    if (i < 0) return null;
+    const { s } = parseSecret(seg.slice(i + 1));
+    return { room: seg.slice(0, i), s, host };
+  }
+  return null;
+}
+
+/** True if `spec` looks like a WebRTC share link (vs. an http remote or alias). */
+export function isWebrtcSpec(spec: string): boolean {
+  return spec.startsWith("webrtc://") || (/^https?:\/\//.test(spec) && spec.includes("#"));
+}
+
+interface PendingReq {
+  onRes: (status: number, ct: string) => void;
+  onData: (chunk: string) => void;
+  onEnd: (error?: string) => void;
+}
+
+/** A live, key-confirmed WebRTC connection to a single share room. */
+class WebRtcConn {
+  private ws: WebSocket;
+  private pc: any = null;
+  private dc: any = null;
+  private readonly send = { sendCtr: 0n };
+  private readonly recv = { lastSeen: -1n };
+  private keyC2H: CryptoKey | null = null; // client encrypts host-bound frames
+  private keyH2C: CryptoKey | null = null; // client decrypts host-sent frames
+  private th: Uint8Array | null = null;
+  private hostPeer: string | null = null;
+  private readonly myNonce = randomHex(16);
+  private confirmedIn = false;
+  private confirmedOut = false;
+  private confirmed = false;
+  private sendChain: Promise<void> = Promise.resolve();
+  private recvChain: Promise<void> = Promise.resolve();
+  private idCounter = 0;
+  private readonly pending = new Map<string, PendingReq>();
+
+  readonly ready: Promise<void>;
+  private resolveReady!: () => void;
+  private rejectReady!: (e: Error) => void;
+
+  constructor(private readonly link: WebrtcLink) {
+    this.ready = new Promise<void>((res, rej) => {
+      this.resolveReady = res;
+      this.rejectReady = rej;
+    });
+    const timer = setTimeout(
+      () => this.rejectReady(new Error(`WebRTC connect timeout after ${CONNECT_TIMEOUT_MS}ms`)),
+      CONNECT_TIMEOUT_MS,
+    );
+    this.ready.then(
+      () => clearTimeout(timer),
+      () => clearTimeout(timer),
+    );
+    this.ws = this.dial();
+  }
+
+  private dial(): WebSocket {
+    const { room, host } = this.link;
+    const ws = new WebSocket(`wss://${host}/${room}`, [SUB]);
+    ws.onopen = async () => {
+      const authToken = await deriveAuthToken(this.link.s, room, host);
+      ws.send(JSON.stringify({ type: "hello", role: "client", v: 2, token: authToken }));
+    };
+    ws.onerror = (e: any) =>
+      this.rejectReady(new Error(`signaling error: ${String(e?.message ?? e)}`));
+    ws.onclose = () => {
+      if (!this.confirmed) this.rejectReady(new Error("signaling closed before connect"));
+    };
+    ws.onmessage = (ev: any) => void this.onSignal(ev);
+    return ws;
+  }
+
+  private async onSignal(ev: any): Promise<void> {
+    const m = JSON.parse(typeof ev.data === "string" ? ev.data : await ev.data.text());
+    if (m.type === "offer") {
+      this.hostPeer = m.from;
+      const pc = new RTCPeerConnection({ iceServers: m.iceServers || [] });
+      this.pc = pc;
+      pc.onicecandidate = (e: any) => {
+        if (e.candidate)
+          this.ws.send(
+            JSON.stringify({ type: "candidate", to: this.hostPeer, candidate: e.candidate }),
+          );
+      };
+      pc.ondatachannel = (e: any) => {
+        const dc = e.channel;
+        this.dc = dc;
+        dc.binaryType = "arraybuffer";
+        dc.onopen = () => this.enqueueSeal(FLAG_CONFIRM, { t: "confirm", nonce: this.myNonce });
+        dc.onmessage = (ev2: any) => {
+          this.recvChain = this.recvChain.then(() => this.onFrame(ev2.data)).catch(() => {});
+        };
+      };
+      await pc.setRemoteDescription({ type: "offer", sdp: m.sdp });
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+      this.th = await computeTranscriptHash(m.sdp, pc.localDescription.sdp);
+      const keys = await deriveDirKeys(this.link.s, this.th);
+      this.keyC2H = keys.keyC2H;
+      this.keyH2C = keys.keyH2C;
+      this.ws.send(JSON.stringify({ type: "answer", to: this.hostPeer, sdp: pc.localDescription.sdp }));
+    } else if (m.type === "candidate" && this.pc) {
+      await this.pc.addIceCandidate(m.candidate).catch(() => {});
+    }
+  }
+
+  private enqueueSeal(flags: number, obj: object): Promise<void> {
+    this.sendChain = this.sendChain.then(async () => {
+      if (!this.dc || this.dc.readyState !== "open" || !this.keyC2H || !this.th) return;
+      const frame = await e2eSeal(this.keyC2H, this.send, flags, this.th, packEnvelope(obj));
+      try {
+        this.dc.send(frame);
+      } catch {}
+    });
+    return this.sendChain;
+  }
+
+  private async onFrame(data: any): Promise<void> {
+    if (typeof data === "string" || !this.keyH2C || !this.th) return;
+    let env: any;
+    try {
+      const { plaintext } = await e2eOpen(this.keyH2C, data, this.th, this.recv);
+      env = unpackEnvelope(plaintext);
+    } catch {
+      return; // drop undecryptable frames
+    }
+    if (!this.confirmed) {
+      if (!env || env.t !== "confirm") return;
+      if (typeof env.nonce === "string" && !this.confirmedOut) {
+        await this.enqueueSeal(FLAG_CONFIRM, { t: "confirm", nonce: this.myNonce, echo: env.nonce });
+        this.confirmedOut = true;
+      }
+      if (env.echo && env.echo === this.myNonce) this.confirmedIn = true;
+      if (this.confirmedIn && this.confirmedOut) {
+        this.confirmed = true;
+        this.resolveReady();
+      }
+      return;
+    }
+    if (!env || env.t === "confirm") return;
+    const p = this.pending.get(env.id);
+    if (!p) return;
+    if (env.t === "res") p.onRes(env.status, env.ct);
+    else if (env.t === "data") p.onData(env.chunk);
+    else if (env.t === "end") p.onEnd(env.error);
+  }
+
+  /**
+   * Issue one request over the channel. Resolves once the response head (status,
+   * content-type) arrives; the body is a ReadableStream fed by `data` frames as
+   * they land, so streaming endpoints (SSE `tail`) flow without buffering.
+   */
+  request(
+    method: string,
+    path: string,
+    body?: string,
+  ): Promise<{ status: number; ct: string; stream: ReadableStream<Uint8Array> }> {
+    const id = String(++this.idCounter);
+    return new Promise((resolve, reject) => {
+      let controller: ReadableStreamDefaultController<Uint8Array>;
+      const enc = new TextEncoder();
+      let head = false;
+      const stream = new ReadableStream<Uint8Array>({
+        start: (c) => {
+          controller = c;
+        },
+        cancel: () => {
+          this.pending.delete(id);
+          void this.enqueueSeal(0, { t: "abort", id });
+        },
+      });
+      this.pending.set(id, {
+        onRes: (status, ct) => {
+          if (!head) {
+            head = true;
+            resolve({ status, ct, stream });
+          }
+        },
+        onData: (chunk) => {
+          try {
+            controller.enqueue(enc.encode(chunk));
+          } catch {}
+        },
+        onEnd: (error) => {
+          this.pending.delete(id);
+          if (error) {
+            if (!head) {
+              head = true;
+              reject(new Error(error));
+            }
+            try {
+              controller.error(new Error(error));
+            } catch {}
+          } else {
+            try {
+              controller.close();
+            } catch {}
+          }
+        },
+      });
+      void this.enqueueSeal(0, { t: "req", id, method, path, body });
+    });
+  }
+
+  close(): void {
+    try {
+      this.ws.close();
+    } catch {}
+    try {
+      this.pc?.close();
+    } catch {}
+  }
+}
+
+export interface WebrtcBridge {
+  baseUrl: string;
+  token: string;
+  close: () => void;
+}
+
+/**
+ * Connect to a share room and start a local HTTP server that forwards every
+ * request over the encrypted DataChannel. Returns the loopback base URL the
+ * existing remote commands can `fetch()` against. The process owns teardown:
+ * `ay` subcommands `process.exit()` when done, which closes the socket/peer.
+ */
+export async function startWebrtcBridge(link: string): Promise<WebrtcBridge> {
+  const parsed = parseWebrtcLink(link);
+  if (!parsed) throw new Error(`not a WebRTC share link: ${link}`);
+  const conn = new WebRtcConn(parsed);
+  await conn.ready;
+
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    idleTimeout: 0, // streaming tail can idle indefinitely between log lines
+    async fetch(req: Request) {
+      const u = new URL(req.url);
+      const pathWithQuery = u.pathname + u.search;
+      const hasBody = req.method !== "GET" && req.method !== "HEAD";
+      const body = hasBody ? await req.text() : undefined;
+      try {
+        const { status, ct, stream } = await conn.request(req.method, pathWithQuery, body);
+        return new Response(stream, { status, headers: ct ? { "content-type": ct } : {} });
+      } catch (e: any) {
+        return new Response(String(e?.message ?? e), { status: 502 });
+      }
+    },
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${server.port}`,
+    token: "webrtc", // auth is the E2E secret; the host injects its own bearer
+    close: () => {
+      try {
+        server.stop(true);
+      } catch {}
+      conn.close();
+    },
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -64,6 +64,11 @@ export default defineConfig({
         // WebRTC share bridge — needs a peer + signaling server; proven e2e, not
         // unit-testable.
         "ts/share.ts",
+        // WebRTC remote client/bridge — the inverse of share.ts; needs a live
+        // peer + signaling server + DataChannel. Pure helpers (parseWebrtcLink /
+        // isWebrtcSpec) are unit-tested in webrtcRemote.spec.ts; the connection
+        // and HTTP bridge are integration-only (same rationale as share.ts).
+        "ts/webrtcRemote.ts",
         // Guided onboarding — the workspace-setting path is unit-tested
         // (setup.spec.ts); the TTY prompt and the daemon install it delegates to
         // are integration-only.


### PR DESCRIPTION
Closes #90.

## What
A CLI WebRTC client so `ay` can reach a host that has **no reachable HTTP port** — over the same E2E-encrypted WebRTC DataChannel the browser console uses.

```
ay ls   webrtc://<room>:<token>@<host>
ay ls   https://agent-yes.com/w/#<room>:<token>
ay remote add room <share-link>
ay ls room   ·   ay status room:kw   ·   ay tail room:kw [-f]   ·   ay send room:kw "…"
```

## How
- **`ts/webrtcRemote.ts`** — dials the room as a *client* peer (mirror of the host in `ts/share.ts`: host offers + responds, we answer + request). Crypto is reused **verbatim** from `lab/ui/e2e.js`, so the AES-256-GCM / transcript-hash key-confirmation handshake is byte-identical to the browser console and the host.
- **Local HTTP↔WebRTC bridge** — once connected, it starts a `127.0.0.1` server that forwards every request over the DataChannel. This means **every existing fetch-based remote command works unchanged**, including streaming: the host's `res`→`data`*→`end` frames are piped into a `ReadableStream`, so SSE `tail -f` flows without buffering.
- **`ts/remotes.ts`** — `resolveRemoteSpec` and `ay remote add` detect share links (inline or saved alias) and bridge them transparently; `--all-remotes` bridges saved WebRTC aliases too.
- Bridge teardown rides on the existing `process.exit` in the subcommand dispatch path.

## Verified end-to-end against a live room
`ls`, alias `ls`, `status` (returned a live `needs_input` question), static `tail`, and **streaming `tail -f`** (5.9 KB of live screen streamed) — in both source and the bundled `dist` (runs under Bun). `send` rides the identical `remotePost`→bridge path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)