### PR TITLE
perf(test): run vitest files in parallel (forks) instead of fully serial

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,10 +14,18 @@ export default defineConfig({
       "ts/tests/rust-cwd.spec.ts",
       "node_modules/**/*",
     ],
-    fileParallelism: false,
+    // Run test FILES in parallel across multiple forked processes. Forks (not
+    // threads) are deliberate: subcommands.spec uses process.chdir() — which
+    // throws in worker threads — and forks give each file its own process.env +
+    // cwd, so per-file env/cwd mutations can't leak across files. Cross-file
+    // filesystem collisions are avoided because every spec's temp dir is keyed by
+    // process.pid or mkdtemp() (unique per fork), and tests WITHIN a file stay
+    // sequential (sequence.concurrent: false). This replaces the old fully-serial
+    // singleFork config, which made the suite ~Ncores× slower and — on a
+    // CPU-oversubscribed host — wedged on fork spawn/terminate timeouts.
+    fileParallelism: true,
     pool: "forks",
     forks: {
-      singleFork: true,
       isolate: true,
     },
     sequence: {


### PR DESCRIPTION
## Why

`vitest.config.ts` ran the suite **fully serial**: `fileParallelism: false` + `forks.singleFork: true` + `isolate: true` → all 38 test files executed one-at-a-time in a single fork process. ~82s on a healthy box, and on a CPU-oversubscribed host (load 60 on 8 cores) the forks pool wedged on worker spawn/terminate timeouts.

## What

Enable **file parallelism over the forks pool** (drop `singleFork`, set `fileParallelism: true`).

**Why forks, not threads:** `subcommands.spec` uses `process.chdir()`, which throws in worker threads. Forks are real processes, so each test file gets its own `process.env` **and** `cwd` — per-file env/cwd mutations can't leak across files. Cross-file filesystem collisions are avoided because every spec's temp dir is keyed by `process.pid` or `mkdtemp()` (unique per fork), and tests **within** a file stay sequential (`sequence.concurrent: false`).

## Validation

Full `--coverage` run deferred to CI (it owns the 90% threshold on a clean box; this dev host is too oversubscribed to finish it). Locally, under the new parallel config:
- All 10 stateful specs run **concurrently** with no collisions — pidStore, globalPidIndex, reaper, runningLock, configLoader, workspaceConfig, setup, JsonlStore, configShared, agentYesHome (143 tests, 4.5s).
- `subcommands.spec` (the `process.chdir` one) passes alongside others (106 tests, 3.6s).

Pairs with #123 (which moved the coverage gate to pre-push) to fix the "commits/pushes hang for hours" problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)