### PR TITLE
fix(pty): color-capable TERM/COLORTERM for console/daemon-spawned agents

### DIFF
--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -294,6 +294,20 @@ pub async fn spawn_agent(
     // tree in `ay ls` and the console. Mirrors ts/index.ts.
     cmd.env("AGENT_YES_PID", std::process::id().to_string());
 
+    // The agent runs in a PTY (a real terminal), so advertise terminal
+    // capabilities. A console/daemon-spawned agent inherits an env with no TERM/
+    // COLORTERM: neither the daemon (no controlling terminal) nor the recovered
+    // login-shell env (captured without a tty) carries them — those vars are set
+    // by the terminal emulator, not by the shell. Without them the wrapped CLI
+    // renders colorless in the web console. Fill only when absent so a
+    // terminal-launched agent keeps its real values (e.g. xterm-256color, tmux).
+    if std::env::var_os("TERM").is_none() {
+        cmd.env("TERM", "xterm-256color");
+    }
+    if std::env::var_os("COLORTERM").is_none() {
+        cmd.env("COLORTERM", "truecolor");
+    }
+
     // Inject per-CLI env (e.g. glm → Z.AI endpoint). Expand ${VAR} against the
     // launching env; skip entries whose vars are unset/empty so we never blank
     // out an inherited value (e.g. ANTHROPIC_AUTH_TOKEN when ZAI_API_KEY isn't

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -395,8 +395,17 @@ export default async function agentYes({
       ptyEnv[key] = value;
     }
   }
+  // The agent runs in a PTY (a real terminal), so advertise terminal
+  // capabilities. A console/daemon-spawned agent inherits an env with no TERM/
+  // COLORTERM: neither the daemon (no controlling terminal) nor the recovered
+  // login-shell env (captured without a tty) carries them — those vars are set
+  // by the terminal emulator, not by the shell. Without them the wrapped CLI
+  // renders colorless in the web console. Fill only when absent so a
+  // terminal-launched agent keeps its real values (e.g. xterm-256color, tmux).
+  if (!ptyEnv.TERM) ptyEnv.TERM = "xterm-256color";
+  if (!ptyEnv.COLORTERM) ptyEnv.COLORTERM = "truecolor";
   const ptyOptions = {
-    name: "xterm-color",
+    name: ptyEnv.TERM,
     ...getTerminalDimensions(),
     cwd: cwd ?? process.cwd(),
     env: ptyEnv,
@@ -561,7 +570,7 @@ export default async function agentYes({
       logger.info(`Restarting ${cli} ${JSON.stringify([bin, ...args])}`);
 
       const restartPtyOptions = {
-        name: "xterm-color",
+        name: ptyEnv.TERM,
         ...getTerminalDimensions(),
         cwd: cwd ?? process.cwd(),
         env: ptyEnv,
@@ -667,7 +676,7 @@ export default async function agentYes({
       }
 
       const restorePtyOptions = {
-        name: "xterm-color",
+        name: ptyEnv.TERM,
         ...getTerminalDimensions(),
         cwd: cwd ?? process.cwd(),
         env: ptyEnv,


### PR DESCRIPTION
## Problem

Agents spawned from the web console **+ new agent** button (and any agent under the oxmgr/launchd/pm2 daemon) render **colorless** in the xterm.js console.

## Root cause

The wrapped CLI decides on color from `TERM`/`COLORTERM`. The daemon has no controlling terminal, and the recovered login-shell env (`loginShellEnv`, captured via `$SHELL -ilc` without a tty) carries neither — those vars are set by the terminal emulator, not the shell.

Measured: `"$SHELL" -ilc 'echo $TERM $COLORTERM' </dev/null` → both empty. The Rust runtime set neither on the PTY child; the TS runtime hardcoded node-pty `name: "xterm-color"` (8/16-color, no `COLORTERM`).

## Fix

The agent always runs in a PTY, so advertise terminal capabilities. Both runtimes set `TERM=xterm-256color` + `COLORTERM=truecolor` only when absent (a terminal-launched agent keeps its real values).

- `rs/src/pty_spawner.rs`
- `ts/index.ts` (node-pty `name` now follows `TERM`)

## Verification

Spawned `ay claude` with `TERM`/`COLORTERM` unset; raw PTY log now contains truecolor SGR (`38;2;r;g;b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)