### PR TITLE
fix(autoretry): stop Claude stall pattern self-triggering on prose

### DIFF
--- a/default.config.yaml
+++ b/default.config.yaml
@@ -67,13 +67,12 @@ clis:
       # "API Error: Response stalled mid-stream. The response above may be
       # incomplete." — the streamed response wedged and the client aborted
       # mid-token. Transient + server-side like Overloaded, so retry with
-      # backoff instead of dying. Matches the full error wording ("Response …
-      # stalled … mid-stream") rather than the "API Error" prefix, so a
-      # narrow-terminal line-wrap can't hide it AND a casual mention of just
-      # "stalled mid-stream" in normal agent output can't trigger a spurious
-      # retry. `\s+` between words tolerates the wrap; `\s*` after the hyphen
-      # tolerates a wrap inside "mid-stream".
-      - pattern: 'Response\s+stalled\s+mid-\s*stream'
+      # backoff instead of dying. Anchored on the literal "API Error:" chrome
+      # the CLI emits, so an agent merely *discussing* a stalled mid-stream
+      # (docs, commits, this very feature's PR) can't self-trigger a retry —
+      # only the real error banner does. `[\s\S]{0,40}` spans the prefix→phrase
+      # gap across a line-wrap; `\s+`/`\s*` tolerate wraps inside the phrase.
+      - pattern: 'API Error:[\s\S]{0,40}Response\s+stalled\s+mid-\s*stream'
         flags: i
       # Any 5xx API error (e.g. "API Error: 529 Overloaded", "API Error: 503 …",
       # or a 529 rendered as a raw JSON error blob) is server-side + transient —

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -10,11 +10,11 @@
 `POST /api/spawn` prepares a working directory, then spawns the agent in it.
 Three ways to produce the `cwd`, in precedence order:
 
-| Request body                  | What happens                                                                                          | Backed by                              |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| `fork: { fromCwd, branch }`   | Fork an existing worktree to a **new branch carrying its uncommitted work**, then spawn there        | `codehost/provision` `forkWorktree`    |
-| `from: "<source>"`            | Provision a GitHub source (clone / worktree / ff-pull) into `<root>/<owner>/<repo>/tree/<branch>`     | `codehost/provision` `provision`       |
-| `cwd: "<dir>"` (or omitted)   | Resolve against the workspace root and `mkdir -p` (a missing dir no longer ENOENTs into a 500)        | `ts/workspaceConfig.ts` `resolveSpawnCwd` |
+| Request body                | What happens                                                                                      | Backed by                                 |
+| --------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `fork: { fromCwd, branch }` | Fork an existing worktree to a **new branch carrying its uncommitted work**, then spawn there     | `codehost/provision` `forkWorktree`       |
+| `from: "<source>"`          | Provision a GitHub source (clone / worktree / ff-pull) into `<root>/<owner>/<repo>/tree/<branch>` | `codehost/provision` `provision`          |
+| `cwd: "<dir>"` (or omitted) | Resolve against the workspace root and `mkdir -p` (a missing dir no longer ENOENTs into a 500)    | `ts/workspaceConfig.ts` `resolveSpawnCwd` |
 
 `from` accepts a GitHub URL, `owner/repo@branch`, or `owner/repo/tree/branch`.
 For `fork`, `fromCwd` is the anchor agent's worktree and `branch` is the new
@@ -66,7 +66,7 @@ so config lives per host, never synced between peers.
 ```jsonc
 {
   "provisionRoot": "/code",
-  "provisionAllowlist": ["snomiao"]
+  "provisionAllowlist": ["snomiao"],
 }
 ```
 
@@ -76,7 +76,7 @@ so config lives per host, never synced between peers.
   (dependency installs + package lifecycle hooks = **code execution** on the
   host), so a non-allowlisted owner/repo → **403**, and an empty allowlist denies
   everything. The `/api/spawn` token is still the trust boundary (it already
-  grants agent-RCE); the allowlist narrows the *new* "clone an arbitrary repo and
+  grants agent-RCE); the allowlist narrows the _new_ "clone an arbitrary repo and
   run its setup" surface.
 - **No injection.** The clone URL is hard-pinned to `https://github.com/<o>/<r>`,
   git runs via `execFile` (no shell), and every path segment is validated
@@ -111,4 +111,4 @@ implementation originated before being promoted into codehost).
 - `lab/ui/index.html` — the "Spawn from" field + the Cmd+K fork / spawn-in-dir rows.
 - codehost `src/provision/` + its `docs/provisioning.md` — the standard.
 - [`docs/auth-and-permissions.md`](./auth-and-permissions.md) — the `agent:spawn`
-  capability whose `cwdRoots` scoping must re-validate the *resolved* cwd.
+  capability whose `cwdRoots` scoping must re-validate the _resolved_ cwd.

--- a/rs/src/config.rs
+++ b/rs/src/config.rs
@@ -325,7 +325,12 @@ mod tests {
             .auto_retry
             .iter()
             .any(|rx| rx.is_match("API Error: Response stalled mid-\nstream.")));
-        // …but a casual mention of the phrase in normal output must NOT.
+        // …but the agent merely *discussing* a stalled mid-stream (docs, commit
+        // messages, this feature's own PR) must NOT self-trigger a retry — the
+        // "API Error:" chrome anchor is what separates the real banner from prose.
+        assert!(!config.auto_retry.iter().any(
+            |rx| rx.is_match("shipped the Response stalled mid-stream auto-retry in v1.153.0")
+        ));
         assert!(!config
             .auto_retry
             .iter()


### PR DESCRIPTION
## Problem

The stall `autoRetry` pattern from #117 matched the bare wording `Response … stalled … mid-stream`. That also matches an agent **merely discussing** the error — docs, commit messages, even this feature's own PR.

When `agent-yes` wraps a Claude Code session that talks about the phrase, it **self-triggers**: the phrase is on screen, the session is idle at its ready prompt → agent-yes types `retry` → that becomes a new turn that re-renders the phrase → re-arms → types `retry` again. A self-reinforcing loop. (This was the exact false-positive flagged in the #117 codex review, reproduced live — the session that built it kept getting `retry`'d.)

## Fix

Anchor on the literal `API Error:` chrome the CLI emits before the phrase:

```yaml
- pattern: 'API Error:[\s\S]{0,40}Response\s+stalled\s+mid-\s*stream'
  flags: i
```

- The real error banner still matches, including a line-wrapped `mid-\nstream` (`[\s\S]{0,40}` spans a wrapped prefix→phrase gap).
- Prose that only *mentions* a stalled mid-stream no longer matches — so an agent discussing it can't trigger a retry.
- Added negative tests for the discussion-prose case (incl. "shipped the Response stalled mid-stream auto-retry in v1.153.0").

## Known residual

Pure screen-scraping still can't distinguish the CLI *emitting* the error from an agent *quoting the full banner verbatim* (`API Error: Response stalled mid-stream`). That's rare outside a conversation literally about this feature, and the chrome anchor eliminates the common case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)