### PR TITLE
feat(console): fork the current branch (carrying WIP) or spawn into a cwd from Cmd+K

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -3794,6 +3794,18 @@
         }, 120);
       }
 
+      // Auto-derive a branch name from the typed prompt for the Cmd+K fork action
+      // (editable at launch). e.g. "fix the auth bug" → "fork/fix-the-auth-bug".
+      function forkSlug(q) {
+        const s = q
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "")
+          .slice(0, 40)
+          .replace(/-+$/, "");
+        return "fork/" + (s || "wip");
+      }
+
       function renderOmni() {
         const q = $("omni-input").value.trim();
         if (omniIdx >= omniRows.length) omniIdx = Math.max(0, omniRows.length - 1);
@@ -3807,6 +3819,22 @@
                 <div class="omni-main">
                   <div class="omni-title">✦ Spawn new ${esc(anchor?.cli || "claude")} agent here</div>
                   <div class="omni-sub">${esc(anchor?.cwd || "(host default)")} &nbsp;·&nbsp; prompt: ${esc(q || "(empty)")}</div>
+                </div></div>`;
+            }
+            if (r.kind === "fork") {
+              return `<div class="omni-row omni-spawn${sc}" data-i="${i}">
+                <span class="dot active"></span>
+                <div class="omni-main">
+                  <div class="omni-title">⑂ Fork current branch &amp; run <span style="opacity:.55">(carries uncommitted work)</span></div>
+                  <div class="omni-sub">${esc(anchor?.cwd || "?")} &nbsp;→&nbsp; new branch <b>${esc(r.branch)}</b> &nbsp;·&nbsp; ⏎ to edit &amp; launch</div>
+                </div></div>`;
+            }
+            if (r.kind === "spawncwd") {
+              return `<div class="omni-row omni-spawn${sc}" data-i="${i}">
+                <span class="dot active"></span>
+                <div class="omni-main">
+                  <div class="omni-title">⊕ Spawn new ${esc(anchor?.cli || "claude")} agent in a directory…</div>
+                  <div class="omni-sub">⏎ to choose a working dir &nbsp;·&nbsp; prompt: ${esc(q || "(empty)")}</div>
                 </div></div>`;
             }
             const e = r.entry;
@@ -3837,7 +3865,12 @@
           )
           .slice(0, 30);
         omniRows = hits.map((entry) => ({ kind: "agent", entry }));
-        if (q) omniRows.push({ kind: "spawn" });
+        if (q) {
+          omniRows.push({ kind: "spawn" });
+          const anchor = omniAnchor();
+          if (anchor?.cwd) omniRows.push({ kind: "fork", branch: forkSlug(q) });
+          omniRows.push({ kind: "spawncwd" });
+        }
         omniIdx = 0;
         renderOmni();
         // Tier 2 — debounced output (tail) search for alive agents not already shown.
@@ -3902,11 +3935,37 @@
       async function omniActivate(forceSpawn) {
         const q = $("omni-input").value.trim();
         const row = omniRows[omniIdx];
+        const anchor = omniAnchor();
+        // ⌘⏎ always = spawn-here (the fast default), regardless of the selected row.
         if (forceSpawn || (row && row.kind === "spawn")) {
-          const anchor = omniAnchor();
           closeOmni(false); // committing — keep the bg as-is, spawnAndSelect takes over
           await spawnAndSelect(
             { cli: anchor?.cli || "claude", cwd: anchor?.cwd || undefined, prompt: q || undefined },
+            anchor?._room,
+          );
+          return;
+        }
+        if (row && row.kind === "fork") {
+          // Editable at launch (auto-slug is the default); carries the anchor's WIP.
+          const branch = prompt("Fork to a new branch (carries your uncommitted work):", row.branch);
+          if (!branch || !branch.trim()) return; // cancelled — leave the omnibox open
+          closeOmni(false);
+          await spawnAndSelect(
+            {
+              cli: anchor?.cli || "claude",
+              prompt: q || undefined,
+              fork: { fromCwd: anchor?.cwd, branch: branch.trim() },
+            },
+            anchor?._room,
+          );
+          return;
+        }
+        if (row && row.kind === "spawncwd") {
+          const cwd = prompt("Spawn in which working directory?", anchor?.cwd || "");
+          if (cwd == null) return; // cancelled
+          closeOmni(false);
+          await spawnAndSelect(
+            { cli: anchor?.cli || "claude", cwd: cwd.trim() || undefined, prompt: q || undefined },
             anchor?._room,
           );
           return;
@@ -4335,6 +4394,7 @@
         const res = await target.tx.post("/api/spawn", {
           cli: spec.cli || "claude",
           from: spec.from || undefined,
+          fork: spec.fork || undefined,
           cwd: spec.cwd || undefined,
           prompt: spec.prompt || undefined,
         });

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1472,7 +1472,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
     // standard); otherwise `cwd` is resolved against the workspace root and
     // created if missing (Layer-0 plain-dir provisioning — no more ENOENT 500).
     if (req.method === "POST" && p === "/api/spawn") {
-      let body: { cli?: string; cwd?: string; from?: string; prompt?: string };
+      let body: {
+        cli?: string;
+        cwd?: string;
+        from?: string;
+        prompt?: string;
+        fork?: { fromCwd?: string; branch?: string };
+      };
       try {
         body = (await req.json()) as typeof body;
       } catch {
@@ -1488,8 +1494,61 @@ export async function cmdServe(rest: string[]): Promise<number> {
       // workspace root and mkdir-p'd so a missing dir no longer ENOENTs.
       let cwd: string;
       let provisioned: { action: string; folder: string } | null = null;
+      const fork =
+        body.fork && typeof body.fork.fromCwd === "string" && typeof body.fork.branch === "string"
+          ? { fromCwd: body.fork.fromCwd, branch: body.fork.branch }
+          : null;
       const from = typeof body.from === "string" ? body.from.trim() : "";
-      if (from) {
+      if (fork) {
+        // Fork the anchor agent's branch (carrying its WIP) into a new sibling
+        // worktree via codehost/provision (git worktree off HEAD, no clone), then
+        // spawn the agent there.
+        let prov: {
+          forkWorktree: (o: { fromCwd: string; branch: string; wsRoot?: string }) => Promise<{
+            ok: boolean;
+            folder: string;
+            action: string;
+            error?: string;
+            spec?: { owner: string; repo: string };
+          }>;
+        };
+        try {
+          prov = (await import("codehost/provision")) as typeof prov;
+        } catch (e) {
+          return new Response(
+            `fork needs the 'codehost' package (codehost/provision) — install it ` +
+              `(npm i -g codehost) or 'bun link' it for local dev: ${(e as Error).message}`,
+            { status: 501 },
+          );
+        }
+        let result: {
+          ok: boolean;
+          folder: string;
+          action: string;
+          error?: string;
+          spec?: { owner: string; repo: string };
+        };
+        try {
+          const wsRoot = getProvisionRoot();
+          result = await prov.forkWorktree({
+            fromCwd: fork.fromCwd,
+            branch: fork.branch,
+            ...(wsRoot ? { wsRoot } : {}),
+          });
+        } catch (e) {
+          return new Response(`fork failed: ${(e as Error).message}`, { status: 502 });
+        }
+        if (!result?.ok) return new Response(result?.error ?? "fork failed", { status: 502 });
+        // Same allowlist gate as `from` — the fork runs setup-repo.sh (code exec).
+        if (result.spec && !isProvisionAllowed(result.spec.owner, result.spec.repo))
+          return new Response(
+            `forking '${result.spec.owner}/${result.spec.repo}' is not allowed — add the owner ` +
+              `to provisionAllowlist in ~/.agent-yes/config.json (or "*" to allow all)`,
+            { status: 403 },
+          );
+        cwd = result.folder;
+        provisioned = { action: result.action, folder: result.folder };
+      } else if (from) {
         type Spec = { owner: string; repo: string; branch: string };
         let prov: {
           parseSource?: (s: string) => Spec | null;
@@ -1547,7 +1606,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
         }
       }
       process.stderr.write(
-        `→ console spawned:  ay ${cli}${prompt ? ` -- "${prompt.slice(0, 60)}"` : ""}  (cwd: ${cwd}${provisioned ? `, ${provisioned.action} from ${from}` : ""})\n`,
+        `→ console spawned:  ay ${cli}${prompt ? ` -- "${prompt.slice(0, 60)}"` : ""}  (cwd: ${cwd}${provisioned ? `, ${provisioned.action}` : ""})\n`,
       );
       // Resolve `ay` to an absolute command. The detached daemon (oxmgr/launchd/
       // pm2) usually has a PATH WITHOUT ~/.bun/bin, so a bare "ay" fails with


### PR DESCRIPTION
## Cmd+K: fork the current branch (carrying WIP) + spawn into a cwd

Extends the Cmd+K omnibox with two action rows (when you type a prompt):
- **⑂ Fork current branch & run** — forks the anchor agent's worktree to a NEW
  branch (auto-slugged from the prompt, editable at launch via a one-field
  prompt) **carrying its uncommitted work**, then spawns the agent there. Uses
  codehost/provision's `forkWorktree` (git worktree off HEAD, no clone; tracked
  WIP via `stash create`→`apply`, untracked files copied — the source worktree is
  untouched).
- **⊕ Spawn in a directory…** — spawn into an arbitrary working dir.

`⌘⏎` stays the fast "spawn here" default; the rows are selectable/clickable.

### Server
`POST /api/spawn` gains `fork: { fromCwd, branch }` → `forkWorktree` → spawn in
the returned folder. Gated by the same `provisionAllowlist` as `from` (the fork
runs `setup-repo.sh` = code exec). `codehost/provision` stays an optional dep
(forkWorktree shipped in `codehost@0.25.0`).

### Verified
- codehost `forkWorktree` unit tests (WIP carry, unsafe-branch, non-git input).
- Live API end-to-end: `fork:{fromCwd, branch}` → forked into `/code/...`,
  untracked WIP carried, agent spawned & registered; source worktree untouched.
- Browser: the fork + spawn-cwd rows render (auto-slug `fix the auth bug` →
  `fork/fix-the-auth-bug`), and the editable branch prompt fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
