### PR TITLE
feat(serve): robust whoami uid resolution for /api/whoami

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1,5 +1,6 @@
 import { mkdir, open, readFile, stat, writeFile } from "fs/promises";
 import { renameSync, watch, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { createHash, randomBytes, timingSafeEqual } from "crypto";
 import { homedir, hostname, userInfo } from "os";
@@ -1118,9 +1119,24 @@ export async function cmdServe(rest: string[]): Promise<number> {
     if (req.method === "GET" && p === "/api/whoami") {
       let user = "";
       try {
-        user = userInfo().username;
+        // Bun's userInfo() doesn't always throw on a uid with no /etc/passwd
+        // entry (arbitrary-uid / minimal containers) — it can return the literal
+        // "unknown". Treat that (and "") as a miss so the fallbacks run; without
+        // this a root container surfaced as `unknown@host`, not `root@host`.
+        const u = userInfo().username;
+        if (u && u !== "unknown") user = u;
       } catch {
-        /* userInfo throws if there's no passwd entry (some containers) */
+        /* userInfo can still throw outright on some platforms */
+      }
+      user ||= process.env.USER || process.env.LOGNAME || process.env.USERNAME || "";
+      // Last resort on Unix: resolve the uid against the passwd db directly,
+      // which returns `root` for uid 0 even when the env carries no USER.
+      if (!user && process.platform !== "win32") {
+        try {
+          user = execFileSync("id", ["-un"], { encoding: "utf8" }).trim();
+        } catch {
+          /* no `id` on PATH — leave user blank, host-only label */
+        }
       }
       const host = hostname();
       return Response.json({ host: user ? `${user}@${host}` : host });


### PR DESCRIPTION
## What

Hardens the `/api/whoami` route so a remote console always tags agents with a real `user@host`, even on arbitrary-uid / minimal containers.

`os.userInfo()` does not reliably throw when the running uid has no `/etc/passwd` entry — under Bun it can return the literal username `"unknown"`. The route previously surfaced that verbatim (e.g. `unknown@host` for a root container). This change:

1. Treats `userInfo().username === "unknown"` (and `""`) as a miss.
2. Falls back to `process.env.USER || LOGNAME || USERNAME`.
3. Last resort on non-win32: runs `id -un`, which returns `root` for uid 0 even when the env carries no `USER`.

Adds `import { execFileSync } from "node:child_process";`.

## Scope note

This branch was intended to carry three daemon-resilience fixes (pm2 exponential restart backoff, EADDRINUSE retry-with-backoff, and robust whoami). On inspection, the pm2 exp-backoff and the EADDRINUSE retry loop are **already present on `origin/main`**, so only the whoami robustness change remained genuinely unmerged. This PR contains just that one isolated change to `ts/serve.ts`.

## Verification

- `bun run build` succeeds.
- No `ts/serve.spec.ts` present to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)