### PR TITLE
chore(hooks): move full coverage gate from pre-commit to pre-push

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,7 +4,13 @@ bun run fmt
 git add -u
 bunx lint-staged
 bun run build
-bun run test:coverage
+# NOTE: the full `bun run test:coverage` gate runs in pre-push, NOT here. It's
+# the heaviest thing in the toolchain (full suite + v8 coverage in a serial
+# fork pool), so running it on EVERY commit made commits take minutes — and
+# hang for ~hours when the host is CPU-oversubscribed (shared dev box, many
+# agents). Keeping commits fast (fmt + lint + build) and gating the full suite
+# at push time means you still can't push red, but you can commit freely. CI
+# remains the authoritative coverage gate either way.
 
 # Rust validation (only when rs/ files are staged) — gives local feedback
 # before CI does. cargo check is fast (~5-15s incremental, type/borrow only,

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,14 @@
 #!/usr/bin/env sh
 set -e
 
+# Full test + coverage gate. Moved here from pre-commit (see .husky/pre-commit)
+# so commits stay fast — but you still can't push red: the same suite CI
+# enforces runs locally before the push leaves your machine. Use
+# `git push --no-verify` only as a deliberate escape hatch (e.g. a host too
+# CPU-oversubscribed to finish the suite) — CI is still authoritative.
+echo "[pre-push] running full test + coverage gate"
+bun run test:coverage
+
 # Guard the console's OS light/dark adaptation before it can ship. Only when the
 # UI source actually changed since upstream, so unrelated pushes stay fast. The
 # CI deploy job (ui-test.yml) ships lab/ui to agent-yes.com on merge, so this is


### PR DESCRIPTION
## Why

`.husky/pre-commit` ran `bun run test:coverage` — the full vitest suite **with v8 coverage** in a fully-serial fork pool (`fileParallelism: false`, `singleFork: true`, `isolate: true`) — on **every commit**. That's the heaviest thing in the toolchain. On a healthy box it's ~82s/commit; on a CPU-oversubscribed shared host (reproduced at **load 60 on 8 cores, 55 agent procs**) vitest's `forks` pool can't spawn/terminate workers within its internal timeouts (`Failed to start forks worker` / `Timeout terminating forks worker`), so commits **wedge for hours**.

## What

- **pre-commit** now runs only the fast gates: `fmt` + `lint-staged` + `build` (+ the existing rust checks). No test suite.
- **pre-push** now runs the full `bun run test:coverage` gate (always), then the existing conditional console-theme e2e. You still can't push red; you just commit freely.
- CI remains the authoritative coverage gate. `git push --no-verify` stays as a deliberate escape hatch for a host too loaded to finish the suite.

This is the dev-flow half of the fix. A separate PR parallelizes the vitest fork pool so the suite itself is faster and doesn't wedge under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)