### PR TITLE
docs(build): build:rs builds in place instead of cargo install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,5 +16,10 @@ This compiles `ts/` → `dist/` via tsdown and registers the binaries globally.
 bun run build:rs && bun run build && bun link
 ```
 
-`build:rs` runs `cargo install --path rs` (release build, installs to `~/.cargo/bin/agent-yes`).
-Must be done whenever any `.rs` file changes, otherwise the old binary stays in place.
+`build:rs` runs `cargo build --release` (writes `rs/target/release/agent-yes`). It does
+**not** `cargo install` a system-wide `agent-yes` — only the TypeScript launcher is linked
+onto PATH (`bun link`), and it spawns this Rust binary from `target/release` via
+`findRustBinary()` when needed. A cargo-installed `agent-yes` would shadow that launcher on
+PATH and break subcommands like `agent-yes serve` (the raw runner has no subcommands), so if
+you have a stale `~/.cargo/bin/agent-yes`, remove it. Re-run `build:rs` whenever any `.rs`
+file changes, otherwise the old binary stays in place.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,13 @@ This compiles `ts/` → `dist/` via tsdown and registers the binaries globally.
 bun run build:rs && bun run build && bun link
 ```
 
-`build:rs` runs `cargo install --path rs` (release build, installs to `~/.cargo/bin/agent-yes`).
-Must be done whenever any `.rs` file changes, otherwise the old binary stays in place.
+`build:rs` runs `cargo build --release` (writes `rs/target/release/agent-yes`). It does
+**not** `cargo install` a system-wide `agent-yes` — only the TypeScript launcher is linked
+onto PATH (`bun link`), and it spawns this Rust binary from `target/release` via
+`findRustBinary()` when needed. A cargo-installed `agent-yes` would shadow that launcher on
+PATH and break subcommands like `agent-yes serve` (the raw runner has no subcommands), so if
+you have a stale `~/.cargo/bin/agent-yes`, remove it. Re-run `build:rs` whenever any `.rs`
+file changes, otherwise the old binary stays in place.
 
 `rs/default.config.yaml` is embedded into the Rust binary at compile time via
 `include_str!` (see `rs/src/config.rs`), so editing the CLI ready/enter/etc. markers

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "build": "tsdown",
     "check:e2e": "bun scripts/check-e2e.ts",
     "cf": "bun scripts/cf.ts",
-    "build:rs": "bun ./scripts/build-rs.ts",
+    "build:rs": "cargo build --release --features swarm --manifest-path rs/Cargo.toml",
     "postbuild": "bun ./ts/postbuild.ts",
     "demo": "bun run build && bun link && claude-yes -- demo",
     "dev": "bun ts/index.ts",


### PR DESCRIPTION
## Summary

- Change the `build:rs` npm script from `bun ./scripts/build-rs.ts` (which runs `cargo install --path rs`) to `cargo build --release --features swarm --manifest-path rs/Cargo.toml`. It now builds `rs/target/release/agent-yes` **in place** and no longer installs a system-wide `agent-yes`.
- Why: `findRustBinary()` already resolves `rs/target/release/agent-yes` first, so the `cargo install` copy in `~/.cargo/bin` is unnecessary — and worse, it shadows the `bun link`-ed TS launcher named `agent-yes` on PATH, breaking subcommands like `agent-yes serve` (the raw Rust runner has no subcommands).
- Update `AGENTS.md` and `CLAUDE.md` build:rs descriptions to match (build writes `rs/target/release/agent-yes`; remove any stale `~/.cargo/bin/agent-yes`).
- `CLAUDE.md` already documents the `./tmp/` scratch-scripts convention on main; this branch keeps that section (no duplication).

## Note

`scripts/build-rs.ts` (added in #61 for Windows lock-free rebuilds) is no longer referenced by `build:rs` after this change. It is left untouched here to keep this PR docs/script-scoped; removing or repurposing it can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)