### PR TITLE
fix(rust): stop cargo-installing a system-wide agent-yes on auto-rebuild

### DIFF
--- a/ts/rustBinary.ts
+++ b/ts/rustBinary.ts
@@ -264,15 +264,10 @@ function autoRebuildIfOutdated(binaryPath: string, verbose: boolean): boolean {
       stdio: "inherit",
       timeout: 300_000, // 5 min max
     });
-    // Also update ~/.cargo/bin so the system-wide binary stays current
-    try {
-      execFileSync("cargo", ["install", "--path", rsDir], {
-        stdio: "inherit",
-        timeout: 60_000,
-      });
-    } catch {
-      // non-fatal: the target/ binary is already updated
-    }
+    // Only the target/ binary is rebuilt — we deliberately do NOT `cargo install`
+    // a system-wide `agent-yes`. The launcher is the single global command (it's
+    // what's linked onto PATH) and it spawns this binary from target/release via
+    // findRustBinary(); a cargo-installed `agent-yes` would shadow that launcher.
     process.stderr.write(`\x1b[32m[rust] Rebuild complete\x1b[0m\n`);
     return true;
   } catch {


### PR DESCRIPTION
## What

`autoRebuildIfOutdated()` in `ts/rustBinary.ts` used to do two things when the bundled Rust binary was stale: rebuild `target/release` via `cargo build`, **and** run `cargo install --path` to refresh a system-wide `~/.cargo/bin/agent-yes`. This drops the second step — only the `target/release` binary is rebuilt now.

## Why

The TypeScript launcher is the single global command linked onto PATH. It spawns the Rust binary from `target/release` via `findRustBinary()`. A cargo-installed `agent-yes` on PATH would **shadow that launcher** and break subcommands like `agent-yes serve` (the raw Rust runner has no subcommands). Removing the `cargo install` keeps the launcher authoritative and matches the documented build/run model in CLAUDE.md.

## Notes

This branch was split from a larger CLI-args refactor. The CLI argument-parsing portion of that work (extracting bin-name → CLI resolution into a shared helper, and gating the subcommand fast-path on it) has **already landed on main** as `ts/invokedCli.ts` / `invokedCliName()` with `ts/invokedCli.spec.ts`, so the only remaining, not-yet-on-main hunk is this `rustBinary.ts` change.

## Verification

- `bun test ts/parseCliArgs.spec.ts` → 46 pass
- `npx vitest run ts/invokedCli.spec.ts` → 4 pass
- `bun run build` (typecheck + bundle) → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)