### PR TITLE
feat(autoretry): retry Claude "Response stalled mid-stream" errors

### DIFF
--- a/default.config.yaml
+++ b/default.config.yaml
@@ -64,6 +64,17 @@ clis:
       - pattern: "API Error.*Overloaded"
         flags: i
       - Overloaded
+      # "API Error: Response stalled mid-stream. The response above may be
+      # incomplete." — the streamed response wedged and the client aborted
+      # mid-token. Transient + server-side like Overloaded, so retry with
+      # backoff instead of dying. Matches the full error wording ("Response …
+      # stalled … mid-stream") rather than the "API Error" prefix, so a
+      # narrow-terminal line-wrap can't hide it AND a casual mention of just
+      # "stalled mid-stream" in normal agent output can't trigger a spurious
+      # retry. `\s+` between words tolerates the wrap; `\s*` after the hyphen
+      # tolerates a wrap inside "mid-stream".
+      - pattern: 'Response\s+stalled\s+mid-\s*stream'
+        flags: i
       # Any 5xx API error (e.g. "API Error: 529 Overloaded", "API Error: 503 …",
       # or a 529 rendered as a raw JSON error blob) is server-side + transient —
       # retry with backoff regardless of the wording. Anchored to "API Error" so

--- a/rs/src/config.rs
+++ b/rs/src/config.rs
@@ -315,6 +315,21 @@ mod tests {
             .auto_retry
             .iter()
             .any(|rx| rx.is_match("API Error: 503 Service Unavailable")));
+        // A stalled/aborted SSE stream prints no status code but is just as
+        // transient — it must auto-retry too…
+        assert!(config.auto_retry.iter().any(|rx| rx.is_match(
+            "API Error: Response stalled mid-stream. The response above may be incomplete."
+        )));
+        // …including when the terminal wraps "mid-stream" across rows…
+        assert!(config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("API Error: Response stalled mid-\nstream.")));
+        // …but a casual mention of the phrase in normal output must NOT.
+        assert!(!config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("the download stalled mid-stream so I retried it")));
         // …but a stray status-like number in normal output must NOT.
         assert!(!config
             .auto_retry


### PR DESCRIPTION
## What

`agent-yes` now auto-retries Claude's **"API Error: Response stalled mid-stream. The response above may be incomplete."** error, the same way it already retries `Overloaded` / 5xx / usage-limit errors.

## Why

A stalled/aborted SSE stream prints that message with **no status code**, so none of the existing `autoRetry` patterns (`API Error.*Overloaded`, `API Error.{0,4}5\d\d`, …) matched it — the run died on a transient, server-side failure instead of recovering.

## How

Added one pattern to the `claude` / `glm` / `openrouter` `autoRetry` lists in `default.config.yaml`:

```yaml
- pattern: 'Response\s+stalled\s+mid-\s*stream'
  flags: i
```

- Matches the **full error wording** (`Response … stalled … mid-stream`) rather than the `API Error` prefix, so it survives a narrow-terminal line-wrap **and** won't fire on a casual mention of the phrase in normal agent output (per codex review).
- `\s+` between words tolerates wrapping; `\s*` after the hyphen tolerates a wrap inside `mid-stream`.
- Retries inherit the existing **exponential backoff** (8s, 16, 32 … 256, give up after 8h) — no new timing code.

Single source of truth is the root `default.config.yaml`; `rs/default.config.yaml` is gitignored and re-copied by `rs/build.rs` at compile time, and embedded via `include_str!`.

## Tests

Extended `config::tests::test_claude_patterns` with positive (plain + line-wrapped) and negative (casual-mention) assertions. `cargo test` + `vitest` green; rebuilt (`build:rs` + `build`) and relinked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)