### PR TITLE
fix(ui): show Ctrl+Enter on non-Mac in spawn form hint

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -4453,7 +4453,7 @@
         <button class="lfleet" id="nf-go">▷ Launch</button>
         <button class="lcancel" id="nf-cancel">cancel</button>
       </div>
-      <div class="lhint">POST /api/spawn on this fleet. ⌘/Ctrl+Enter to launch.</div></div>`;
+      <div class="lhint">POST /api/spawn on this fleet. ${IS_MAC ? "⌘" : "Ctrl"}+Enter to launch.</div></div>`;
         $("newform").style.display = "flex";
         setTimeout(() => $("nf-prompt")?.focus(), 0);
       }


### PR DESCRIPTION
The spawn form's submit hint hardcoded the macOS `⌘+Enter` glyph. Use the existing `IS_MAC` flag to show `⌘+Enter` on macOS and `Ctrl+Enter` on Windows/Linux. Display-only — the keydown handler already accepts both `metaKey` and `ctrlKey`.

Cherry-picked from the stale `fix/console-tail-race` branch (the one committed change there not already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)