### PR TITLE
feat(serve): spawn agents from a GitHub URL/branch via codehost/provision

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -4245,6 +4245,7 @@
         const before = new Set(entries.filter((e) => e._room === target.id).map((e) => e.pid));
         const res = await target.tx.post("/api/spawn", {
           cli: spec.cli || "claude",
+          from: spec.from || undefined,
           cwd: spec.cwd || undefined,
           prompt: spec.prompt || undefined,
         });
@@ -4296,7 +4297,8 @@
         $("newform").innerHTML = `<div class="lcard">
       <div class="ltitle">New agent · ${esc(where)}</div>
       <div class="nfield"><label>CLI</label><input id="nf-cli" value="claude" spellcheck="false" autocapitalize="off" /></div>
-      <div class="nfield"><label>Working dir</label><input id="nf-cwd" value="${esc(cwd)}" placeholder="(host default)" spellcheck="false" autocapitalize="off" /></div>
+      <div class="nfield"><label>Spawn from — optional</label><input id="nf-from" placeholder="github URL / owner/repo@branch — provisions a worktree" spellcheck="false" autocapitalize="off" /></div>
+      <div class="nfield"><label>Working dir</label><input id="nf-cwd" value="${esc(cwd)}" placeholder="(host default — ignored when Spawn from is set)" spellcheck="false" autocapitalize="off" /></div>
       <div class="nfield"><label>Prompt — optional</label><textarea id="nf-prompt" rows="3" placeholder="initial message to send the agent…"></textarea></div>
       <div class="lrow">
         <button class="lfleet" id="nf-go">▷ Launch</button>
@@ -4312,6 +4314,7 @@
         if (!go || go.disabled) return;
         const spec = {
           cli: ($("nf-cli").value || "claude").trim(),
+          from: $("nf-from")?.value.trim() || "",
           cwd: $("nf-cwd").value.trim(),
           prompt: $("nf-prompt").value,
         };
@@ -4320,7 +4323,7 @@
         // target fleet. A 2nd `claude -c` in the same repo fights over the same
         // session/files and usually exits on startup — which looks like "the new
         // agent never appears". Let the user pick a different dir or proceed.
-        if (spec.cwd) {
+        if (spec.cwd && !spec.from) {
           await loadList();
           const norm = (p) => (p || "").replace(/\/+$/, "");
           const busy = entries.some(

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -21,8 +21,32 @@ import { updateGlobalPidStatus } from "./globalPidIndex.ts";
 import { pgidForWrapper } from "./reaper.ts";
 import { SUPPORTED_CLIS } from "./SUPPORTED_CLIS.ts";
 import { getInstalledPackage } from "./versionChecker.ts";
+import { getProvisionRoot, isProvisionAllowed, resolveSpawnCwd } from "./workspaceConfig.ts";
 
 const DEFAULT_PORT = 7432;
+
+/**
+ * Normalize a user-supplied GitHub-ish source into the standard
+ * `<owner>/<repo>/tree/<branch>` path that codehost/provision's `parseSpec`
+ * understands. Interim fallback used only when the linked codehost build
+ * predates `parseSource` (the canonical normalizer in the standard):
+ *   https://github.com/o/r/tree/b · github.com/o/r/tree/b · o/r/tree/b
+ *   o/r@branch · o/r (→ default branch main)
+ */
+function normalizeGithubSource(s: string): string {
+  let v = s
+    .trim()
+    .replace(/^https?:\/\//, "")
+    .replace(/^github\.com\//, "");
+  v = v
+    .replace(/[?#].*$/, "")
+    .replace(/\.git$/, "")
+    .replace(/^\/+|\/+$/g, "");
+  const at = v.match(/^([^/]+)\/([^/@]+)@(.+)$/);
+  if (at) return `${at[1]}/${at[2]}/tree/${at[3]}`;
+  if (/^[^/]+\/[^/]+$/.test(v)) return `${v}/tree/main`;
+  return v;
+}
 
 function agentYesHome(): string {
   return process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes");
@@ -1448,9 +1472,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
       return Response.json(live);
     }
 
-    // POST /api/spawn  body {cli, cwd, prompt} — launch a new agent
+    // POST /api/spawn  body {cli, cwd?, from?, prompt?} — launch a new agent.
+    // `from` (a GitHub URL / owner/repo@branch / owner/repo/tree/branch) is
+    // resolved to a ready worktree via codehost/provision (the shared workspace
+    // standard); otherwise `cwd` is resolved against the workspace root and
+    // created if missing (Layer-0 plain-dir provisioning — no more ENOENT 500).
     if (req.method === "POST" && p === "/api/spawn") {
-      let body: { cli?: string; cwd?: string; prompt?: string };
+      let body: { cli?: string; cwd?: string; from?: string; prompt?: string };
       try {
         body = (await req.json()) as typeof body;
       } catch {
@@ -1459,10 +1487,73 @@ export async function cmdServe(rest: string[]): Promise<number> {
       const cli = String(body.cli ?? "claude");
       if (!SUPPORTED_CLIS.includes(cli as never))
         return new Response(`unsupported cli: ${cli}`, { status: 400 });
-      const cwd = typeof body.cwd === "string" && body.cwd ? body.cwd : process.cwd();
       const prompt = String(body.prompt ?? "");
+
+      // Resolve the working directory. A `from` source is provisioned (clone /
+      // worktree) through codehost/provision; a plain `cwd` is resolved to the
+      // workspace root and mkdir-p'd so a missing dir no longer ENOENTs.
+      let cwd: string;
+      let provisioned: { action: string; folder: string } | null = null;
+      const from = typeof body.from === "string" ? body.from.trim() : "";
+      if (from) {
+        type Spec = { owner: string; repo: string; branch: string };
+        let prov: {
+          parseSource?: (s: string) => Spec | null;
+          parseSpec: (s: string) => Spec | null;
+          provision: (
+            spec: Spec,
+            opts?: { wsRoot?: string },
+          ) => Promise<{ ok: boolean; folder: string; action: string; error?: string }>;
+        };
+        try {
+          prov = (await import("codehost/provision")) as typeof prov;
+        } catch (e) {
+          return new Response(
+            `spawn-from needs the 'codehost' package (codehost/provision) — install it ` +
+              `(npm i -g codehost) or 'bun link' it for local dev: ${(e as Error).message}`,
+            { status: 501 },
+          );
+        }
+        // Malformed input (e.g. bad %-encoding) must surface as 400, not a 500.
+        let spec: Spec | null;
+        try {
+          spec =
+            typeof prov.parseSource === "function"
+              ? prov.parseSource(from)
+              : prov.parseSpec(normalizeGithubSource(from));
+        } catch {
+          spec = null;
+        }
+        if (!spec) return new Response(`unrecognized spawn source: ${from}`, { status: 400 });
+        // Provisioning clones the repo and runs its setup script (dependency
+        // installs + package lifecycle hooks = code execution on the host), so
+        // gate it behind an owner/repo allowlist — empty allowlist = deny all.
+        if (!isProvisionAllowed(spec.owner, spec.repo))
+          return new Response(
+            `provisioning '${spec.owner}/${spec.repo}' is not allowed — add the owner to ` +
+              `provisionAllowlist in ~/.agent-yes/config.json (or "*" to allow all)`,
+            { status: 403 },
+          );
+        let result: { ok: boolean; folder: string; action: string; error?: string };
+        try {
+          const wsRoot = getProvisionRoot();
+          result = await prov.provision(spec, wsRoot ? { wsRoot } : undefined);
+        } catch (e) {
+          return new Response(`provision failed: ${(e as Error).message}`, { status: 502 });
+        }
+        if (!result?.ok) return new Response(result?.error ?? "provision failed", { status: 502 });
+        cwd = result.folder;
+        provisioned = { action: result.action, folder: result.folder };
+      } else {
+        cwd = resolveSpawnCwd(body.cwd);
+        try {
+          await mkdir(cwd, { recursive: true });
+        } catch (e) {
+          return new Response(`cannot create cwd ${cwd}: ${(e as Error).message}`, { status: 500 });
+        }
+      }
       process.stderr.write(
-        `→ console spawned:  ay ${cli}${prompt ? ` -- "${prompt.slice(0, 60)}"` : ""}  (cwd: ${cwd})\n`,
+        `→ console spawned:  ay ${cli}${prompt ? ` -- "${prompt.slice(0, 60)}"` : ""}  (cwd: ${cwd}${provisioned ? `, ${provisioned.action} from ${from}` : ""})\n`,
       );
       // Resolve `ay` to an absolute command. The detached daemon (oxmgr/launchd/
       // pm2) usually has a PATH WITHOUT ~/.bun/bin, so a bare "ay" fails with
@@ -1483,7 +1574,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
           stderr: "ignore",
         });
         child.unref();
-        return Response.json({ ok: true, pid: child.pid, cli, cwd });
+        return Response.json({
+          ok: true,
+          pid: child.pid,
+          cli,
+          cwd,
+          ...(provisioned ? { provisioned } : {}),
+        });
       } catch (e) {
         return new Response((e as Error).message, { status: 500 });
       }

--- a/ts/workspaceConfig.spec.ts
+++ b/ts/workspaceConfig.spec.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import path from "path";
 import {
   expandTilde,
+  getProvisionAllowlist,
+  getProvisionRoot,
   getWorkspaceRoot,
+  isProvisionAllowed,
   resolveSpawnCwd,
   setWorkspaceRoot,
 } from "./workspaceConfig.ts";
@@ -20,6 +23,8 @@ describe("workspaceConfig", () => {
   afterEach(() => {
     if (original === undefined) delete process.env.AGENT_YES_HOME;
     else process.env.AGENT_YES_HOME = original;
+    delete process.env.CODEHOST_WS_ROOT;
+    delete process.env.CODEHOST_PROVISION_ALLOWLIST;
     rmSync(tmp, { recursive: true, force: true });
   });
 
@@ -69,6 +74,72 @@ describe("workspaceConfig", () => {
 
     it("a relative path with a separator is resolved, not joined to the workspace", () => {
       expect(resolveSpawnCwd("a/b")).toBe(path.resolve("a/b"));
+    });
+  });
+
+  const writeConfig = (c: Record<string, unknown>) =>
+    writeFileSync(path.join(tmp, "config.json"), JSON.stringify(c));
+
+  describe("getProvisionRoot", () => {
+    it("is undefined when neither env nor config is set", () => {
+      expect(getProvisionRoot()).toBeUndefined();
+    });
+
+    it("returns the configured provisionRoot, resolved", () => {
+      writeConfig({ provisionRoot: "/code" });
+      expect(getProvisionRoot()).toBe(path.resolve("/code"));
+    });
+
+    it("env CODEHOST_WS_ROOT overrides the config and expands ~", () => {
+      writeConfig({ provisionRoot: "/code" });
+      process.env.CODEHOST_WS_ROOT = "~/ws";
+      expect(getProvisionRoot()).toBe(path.join(homedir(), "ws"));
+    });
+
+    it("ignores a blank configured value", () => {
+      writeConfig({ provisionRoot: "   " });
+      expect(getProvisionRoot()).toBeUndefined();
+    });
+  });
+
+  describe("getProvisionAllowlist", () => {
+    it("is empty when unset", () => {
+      expect(getProvisionAllowlist()).toEqual([]);
+    });
+
+    it("reads and normalizes the configured list (trim/lowercase/drop empties)", () => {
+      writeConfig({ provisionAllowlist: [" Snomiao ", "Acme/Repo", ""] });
+      expect(getProvisionAllowlist()).toEqual(["snomiao", "acme/repo"]);
+    });
+
+    it("env CODEHOST_PROVISION_ALLOWLIST (comma-separated) overrides config", () => {
+      writeConfig({ provisionAllowlist: ["snomiao"] });
+      process.env.CODEHOST_PROVISION_ALLOWLIST = "Foo, bar/baz ,";
+      expect(getProvisionAllowlist()).toEqual(["foo", "bar/baz"]);
+    });
+  });
+
+  describe("isProvisionAllowed", () => {
+    it("denies everything when the allowlist is empty (secure default)", () => {
+      expect(isProvisionAllowed("snomiao", "agent-yes")).toBe(false);
+    });
+
+    it("'*' allows any owner/repo", () => {
+      writeConfig({ provisionAllowlist: ["*"] });
+      expect(isProvisionAllowed("anyone", "anything")).toBe(true);
+    });
+
+    it("matches by owner case-insensitively and rejects others", () => {
+      writeConfig({ provisionAllowlist: ["snomiao"] });
+      expect(isProvisionAllowed("SNOMIAO", "x")).toBe(true);
+      expect(isProvisionAllowed("evil", "x")).toBe(false);
+    });
+
+    it("matches an exact owner/repo and an owner/* glob", () => {
+      writeConfig({ provisionAllowlist: ["acme/widget", "org/*"] });
+      expect(isProvisionAllowed("acme", "widget")).toBe(true);
+      expect(isProvisionAllowed("acme", "other")).toBe(false);
+      expect(isProvisionAllowed("org", "anything")).toBe(true);
     });
   });
 });

--- a/ts/workspaceConfig.ts
+++ b/ts/workspaceConfig.ts
@@ -15,6 +15,10 @@ import { agentYesHome } from "./agentYesHome.ts";
 
 interface Config {
   workspace?: string;
+  /** Root for `from`-provisioned worktrees (`<root>/<owner>/<repo>/tree/<branch>`). */
+  provisionRoot?: string;
+  /** Owners/repos permitted for `from`-provisioning; empty = deny all. */
+  provisionAllowlist?: string[];
 }
 
 function configPath(): string {
@@ -41,6 +45,45 @@ export function expandTilde(p: string): string {
 export function getWorkspaceRoot(): string {
   const w = readConfig().workspace;
   return w && w.trim() ? w : homedir();
+}
+
+/**
+ * Root for `from`-provisioned worktrees, handed to codehost/provision so they
+ * land in `<root>/<owner>/<repo>/tree/<branch>`. Resolution order: env
+ * `CODEHOST_WS_ROOT` wins (ops override), then the configured `provisionRoot`,
+ * else undefined — letting codehost/provision fall back to its own `~/ws`
+ * default. Kept separate from `workspace` (the plain-cwd default), which may be a
+ * specific project dir rather than a root.
+ */
+export function getProvisionRoot(): string | undefined {
+  const env = process.env.CODEHOST_WS_ROOT?.trim();
+  if (env) return path.resolve(expandTilde(env));
+  const r = readConfig().provisionRoot;
+  return r && r.trim() ? path.resolve(expandTilde(r)) : undefined;
+}
+
+/**
+ * Owner/repo allowlist for `from`-provisioning. Provisioning clones a repo and
+ * runs its setup script (dependency installs + package lifecycle hooks = code
+ * execution on the host), so an **empty allowlist means DENY ALL** — a secure
+ * default the host opts out of by listing owners it trusts. Entries match
+ * `<owner>` (any repo of that owner), `<owner>/<repo>` (exact), or `*` (allow
+ * all — an explicit opt-in to the wide-open behavior). Env
+ * `CODEHOST_PROVISION_ALLOWLIST` (comma-separated) overrides the config.
+ */
+export function getProvisionAllowlist(): string[] {
+  const env = process.env.CODEHOST_PROVISION_ALLOWLIST?.trim();
+  const raw = env ? env.split(",") : (readConfig().provisionAllowlist ?? []);
+  return raw.map((s) => s.trim().toLowerCase()).filter(Boolean);
+}
+
+/** Whether `<owner>/<repo>` may be `from`-provisioned, per {@link getProvisionAllowlist}. */
+export function isProvisionAllowed(owner: string, repo: string): boolean {
+  const list = getProvisionAllowlist();
+  if (list.includes("*")) return true;
+  const o = owner.toLowerCase();
+  const full = `${owner}/${repo}`.toLowerCase();
+  return list.some((e) => e.replace(/\/\*$/, "") === o || e === full);
 }
 
 /** Persist the workspace root, tilde-expanded and resolved to an absolute path. */

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,7 +5,17 @@ export default defineConfig({
   outDir: "dist",
   platform: "node",
   sourcemap: true,
-  external: ["@snomiao/bun-pty", "bun-pty", "node-pty", "from-node-stream", "bun", "systray2"],
+  external: [
+    "@snomiao/bun-pty",
+    "bun-pty",
+    "node-pty",
+    "from-node-stream",
+    "bun",
+    "systray2",
+    // codehost/provision is resolved at runtime (bun link) — never bundle it,
+    // so a missing link degrades to a 501 instead of breaking the build.
+    /^codehost(\/|$)/,
+  ],
   format: "esm",
   outExtensions: () => ({ js: ".js" }),
   inlineOnly: false,


### PR DESCRIPTION
## Spawn agents from a GitHub URL/branch

`POST /api/spawn` gains an optional `from` (GitHub URL / `owner/repo@branch` /
`owner/repo/tree/branch`) → provisions a worktree via **codehost/provision** (the
shared workspace standard) → spawns the agent there. The console "+ New agent"
form gains a "Spawn from" field. Plain `cwd` now `mkdir -p`'s (fixes a missing-dir
ENOENT 500).

### Security (codex pre-push review)
codex flagged that `from` lets a token-holder make the host clone an arbitrary
repo and auto-run its setup/install hooks (code execution). Addressed:
- **Allowlist** (`provisionAllowlist` in `~/.agent-yes/config.json`, or
  `CODEHOST_PROVISION_ALLOWLIST` env): empty = **deny all**; a non-allowlisted
  owner/repo → **403**. `*` opts into wide-open.
- Malformed input (e.g. bad %-encoding) → **400**, not 500.
- No shell/argv injection (clone URL hard-pinned to github.com, `execFile`, `--`,
  per-segment validation) — confirmed by the review.

### Notes
- `codehost/provision` is optional: install `codehost` to enable spawn-from, else
  `from` → **501**. `codehost/*` is externalized in tsdown.
- Verified live: clone+spawn works for allowlisted repos; non-allowlisted → 403;
  bad input → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
