### PR TITLE
feat(ls): surface the Rust unresponsive flag as 'stuck' in ay ls

### DIFF
--- a/ts/globalPidIndex.ts
+++ b/ts/globalPidIndex.ts
@@ -33,6 +33,11 @@ export interface GlobalPidRecord {
   log_file: string | null;
   fifo_file?: string | null;
   status: "active" | "idle" | "exited";
+  // Set by the Rust supervisor when the agent produced no PTY output after a
+  // high-signal poke / while a "working" spinner is frozen — i.e. it looks
+  // wedged. Orthogonal to `status` (which stays "active"); cleared on recovery
+  // and on exit. The ls/status live-state derivation surfaces it as `stuck`.
+  unresponsive?: boolean;
   exit_code: number | null;
   exit_reason: string | null;
   started_at: number;

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -987,7 +987,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
     const status = await deriveLiveStatus(r);
     return {
       ...r,
-      status,
+      // The Rust supervisor's unresponsive flag is an authoritative wedge signal —
+      // surface it as `stuck` so the console's dot matches `ay ls`. (A dead agent
+      // is never unresponsive — Rust clears the flag on exit.)
+      status: status !== "exited" && r.unresponsive ? "stuck" : status,
       title: await logTitle(r.log_file),
       git: status === "exited" ? null : await gitStatus(r.cwd),
       // Task progress from the rendered todo block (null when none detected → no

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1019,6 +1019,33 @@ describe("subcommands.cmdLs --all / --active / keyword filter / aliases", () => 
     expect(parsed.some((r: any) => r.prompt === "exited agent")).toBe(true);
   });
 
+  it("--json surfaces the Rust unresponsive flag as state 'stuck'", async () => {
+    const mod = await loadModule();
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    await appendGlobalPid({
+      pid: process.pid, // alive → not "stopped"
+      cli: "claude",
+      prompt: "wedged-agent-probe",
+      cwd: process.cwd(),
+      log_file: null,
+      status: "active",
+      unresponsive: true,
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now(),
+    });
+    const cap = captureOutput();
+    let code: number | null;
+    try {
+      code = await mod.runSubcommand(["bun", "cli.js", "ls", "--json"]);
+    } finally {
+      cap.restore();
+    }
+    expect(code).toBe(0);
+    const row = JSON.parse(cap.stdout).find((r: any) => r.prompt === "wedged-agent-probe");
+    expect(row?.state).toBe("stuck");
+  });
+
   it("keyword filter restricts results to matching agents", async () => {
     const mod = await loadModule();
     const { appendGlobalPid } = await import("./globalPidIndex.ts");
@@ -1741,6 +1768,29 @@ describe("subcommands.isAgentStuck / stuck state", () => {
       const mod = await loadModule();
       const snap = await mod.snapshotStatus(rec({ log_file: log }));
       expect(snap.state).toBe("stuck");
+    } finally {
+      await rm(dir, { recursive: true, force: true }).catch(() => null);
+    }
+  });
+
+  it("snapshotStatus: reports 'stuck' when the Rust unresponsive flag is set (no log needed)", async () => {
+    const mod = await loadModule();
+    const snap = await mod.snapshotStatus(rec({ unresponsive: true, log_file: null }));
+    expect(snap.state).toBe("stuck");
+  });
+
+  it("snapshotStatus: the unresponsive flag overrides a quiet (would-be idle) log", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ay-stuck-"));
+    try {
+      const log = path.join(dir, "a.log");
+      // Long-silent, no busy marker → would read as `idle`; the flag forces `stuck`.
+      await writeFile(log, "⏺ Done — all green.\r\n❯\r\n");
+      await utimes(log, tenMinAgo(), tenMinAgo());
+      const mod = await loadModule();
+      expect((await mod.snapshotStatus(rec({ log_file: log }))).state).toBe("idle");
+      expect((await mod.snapshotStatus(rec({ log_file: log, unresponsive: true }))).state).toBe(
+        "stuck",
+      );
     } finally {
       await rm(dir, { recursive: true, force: true }).catch(() => null);
     }

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -999,6 +999,10 @@ async function deriveLiveState(
 ): Promise<{ state: LiveState; question: string | null }> {
   const base = await deriveLiveStatus(r);
   if (base === "exited") return { state: "stopped", question: null };
+  // The Rust supervisor flagged this agent unresponsive (no PTY output after a
+  // poke / a frozen "working" spinner) — an authoritative wedge signal, so it
+  // wins over the log-tail heuristics (needs_input / stuck) below.
+  if (r.unresponsive) return { state: "stuck", question: null };
   // A blocked menu overrides active/idle (alive + quiet, but waiting for an answer).
   if (r.log_file) {
     const ni = await extractNeedsInput(r.log_file, r.cli);
@@ -2891,6 +2895,10 @@ export async function snapshotStatus(record: GlobalPidRecord): Promise<StatusSna
       state = "stuck";
     }
   }
+  // The Rust supervisor's unresponsive flag is an authoritative wedge signal —
+  // it overrides the log-tail heuristics above (but never a dead agent, which
+  // Rust clears the flag on anyway).
+  if (alive && record.unresponsive) state = "stuck";
   const notes = await readNotes();
   const note = notes.get(record.pid) ?? null;
   return {


### PR DESCRIPTION
## Problem

The Rust supervisor sets an `unresponsive` flag in `pids.jsonl` (no PTY output after a poke / frozen "working" spinner), but **nothing on the TS side consumed it**: `ay ls` showed no indicator, `GlobalPidRecord` didn't even declare the field, and the web console never referenced it. The flag was visible only in raw `ay ls --json` passthrough — invisible to a human. (Found while verifying #112/#115.)

## Change — build the consumer side

- Declare `unresponsive?: boolean` on `GlobalPidRecord`.
- Map it to the existing `stuck` live-state in **`deriveLiveState`** (`ay ls` text + `--json`) and **`snapshotStatus`** (`ay status` / `--watch`), as an authoritative wedge signal that overrides the log-tail heuristics — but never a dead agent (Rust clears the flag on exit).
- Mirror it in **`serve.ts` `withMeta`** so the web console's status dot matches `ay ls`.

One flag → `stuck` consistently across every surface.

## Verification

- New `snapshotStatus` unit tests (flag with no log; flag overrides a would-be `idle`) + an `ay ls --json` integration test asserting `state: "stuck"`.
- Manual end-to-end: with a live unresponsive record, text `ay ls` prints `claude  stuck  …`.
- `oxfmt --check` clean · `bun run build` clean · full `test:coverage` **563 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)