### PR TITLE
test(ui-dom): complete the xterm Terminal stub so select() doesn't throw

### DIFF
--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -16,13 +16,21 @@ import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import { startServer } from "./server.ts";
 
 // Stub the two xterm CDN scripts so creating a Terminal never touches the
-// network. Only the methods the console calls are implemented.
+// network. EVERY method the console calls on a Terminal must exist here, or the
+// select() flow throws partway through and later wiring (e.g. onData) never runs
+// — which silently times out the keystroke tests. Keep this in lockstep with the
+// `term.*` calls in lab/ui/index.html.
 // onData captures the keystroke handler on window so a test can drive it (xterm
 // would normally call it from real key events, which the stub can't synthesize).
+// open(el) records the container as `element` so the right-click-to-copy
+// contextmenu listener (term.element?.addEventListener) has something to bind to;
+// the selection getters report "no selection" so that handler is a harmless no-op.
 const TERMINAL_STUB =
-  "window.Terminal=class{constructor(){this.cols=80;this.rows=24;}" +
-  "loadAddon(){}open(){}focus(){}onTitleChange(){}onResize(){}onData(f){window.__onData=f;}" +
-  "onBinary(){}write(){}resize(c,r){this.cols=c;this.rows=r;}dispose(){}};";
+  "window.Terminal=class{constructor(){this.cols=80;this.rows=24;this.element=null;}" +
+  "loadAddon(){}open(el){this.element=el;}focus(){}onTitleChange(){}onResize(){}onScroll(){}" +
+  "onData(f){window.__onData=f;}onBinary(){}write(){}resize(c,r){this.cols=c;this.rows=r;}" +
+  "hasSelection(){return false;}getSelection(){return '';}getSelectionPosition(){return null;}" +
+  "clearSelection(){}dispose(){}};";
 const FITADDON_STUB = "window.FitAddon={FitAddon:class{activate(){}dispose(){}fit(){}}};";
 
 async function openConsole(


### PR DESCRIPTION
## Problem

The hermetic `ui-dom` Playwright test stubs `window.Terminal`, but the stub had drifted from the real console (`lab/ui/index.html`). It was missing **`onScroll()`** — which `select()` calls right before `term.onData()`. With `onScroll` undefined, selecting an agent threw mid-`select()`, so `window.__onData` was never captured and the keystroke tests timed out (30s each).

This is why the **`ui-dom` check had been red on `main` for days** (and showed red on #101 — verified pre-existing, not caused by that PR).

## Fix

Bring the stub in lockstep with every `term.*` call the console makes:
- Add `onScroll()`.
- Add the selection API the real code uses: `hasSelection()` → `false`, `getSelection()` → `''`, `getSelectionPosition()` → `null`, `clearSelection()`.
- `open(el)` now records the container as `element`, so the new right-click-to-copy contextmenu listener (`term.element?.addEventListener`) has a bind target; the selection getters report "no selection" so the handler is a harmless no-op under test.

## Result

All **12 ui-dom tests pass** locally (the keystroke test that timed out at 30s now runs in ~250ms). Reviewed by codex (LGTM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)