### PR TITLE
feat(restart): ay restart stops a live agent then resumes the session

### DIFF
--- a/agent-yes.config.schema.json
+++ b/agent-yes.config.schema.json
@@ -171,6 +171,10 @@
           "items": { "$ref": "#/definitions/RegexSource" },
           "description": "Regex patterns for errors that require restart WITHOUT continue args"
         },
+        "resumeCommand": {
+          "$ref": "#/definitions/RegexSource",
+          "description": "Optional regex scraped from the agent's log on `ay restart`. Capture group 1 is the argument string (whitespace-split) to relaunch with — i.e. a resume command the CLI printed, like '--resume <id>'. When absent or unmatched, restart falls back to restoreArgs (e.g. --continue)."
+        },
         "bunx": {
           "type": "boolean",
           "description": "Use bunx instead of npx to run the CLI (faster startup)"

--- a/default.config.yaml
+++ b/default.config.yaml
@@ -88,6 +88,15 @@ clis:
         flags: i
     restoreArgs:
       - --continue
+    # resumeCommand (optional): a regex scraped from the agent's log by
+    # `ay restart` to resume the exact session when a CLI prints a resume command.
+    # Capture group 1 is the argument string (whitespace-split) appended to the
+    # relaunched `agent-yes --cli=<cli> …`. The claude family has no printed resume
+    # command — it resumes via restoreArgs (--continue) above — so it's left unset.
+    # Example for a CLI that prints one:
+    #   resumeCommand:
+    #     pattern: 'To resume, run:.*?(--resume \S+)'
+    #     flags: i
     restartWithoutContinueArg:
       - No conversation found to continue
     exitCommands:
@@ -176,6 +185,15 @@ clis:
         flags: i
     restoreArgs:
       - --continue
+    # resumeCommand (optional): a regex scraped from the agent's log by
+    # `ay restart` to resume the exact session when a CLI prints a resume command.
+    # Capture group 1 is the argument string (whitespace-split) appended to the
+    # relaunched `agent-yes --cli=<cli> …`. The claude family has no printed resume
+    # command — it resumes via restoreArgs (--continue) above — so it's left unset.
+    # Example for a CLI that prints one:
+    #   resumeCommand:
+    #     pattern: 'To resume, run:.*?(--resume \S+)'
+    #     flags: i
     restartWithoutContinueArg:
       - No conversation found to continue
     exitCommands:
@@ -269,6 +287,15 @@ clis:
         flags: i
     restoreArgs:
       - --continue
+    # resumeCommand (optional): a regex scraped from the agent's log by
+    # `ay restart` to resume the exact session when a CLI prints a resume command.
+    # Capture group 1 is the argument string (whitespace-split) appended to the
+    # relaunched `agent-yes --cli=<cli> …`. The claude family has no printed resume
+    # command — it resumes via restoreArgs (--continue) above — so it's left unset.
+    # Example for a CLI that prints one:
+    #   resumeCommand:
+    #     pattern: 'To resume, run:.*?(--resume \S+)'
+    #     flags: i
     restartWithoutContinueArg:
       - No conversation found to continue
     exitCommands:

--- a/ts/configShared.ts
+++ b/ts/configShared.ts
@@ -19,6 +19,7 @@ type RawCliConfig = Omit<
   | "exitCommands"
   | "autoRetry"
   | "needsInput"
+  | "resumeCommand"
 > & {
   ready?: RegexSource[];
   fatal?: RegexSource[];
@@ -30,6 +31,7 @@ type RawCliConfig = Omit<
   updateAvailable?: RegexSource[];
   autoRetry?: RegexSource[];
   needsInput?: RegexSource[];
+  resumeCommand?: RegexSource;
   exitCommands?: string[];
   exitCommand?: string[];
 };
@@ -84,6 +86,7 @@ export function normalizeCliConfig(raw: RawCliConfig): AgentCliConfig {
     updateAvailable,
     autoRetry,
     needsInput,
+    resumeCommand,
     exitCommands,
     exitCommand,
     ...rest
@@ -101,6 +104,7 @@ export function normalizeCliConfig(raw: RawCliConfig): AgentCliConfig {
     updateAvailable: compileRegexList(updateAvailable),
     autoRetry: compileRegexList(autoRetry),
     needsInput: compileRegexList(needsInput),
+    resumeCommand: resumeCommand === undefined ? undefined : compileRegexSource(resumeCommand),
     exitCommands: exitCommands ?? exitCommand,
   };
 }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -75,6 +75,7 @@ export type AgentCliConfig = {
   // crash/resuming-session behaviour
   restoreArgs?: string[]; // arguments to continue the session when crashed
   restartWithoutContinueArg?: RegExp[]; // array of regex to match for errors that require restart without continue args
+  resumeCommand?: RegExp; // optional: scraped from the agent's log on `ay restart`. Capture group 1 is the argument string (whitespace-split) to relaunch with — i.e. a resume command the CLI printed, like "--resume <id>". When absent or unmatched, restart falls back to restoreArgs (e.g. --continue).
 };
 export type AgentYesConfig = {
   configDir?: string; // directory to store agent-yes config files, e.g. session store

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1458,7 +1458,10 @@ describe("subcommands.cmdStatus", () => {
 // ---------------------------------------------------------------------------
 
 describe("subcommands.cmdRestart", () => {
-  it("returns 1 and warns when the agent is still alive", async () => {
+  // A live agent is now stopped-then-resumed. With no fifo_file the graceful
+  // stop can't be sent, so it errors out *before* any kill — which also proves
+  // the live test process (used as the fake pid) is never signalled.
+  it("returns 1 when a live agent can't be gracefully stopped (no fifo_file)", async () => {
     const mod = await loadModule();
     const { appendGlobalPid } = await import("./globalPidIndex.ts");
     await appendGlobalPid({
@@ -1482,10 +1485,13 @@ describe("subcommands.cmdRestart", () => {
     try {
       const code = await mod.runSubcommand(["bun", "cli.js", "restart", String(process.pid)]);
       expect(code).toBe(1);
-      expect(stderr.join("")).toMatch(/still running/);
+      expect(stderr.join("")).toMatch(/no fifo_file/);
     } finally {
       process.stderr.write = origErr;
     }
+    // The live process must still be alive — restart must not have killed it.
+    // (signal 0 throws only if the pid is gone / not signalable.)
+    expect(() => process.kill(process.pid, 0)).not.toThrow();
   });
 });
 
@@ -1821,5 +1827,66 @@ describe("subcommands.cmdRead replays at the ptysize sidecar geometry", () => {
     } finally {
       await rm(tmp, { recursive: true, force: true }).catch(() => null);
     }
+  });
+});
+
+describe("subcommands.resolveResumeArgs", () => {
+  it("replays the original prompt when --fresh", async () => {
+    const { resolveResumeArgs } = await loadModule();
+    expect(
+      resolveResumeArgs({ restoreArgs: ["--continue"] }, "irrelevant log", {
+        fresh: true,
+        prompt: "do the thing",
+      }),
+    ).toEqual({ args: ["do the thing"], strategy: "fresh (replay original prompt)" });
+  });
+
+  it("--fresh with no prompt yields no args", async () => {
+    const { resolveResumeArgs } = await loadModule();
+    expect(resolveResumeArgs(undefined, "", { fresh: true })).toEqual({
+      args: [],
+      strategy: "fresh (no prompt)",
+    });
+  });
+
+  it("scrapes a printed resume command (capture group 1, whitespace-split)", async () => {
+    const { resolveResumeArgs } = await loadModule();
+    const conf = { resumeCommand: /To resume run: agent (.+)/ };
+    const log = "...\nTo resume run: agent --resume abc-123\n> ";
+    expect(resolveResumeArgs(conf, log, { fresh: false })).toEqual({
+      args: ["--resume", "abc-123"],
+      strategy: "printed resume command: --resume abc-123",
+    });
+  });
+
+  it("ignores a stray global flag on resumeCommand and still captures", async () => {
+    const { resolveResumeArgs } = await loadModule();
+    const conf = { resumeCommand: /resume=(\S+)/g };
+    expect(resolveResumeArgs(conf, "session resume=zzz here", { fresh: false }).args).toEqual([
+      "zzz",
+    ]);
+  });
+
+  it("falls back to restoreArgs when resumeCommand is absent or unmatched", async () => {
+    const { resolveResumeArgs } = await loadModule();
+    expect(
+      resolveResumeArgs({ restoreArgs: ["--continue"] }, "no resume hint here", { fresh: false }),
+    ).toEqual({ args: ["--continue"], strategy: "restoreArgs (--continue)" });
+    // resumeCommand present but no match in the log → still falls back.
+    expect(
+      resolveResumeArgs(
+        { resumeCommand: /resume (\S+)/, restoreArgs: ["resume", "--last"] },
+        "nothing matches",
+        { fresh: false },
+      ).args,
+    ).toEqual(["resume", "--last"]);
+  });
+
+  it("falls back to --continue when neither resumeCommand nor restoreArgs exist", async () => {
+    const { resolveResumeArgs } = await loadModule();
+    expect(resolveResumeArgs(undefined, "", { fresh: false })).toEqual({
+      args: ["--continue"],
+      strategy: "--continue (fallback)",
+    });
   });
 });

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -392,6 +392,7 @@ export function cmdHelp(managerCommands = true): number {
       `  ay attach <keyword>                 interactive attach (detach: Ctrl-\\)\n` +
       `  ay stop <keyword>                   graceful shutdown (/exit for claude/codex)\n` +
       `  ay exit <keyword> [reason]          graceful shutdown, recording who/why (= 'ay send <kw> exit')\n` +
+      `  ay restart <keyword> [--fresh]      stop (if live) + relaunch resuming the session; --fresh replays the prompt\n` +
       `  ay status <keyword>                 agent status snapshot\n` +
       `  ay result <keyword> [--wait]        pull an agent's structured result envelope\n` +
       `  ay result set '<json>'              (inside an agent) deposit your result envelope\n` +
@@ -2754,11 +2755,72 @@ async function cmdAttach(rest: string[]): Promise<number> {
 // ay restart
 // ---------------------------------------------------------------------------
 
+/**
+ * Decide how to relaunch an agent on `ay restart`. Pure (no I/O) so it's unit
+ * testable. Precedence:
+ *  - `fresh`: replay the original prompt (the old behaviour), no resume.
+ *  - else if the CLI printed a resume command its `resumeCommand` regex matches
+ *    in the captured log (capture group 1 = the arg string), relaunch with those
+ *    whitespace-split args.
+ *  - else fall back to `restoreArgs` (e.g. `--continue`) so the wrapper's own
+ *    resume plumbing (claude --continue, codex stored-session) kicks in.
+ */
+export function resolveResumeArgs(
+  conf: AgentCliConfig | undefined,
+  logText: string,
+  opts: { fresh: boolean; prompt?: string },
+): { args: string[]; strategy: string } {
+  if (opts.fresh) {
+    return opts.prompt
+      ? { args: [opts.prompt], strategy: "fresh (replay original prompt)" }
+      : { args: [], strategy: "fresh (no prompt)" };
+  }
+  const re = conf?.resumeCommand;
+  if (re) {
+    // Strip a stray `g` flag so .exec returns capture groups deterministically.
+    const probe = re.global ? new RegExp(re.source, re.flags.replace(/g/g, "")) : re;
+    const m = probe.exec(logText);
+    const captured = m?.[1]?.trim();
+    if (captured) {
+      const parts = captured.split(/\s+/).filter(Boolean);
+      if (parts.length) return { args: parts, strategy: `printed resume command: ${captured}` };
+    }
+  }
+  const restore = conf?.restoreArgs;
+  if (restore && restore.length) {
+    return { args: [...restore], strategy: `restoreArgs (${restore.join(" ")})` };
+  }
+  return { args: ["--continue"], strategy: "--continue (fallback)" };
+}
+
+/**
+ * Wait for a pid to exit. No cross-process exit event exists (the agent is owned
+ * by its own wrapper), so poll `isPidAlive` — checked once immediately, then with
+ * golden-ratio backoff (1.0, 1.6, 2.6…s, capped) up to `timeoutMs`. Returns true
+ * once the pid is gone.
+ */
+async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+  if (!isPidAlive(pid)) return true;
+  const start = Date.now();
+  let delay = 1000;
+  while (Date.now() - start < timeoutMs) {
+    await new Promise((r) => setTimeout(r, delay));
+    if (!isPidAlive(pid)) return true;
+    delay = Math.min(Math.round(delay * 1.618), 8000);
+  }
+  return !isPidAlive(pid);
+}
+
 async function cmdRestart(rest: string[]): Promise<number> {
   const y = yargs(rest)
-    .usage("Usage: ay restart <keyword>")
+    .usage("Usage: ay restart <keyword> [--fresh]")
     .option("latest", { type: "boolean", default: false, description: "Use most recent match" })
     .option("cwd", { type: "string", description: "Restrict to agents under this dir" })
+    .option("fresh", {
+      type: "boolean",
+      default: false,
+      description: "Replay the original prompt instead of resuming the session",
+    })
     .help(false)
     .version(false)
     .exitProcess(false);
@@ -2773,23 +2835,50 @@ async function cmdRestart(rest: string[]): Promise<number> {
   };
   const keyword = argv._[0] !== undefined ? String(argv._[0]) : undefined;
   const record = await resolveOne(keyword, opts);
+  const fresh = Boolean(argv.fresh);
 
+  // Live agent: gracefully stop it (claude /exit / double-Ctrl+C via FIFO), then
+  // wait for it to actually exit before relaunching.
   if (isPidAlive(record.pid)) {
-    process.stderr.write(`pid ${record.pid} is still running — stop it first or use ay send\n`);
-    return 1;
+    await gracefulExitAgent(record, "restart");
+    process.stdout.write(`stopping pid ${record.pid} (${record.cli}) before restart…\n`);
+    let exited = await waitForExit(record.pid, 30_000);
+    if (!exited) {
+      // Wouldn't go gracefully — SIGKILL the pid (the reaper sweeps its pgid).
+      try {
+        process.kill(record.pid, "SIGKILL");
+      } catch {
+        /* already gone / not permitted */
+      }
+      exited = await waitForExit(record.pid, 5_000);
+    }
+    if (!exited) {
+      process.stderr.write(
+        `pid ${record.pid} did not exit — aborting restart ` +
+          `(try: ay stop ${record.pid} --method=double-ctrl-c)\n`,
+      );
+      return 1;
+    }
   }
 
-  const args = ["--cli=" + record.cli];
-  if (record.prompt) args.push(record.prompt);
+  // Resolve how to relaunch: a printed resume command (config `resumeCommand`),
+  // else restoreArgs/--continue, else replay the prompt when --fresh.
+  const conf = (await cliDefaults())[record.cli];
+  const logText =
+    !fresh && record.log_file ? await readFile(record.log_file, "utf8").catch(() => "") : "";
+  const { args: resumeArgs, strategy } = resolveResumeArgs(conf, logText, {
+    fresh,
+    prompt: record.prompt,
+  });
 
-  const proc = Bun.spawn(["agent-yes", ...args], {
+  const proc = Bun.spawn(["agent-yes", "--cli=" + record.cli, ...resumeArgs], {
     cwd: record.cwd,
     detached: true,
     stdio: ["ignore", "ignore", "ignore"],
   });
 
   process.stdout.write(
-    `restarted ${record.cli} in ${shortenPath(record.cwd)} (new pid: ${proc.pid})\n`,
+    `restarted ${record.cli} in ${shortenPath(record.cwd)} via ${strategy} (new pid: ${proc.pid})\n`,
   );
   process.stderr.write(
     `\n` +


### PR DESCRIPTION
Upgrades `ay restart <kw>` from "refuse if alive, replay the prompt fresh" to **stop-then-resume**.

## Behavior
On a **live** agent, `ay restart`:
1. Gracefully stops it — claude `/exit` / double-Ctrl+C via the per-pid **FIFO** (reusing `gracefulExitAgent`).
2. Waits for exit — no cross-process exit event exists (agents are owned by their own wrapper, see [docs/architecture.md](docs/architecture.md#process-model--ipc)), so it polls `isPidAlive` once immediately then with **golden-ratio backoff** (1.0, 1.6, 2.6…s, capped), up to 30s; escalates to `SIGKILL` (the reaper sweeps the pgid) if it won't go.
3. Relaunches **resuming the session**:
   - if the CLI printed a resume command, scrape it via the new per-CLI **`resumeCommand`** regex (capture group 1 = whitespace-split args) and relaunch with it;
   - else fall back to `restoreArgs` (`--continue`) → the wrapper's existing resume plumbing (claude `--continue`, codex stored-session in `rs/src/codex_sessions.rs`).

`--fresh` keeps the old replay-the-original-prompt behavior. A dead agent is simply resumed (no stop needed).

## Config-driven resume detection (`resumeCommand`)
New optional per-CLI field, wired end to end:
- `agent-yes.config.schema.json` — schema property (RegexSource)
- `ts/index.ts` `AgentCliConfig` + `ts/configShared.ts` `RawCliConfig`/`normalizeCliConfig` — compiles to `RegExp`
- documented (intentionally **unset**) example in `default.config.yaml` for the claude family — they resume via `--continue`, so no built-in hard-codes an unverified pattern; Rust ignores the unknown key (no `deny_unknown_fields`).

## Tests
- Pure `resolveResumeArgs(conf, logText, {fresh, prompt})` helper — unit tests cover `--fresh` (with/without prompt), printed-resume scrape (incl. stray `/g` flag), and fallbacks to `restoreArgs` then `--continue`.
- The live-agent test now asserts the target process is **never killed** when graceful stop can't be sent.

95 TS tests green; Rust config test green; typecheck clean for changed files; rebuilt + relinked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)