### PR TITLE
feat(console): give the stuck status dot a distinct (red) color

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -832,6 +832,12 @@
       .dot.idle {
         background: var(--amber);
       }
+      /* Wedged: the Rust supervisor flagged the agent unresponsive (no PTY output
+         after a poke / frozen spinner) — surfaced as `stuck` by /api/ls. Red so a
+         stuck agent stands out from a healthy green / quiet-amber one. */
+      .dot.stuck {
+        background: var(--red);
+      }
       .dot.stopped,
       .dot.exited {
         background: var(--muted);


### PR DESCRIPTION
Follow-up to #120. That PR made `/api/ls` report an unresponsive agent as `stuck`, but the console's dot CSS only had rules for `active`/`idle`/`stopped` — a `stuck` dot hit the base `.dot` rule with **no `background`**, so it rendered as an invisible circle. The state reached the console but wasn't visible.

Adds `.dot.stuck { background: var(--red) }` so a wedged agent's dot is red (distinct from healthy green / quiet amber).

**Verified** against a live test server: the served console HTML carries the new rule, and `/api/ls` reports `status: "stuck"` for an unresponsive agent — so the row's `class="dot ${e.status}"` resolves to `dot stuck` and paints red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)