### PR TITLE
fix(console): replay raw log at the agent's recorded PTY geometry

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -11,6 +11,7 @@ import {
   extractTaskCounts,
   listRecords,
   readNotes,
+  readPtysize,
   renderRawLog,
   resolveOne,
   snapshotStatus,
@@ -1163,7 +1164,8 @@ export async function cmdServe(rest: string[]): Promise<number> {
         if (!record.log_file)
           return new Response(`pid ${record.pid}: no log_file`, { status: 404 });
         const buf = await readFile(record.log_file);
-        const text = await renderRawLog(buf, { mode, n });
+        const size = await readPtysize(record.pid);
+        const text = await renderRawLog(buf, { mode, n, cols: size?.cols, rows: size?.rows });
         return new Response(text, { headers: { "Content-Type": "text/plain; charset=utf-8" } });
       } catch (e) {
         return new Response((e as Error).message, { status: 404 });
@@ -1177,20 +1179,12 @@ export async function cmdServe(rest: string[]): Promise<number> {
       const keyword = decodeURIComponent(sizeM[1]!);
       try {
         const record = await resolveOne(keyword, defaultOpts());
-        const ayHome = process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes");
-        let cols: number | null = null;
-        let rows: number | null = null;
-        try {
-          const txt = await readFile(path.join(ayHome, "ptysize", String(record.pid)), "utf-8");
-          const [c = 0, r = 0] = txt.trim().split(/\s+/).map(Number);
-          if (c > 0 && r > 0) {
-            cols = c;
-            rows = r;
-          }
-        } catch {
-          /* no ptysize sidecar (older agent or not yet written) */
-        }
-        return Response.json({ pid: record.pid, cols, rows });
+        const size = await readPtysize(record.pid);
+        return Response.json({
+          pid: record.pid,
+          cols: size?.cols ?? null,
+          rows: size?.rows ?? null,
+        });
       } catch (e) {
         return new Response((e as Error).message, { status: 404 });
       }

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1718,3 +1718,80 @@ describe("subcommands.isAgentStuck / stuck state", () => {
     }
   });
 });
+
+// A CLI like Claude Code repaints by moving the cursor UP over the previous
+// frame and rewriting it. The up-count is the frame's height AT THE AGENT'S REAL
+// WIDTH. Replayed narrower, the body line wraps to an extra row, the up-count
+// undershoots, and every old frame strands below as a duplicate — the `ay tail`
+// stutter. `bodyLen` chars stay one row at the real width but wrap below it.
+function buildRedrawLog(frames: number, bodyLen: number): Buffer {
+  const body = "BODY-" + "z".repeat(Math.max(0, bodyLen - 5));
+  const frame = (i: number) => `HEADER-${i}\r\n${body}`;
+  let bytes = frame(0) + "\r\n";
+  for (let i = 1; i < frames; i++) bytes += `\x1b[2A\r` + frame(i) + "\r\n"; // up 2 = header+body at real width
+  return Buffer.from(bytes);
+}
+const countHeaders = (s: string) => (s.match(/^HEADER-\d+/gm) ?? []).length;
+
+describe("renderRawLog honors the agent's recorded PTY geometry", () => {
+  it("collapses redraw frames at the recorded width but duplicates at a mismatched width", async () => {
+    const { renderRawLog } = await loadModule();
+    const buf = buildRedrawLog(6, 220); // one row at >=220 cols, two rows below that
+
+    // Replayed at the real width, each repaint lands on the prior frame: one header.
+    const correct = await renderRawLog(buf, { mode: "cat", n: 0, cols: 240, rows: 50 });
+    expect(countHeaders(correct)).toBe(1);
+
+    // Replayed narrower (the body wraps), repaints undershoot and pile up.
+    const wrong = await renderRawLog(buf, { mode: "cat", n: 0, cols: 120, rows: 50 });
+    expect(countHeaders(wrong)).toBeGreaterThan(1);
+  });
+});
+
+describe("subcommands.cmdRead replays at the ptysize sidecar geometry", () => {
+  it("renders at the recorded geometry, not the 200-col fallback", async () => {
+    const { runSubcommand } = await loadModule();
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    const tmp = await mkdtemp(path.join(tmpdir(), "ay-raw-log-"));
+    try {
+      const logPath = path.join(tmp, "wide.raw.log");
+      // Authored for a 240-col terminal; at the 200-col fallback the body wraps
+      // and the redraw duplicates (see buildRedrawLog / renderRawLogLines).
+      await writeFile(logPath, buildRedrawLog(6, 220));
+
+      // ptysize sidecar lives under the (mocked) home: ~/.agent-yes/ptysize/<pid>.
+      const ptDir = path.join(testHome, ".agent-yes", "ptysize");
+      await mkdir(ptDir, { recursive: true });
+      await writeFile(path.join(ptDir, String(process.pid)), "240 50\n");
+
+      await appendGlobalPid({
+        pid: process.pid,
+        cli: "claude",
+        prompt: null,
+        cwd: process.cwd(),
+        log_file: logPath,
+        status: "active" as const,
+        exit_code: null,
+        exit_reason: null,
+        started_at: Date.now(),
+      });
+
+      const stdout: string[] = [];
+      const orig = process.stdout.write.bind(process.stdout);
+      (process.stdout as any).write = (s: any) => {
+        stdout.push(String(s));
+        return true;
+      };
+      try {
+        const code = await runSubcommand(["bun", "cli.js", "cat", String(process.pid)]);
+        expect(code).toBe(0);
+      } finally {
+        process.stdout.write = orig;
+      }
+      // With the sidecar honored, the six repaints collapse to a single frame.
+      expect(countHeaders(stdout.join(""))).toBe(1);
+    } finally {
+      await rm(tmp, { recursive: true, force: true }).catch(() => null);
+    }
+  });
+});

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -1406,6 +1406,7 @@ async function cmdRead(rest: string[], { mode }: ReadOpts): Promise<number> {
   }
 
   const buf = await readFile(logPath);
+  const size = await readPtysize(record.pid);
   const notes = await readNotes();
   const noteLabel = notes.get(record.pid);
   const header = noteLabel
@@ -1414,7 +1415,7 @@ async function cmdRead(rest: string[], { mode }: ReadOpts): Promise<number> {
 
   if (follow) {
     // Follow mode ignores pagination: print the initial context, then stream deltas.
-    const rendered = await renderRawLog(buf, { mode, n });
+    const rendered = await renderRawLog(buf, { mode, n, cols: size?.cols, rows: size?.rows });
     process.stderr.write(header + "\n");
     process.stdout.write(rendered);
     if (!rendered.endsWith("\n")) process.stdout.write("\n");
@@ -1427,7 +1428,7 @@ async function cmdRead(rest: string[], { mode }: ReadOpts): Promise<number> {
 
   // Static read: render the full log once, then window into the rendered lines
   // so line numbers (and the pagination cursor in the footer) are exact.
-  const allLines = await renderRawLogLines(buf);
+  const allLines = await renderRawLogLines(buf, { cols: size?.cols, rows: size?.rows });
   const total = allLines.length;
   const win = resolveReadWindow({
     total,
@@ -1664,14 +1665,41 @@ async function followPlainLocal(logPath: string, buf: Uint8Array): Promise<numbe
 }
 
 /**
+ * The agent's real PTY geometry (from readPtysize), passed to the renderers so
+ * the raw log replays at the size it was authored for. Omitted → a wide 200x50
+ * default; if the agent ran wider/taller than that its cursor-addressed redraw
+ * frames undershoot on replay and strand into scrollback as duplicates (the
+ * `ay tail` stutter this guards).
+ */
+type RenderGeom = { cols?: number; rows?: number };
+
+/**
+ * Read an agent's last-known PTY geometry from `~/.agent-yes/ptysize/<pid>`
+ * (written by both runtimes — ts/index.ts and rs/src/pty_spawner.rs — as
+ * "<cols> <rows>\n"). Returns null when there's no sidecar (older agent, or not
+ * yet written).
+ */
+export async function readPtysize(pid: number): Promise<{ cols: number; rows: number } | null> {
+  const dir = process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes");
+  try {
+    const txt = await readFile(path.join(dir, "ptysize", String(pid)), "utf-8");
+    const [c = 0, r = 0] = txt.trim().split(/\s+/).map(Number);
+    if (c > 0 && r > 0) return { cols: c, rows: r };
+  } catch {
+    /* no ptysize sidecar */
+  }
+  return null;
+}
+
+/**
  * Feed the raw PTY bytes through @xterm/headless and emit plain text.
  * Same approach as koho's renderTerminalBuffer + agent-yes's XtermProxy.
  */
 export async function renderRawLog(
   buf: Uint8Array,
-  { mode, n }: { mode: "cat" | "tail" | "head"; n: number },
+  { mode, n, cols, rows }: { mode: "cat" | "tail" | "head"; n: number } & RenderGeom,
 ): Promise<string> {
-  const lines = await renderRawLogLines(buf);
+  const lines = await renderRawLogLines(buf, { cols, rows });
   if (mode === "cat") return lines.join("\n");
   if (mode === "tail") return lines.slice(Math.max(0, lines.length - n)).join("\n");
   return lines.slice(0, n).join("\n");
@@ -1685,11 +1713,13 @@ export async function renderRawLog(
  * cursor moves / clears / wraps), so we always render the whole buffer once and
  * window the resulting lines.
  */
-export async function renderRawLogLines(buf: Uint8Array): Promise<string[]> {
-  // Default screen geometry — we don't know what the agent used, but
-  // 200x50 is a reasonable upper bound that won't truncate normal output.
-  const cols = 200;
-  const rows = 50;
+export async function renderRawLogLines(buf: Uint8Array, geom?: RenderGeom): Promise<string[]> {
+  // Replay at the agent's real geometry when known (see RenderGeom / readPtysize);
+  // otherwise fall back to a wide 200x50 — a reasonable upper bound that won't
+  // truncate normal output, though an agent wider/taller than it can still
+  // duplicate on replay (which is why callers pass the recorded size).
+  const cols = geom?.cols && geom.cols > 0 ? geom.cols : 200;
+  const rows = geom?.rows && geom.rows > 0 ? geom.rows : 50;
   // Scrollback caps how far back pagination can reach; older lines are evicted.
   const scrollback = 50000;
 


### PR DESCRIPTION
## Problem

`ay tail`/`cat`/`head` and the web console's `/api/read` render the raw PTY log through a hardcoded **200×50** xterm (`renderRawLogLines`). A full-screen TUI (Claude Code) emits cursor-addressed redraw frames sized for its *real* terminal. An agent that ran wider/taller than 200×50 (observed: **293×80**) has its body lines wrap on replay; the repaint up-counts then **undershoot** and strand every old frame into scrollback as duplicates — the `ay tail` stutter where the same paragraph repeats 4–6×.

## Fix

The real geometry is already persisted per-pid at `~/.agent-yes/ptysize/<pid>` (written by both the TS and Rust runtimes). This:

- adds a `readPtysize(pid)` helper,
- threads optional `{cols, rows}` through `renderRawLog` / `renderRawLogLines`,
- wires `cmdRead` (follow + static paths) and serve.ts `/api/read` to replay at the recorded geometry, falling back to 200×50 only when unknown,
- folds serve.ts's `/api/size` inline ptysize reader onto the same helper.

## Tests

- `renderRawLog` unit test: a redraw-loop log collapses to **1** frame at the recorded width, duplicates (**>1**) at a mismatched width.
- `cmdRead` integration test: with a `240 50` ptysize sidecar, six repaints authored for 240 cols collapse to a single frame (where the 200 fallback would duplicate).

## Verification

`oxfmt --check` (clean on changed files), `bun run build`, and full `test:coverage` (**545 passed**) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)