### PR TITLE
feat(serve): host-local spawn hook to provision the env before each agent

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1,4 +1,4 @@
-import { mkdir, open, readFile, stat, writeFile } from "fs/promises";
+import { mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
 import { renameSync, watch, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -23,7 +23,13 @@ import { updateGlobalPidStatus } from "./globalPidIndex.ts";
 import { pgidForWrapper } from "./reaper.ts";
 import { SUPPORTED_CLIS } from "./SUPPORTED_CLIS.ts";
 import { getInstalledPackage } from "./versionChecker.ts";
-import { getProvisionRoot, isProvisionAllowed, resolveSpawnCwd } from "./workspaceConfig.ts";
+import {
+  getProvisionRoot,
+  getSpawnHook,
+  hasSpawnHook,
+  isProvisionAllowed,
+  resolveSpawnCwd,
+} from "./workspaceConfig.ts";
 
 const DEFAULT_PORT = 7432;
 
@@ -1157,6 +1163,15 @@ export async function cmdServe(rest: string[]): Promise<number> {
       return Response.json({ version: getInstalledPackage().version });
     }
 
+    // GET /api/spawn-config — read-only disclosure of WHETHER a host-local spawn
+    // hook is configured. Deliberately returns only a boolean, never the hook
+    // body: the hook is arbitrary local code and console/room clients holding the
+    // share token are not necessarily host admins. Setting it stays host-local
+    // (edit ~/.agent-yes/config.json) — there is no PUT.
+    if (req.method === "GET" && p === "/api/spawn-config") {
+      return Response.json({ hasSpawnHook: hasSpawnHook() });
+    }
+
     // GET /api/notes
     if (req.method === "GET" && p === "/api/notes") {
       const notes = await readNotes();
@@ -1641,10 +1656,75 @@ export async function cmdServe(rest: string[]): Promise<number> {
         process.platform === "win32" && ayBin.toLowerCase().endsWith(".exe")
           ? [ayBin]
           : [process.execPath, ayBin];
+      const agentArgv = [...ayCmd, cli, ...(prompt ? ["--", prompt] : [])];
+      // don't leak our Claude Code session into the agent
+      const agentEnv = freshAgentEnv();
       try {
-        const child = Bun.spawn([...ayCmd, cli, ...(prompt ? ["--", prompt] : [])], {
+        const hook = getSpawnHook();
+        if (hook) {
+          // Host-local spawn hook (trusted local code, never network-writable). We
+          // run it via POSIX `sh -c` then `exec "$@"` the real agent — the agent
+          // argv is passed as positional params ($1…), so the prompt is NEVER
+          // shell-parsed (no quoting/injection surface). `set -e` aborts the spawn
+          // if any hook step fails. No `-l`: we don't re-source rc files here (the
+          // env is already the recovered login-shell env via freshAgentEnv). cwd
+          // and cli are exposed as env for the hook to consume.
+          const shell = process.env.AGENT_YES_SPAWN_SHELL?.trim() || "/bin/sh";
+          const script = `set -e\n${hook}\nexec "$@"`;
+          const errPath = path.join(
+            agentYesHome(),
+            `spawn-hook-${process.pid}-${performance.now().toString(36).replace(".", "")}.err`,
+          );
+          // File-backed stderr never blocks the child (a pipe we stop draining
+          // after exec would), and bounds our read to the first few KB.
+          const child = Bun.spawn([shell, "-c", script, "ay-spawn", ...agentArgv], {
+            cwd,
+            env: { ...agentEnv, AGENT_YES_CWD: cwd, AGENT_YES_CLI: cli },
+            stdin: "ignore",
+            stdout: "ignore",
+            stderr: Bun.file(errPath),
+          });
+          // Handshake: surface an EARLY hook/provision failure synchronously. If
+          // the child exits non-zero within the window, the hook failed before the
+          // agent settled — return the captured stderr. If it's still alive after
+          // the window, `exec` succeeded (or the agent is running) → detach and
+          // report success. We can't always attribute a failure to the hook vs the
+          // agent, so we just surface the captured output.
+          const windowMs = Number(process.env.AGENT_YES_SPAWN_HOOK_TIMEOUT_MS) || 5000;
+          const exitCode = await Promise.race([
+            child.exited,
+            new Promise<null>((r) => setTimeout(() => r(null), windowMs)),
+          ]);
+          if (exitCode !== null && exitCode !== 0) {
+            let detail = "";
+            try {
+              detail = (await Bun.file(errPath).text()).slice(0, 4096);
+            } catch {
+              /* no stderr captured */
+            }
+            await unlink(errPath).catch(() => {});
+            return new Response(
+              `spawn hook failed (exit ${exitCode})${detail ? `:\n${detail.trimEnd()}` : ""}`,
+              { status: 502 },
+            );
+          }
+          child.unref();
+          // Clean up the stderr sidecar. On POSIX the running agent may still hold
+          // the fd; unlinking an open file is harmless (the inode lives until
+          // close), so a brief delay is enough to keep early-failure reads valid.
+          setTimeout(() => void unlink(errPath).catch(() => {}), 60_000).unref?.();
+          return Response.json({
+            ok: true,
+            pid: child.pid,
+            cli,
+            cwd,
+            hook: true,
+            ...(provisioned ? { provisioned } : {}),
+          });
+        }
+        const child = Bun.spawn(agentArgv, {
           cwd,
-          env: freshAgentEnv(), // don't leak our Claude Code session into the agent
+          env: agentEnv,
           stdin: "ignore",
           stdout: "ignore",
           stderr: "ignore",

--- a/ts/workspaceConfig.spec.ts
+++ b/ts/workspaceConfig.spec.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import path from "path";
 import {
   expandTilde,
   getProvisionAllowlist,
   getProvisionRoot,
+  getSpawnHook,
   getWorkspaceRoot,
+  hasSpawnHook,
   isProvisionAllowed,
   resolveSpawnCwd,
   setWorkspaceRoot,
@@ -25,6 +27,7 @@ describe("workspaceConfig", () => {
     else process.env.AGENT_YES_HOME = original;
     delete process.env.CODEHOST_WS_ROOT;
     delete process.env.CODEHOST_PROVISION_ALLOWLIST;
+    delete process.env.AGENT_YES_SPAWN_HOOK;
     rmSync(tmp, { recursive: true, force: true });
   });
 
@@ -141,5 +144,43 @@ describe("workspaceConfig", () => {
       expect(isProvisionAllowed("acme", "other")).toBe(false);
       expect(isProvisionAllowed("org", "anything")).toBe(true);
     });
+  });
+
+  describe("getSpawnHook / hasSpawnHook", () => {
+    const isPosix = process.platform !== "win32";
+
+    it("is null/false when unset", () => {
+      expect(getSpawnHook()).toBeNull();
+      expect(hasSpawnHook()).toBe(false);
+    });
+
+    it("returns the configured hook from a private (0600) config", () => {
+      writeConfig({ spawnHook: 'echo hi >&2\nexec "$@"' });
+      if (isPosix) chmodSync(path.join(tmp, "config.json"), 0o600);
+      expect(getSpawnHook()).toBe('echo hi >&2\nexec "$@"');
+      expect(hasSpawnHook()).toBe(true);
+    });
+
+    it("ignores a blank hook", () => {
+      writeConfig({ spawnHook: "   " });
+      expect(getSpawnHook()).toBeNull();
+    });
+
+    it("env AGENT_YES_SPAWN_HOOK overrides the config", () => {
+      writeConfig({ spawnHook: "from-file" });
+      process.env.AGENT_YES_SPAWN_HOOK = "from-env";
+      expect(getSpawnHook()).toBe("from-env");
+    });
+
+    it.skipIf(!isPosix)(
+      "refuses a file-backed hook when the config is group/world-writable (tampering guard)",
+      () => {
+        writeConfig({ spawnHook: "echo pwned" });
+        chmodSync(path.join(tmp, "config.json"), 0o666);
+        expect(getSpawnHook()).toBeNull();
+        chmodSync(path.join(tmp, "config.json"), 0o600);
+        expect(getSpawnHook()).toBe("echo pwned");
+      },
+    );
   });
 });

--- a/ts/workspaceConfig.ts
+++ b/ts/workspaceConfig.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { lstatSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import path from "path";
 import { agentYesHome } from "./agentYesHome.ts";
@@ -19,6 +19,12 @@ interface Config {
   provisionRoot?: string;
   /** Owners/repos permitted for `from`-provisioning; empty = deny all. */
   provisionAllowlist?: string[];
+  /**
+   * A trusted, HOST-LOCAL shell hook run before each console/CLI spawn. See
+   * {@link getSpawnHook}. Intentionally NOT settable over the network — it is
+   * arbitrary local code that runs on every spawn.
+   */
+  spawnHook?: string;
 }
 
 function configPath(): string {
@@ -84,6 +90,45 @@ export function isProvisionAllowed(owner: string, repo: string): boolean {
   const o = owner.toLowerCase();
   const full = `${owner}/${repo}`.toLowerCase();
   return list.some((e) => e.replace(/\/\*$/, "") === o || e === full);
+}
+
+/**
+ * A trusted, HOST-LOCAL shell hook run before each agent spawn. It is a POSIX
+ * `sh -c` script that prepares the environment (provisioning, env, cd) and that
+ * agent-yes runs as `sh -c "set -e\n<hook>\nexec \"$@\"" ay-spawn <agent argv…>`
+ * — so the real agent argv is passed as positional params and the prompt is
+ * never shell-parsed. `set -e` aborts the spawn if any hook step fails.
+ *
+ * This is arbitrary local code that runs on EVERY spawn, so it is deliberately
+ * NOT writable over the network. Set it on the machine by editing
+ * `~/.agent-yes/config.json` (`"spawnHook"`), or via env `AGENT_YES_SPAWN_HOOK`.
+ *
+ * Tampering guard (POSIX): a file-backed hook is ignored when the config file is
+ * a symlink, is not owned by us, or is group/world-writable — we refuse to run a
+ * hook from a file other users can swap or rewrite. The env override is trusted
+ * (it comes from the daemon's own environment). Returns null when unset/guarded.
+ */
+export function getSpawnHook(): string | null {
+  const env = process.env.AGENT_YES_SPAWN_HOOK;
+  if (env && env.trim()) return env;
+  const h = readConfig().spawnHook;
+  if (!h || !h.trim()) return null;
+  if (process.platform !== "win32") {
+    try {
+      if (lstatSync(configPath()).isSymbolicLink()) return null;
+      const st = statSync(configPath());
+      if ((st.mode & 0o022) !== 0) return null; // group/world-writable
+      if (typeof process.getuid === "function" && st.uid !== process.getuid()) return null;
+    } catch {
+      return null;
+    }
+  }
+  return h;
+}
+
+/** Whether a usable {@link getSpawnHook} is configured (for read-only disclosure). */
+export function hasSpawnHook(): boolean {
+  return getSpawnHook() !== null;
 }
 
 /** Persist the workspace root, tilde-expanded and resolved to an absolute path. */


### PR DESCRIPTION
## What

An optional **per-machine spawn hook** so a host can provision the environment before every agent launch (the env a non-tty `\$SHELL -ilc` never captured, dir setup, secrets, custom wrappers). Generalizes the class of problems behind the earlier TERM/COLORTERM fix (#105), without hard-coding.

This is the **revised v2** after two rounds of adversarial review (a first pass returned "rethink"; v2 returned "ship-with-changes", all addressed).

## Security-first design

- **Host-local only.** Set via `~/.agent-yes/config.json` (`"spawnHook"`) or env `AGENT_YES_SPAWN_HOOK`. It is arbitrary local code run on **every** spawn, so it is deliberately **not network-writable** — there is no PUT. (A persisted, network-mutable shell hook is delayed, persistent, cross-client RCE — *not* equivalent to the existing one-shot spawn.)
- **`exec "$@"` contract, not string interpolation.** `/api/spawn` runs the hook as `sh -c "set -e\n<hook>\nexec \"\$@\"" ay-spawn <agent argv…>`. The real agent argv (incl. the prompt) is passed as positional params → the prompt is **never shell-parsed** (no quoting/injection surface). `set -e` aborts the spawn if any hook step fails. Non-login `sh -c` (no `-l`) — we don't re-source rc files. `cwd`/`cli` exposed as `\$AGENT_YES_CWD` / `\$AGENT_YES_CLI`.
- **Tampering guard:** a file-backed hook is ignored when the config is a symlink, not owned by us, or group/world-writable.
- **Early-failure handshake:** if the hooked child exits non-zero within a window (`AGENT_YES_SPAWN_HOOK_TIMEOUT_MS`, default 5s), `/api/spawn` returns **502 with the bounded captured stderr**; if still alive after the window, `exec` succeeded → detach and report ok. stderr is file-backed so it never blocks the child.
- **`GET /api/spawn-config`** discloses only *whether* a hook is set (`{hasSpawnHook}`), never the body.
- **Zero regression:** with no hook, the spawn path is byte-for-byte the prior direct argv `Bun.spawn`. No changes to the Rust runtime, `ts/index.ts`, or the CLI.

## Verification

Over real HTTP (`ay serve --http`, isolated `AGENT_YES_HOME`):
- success: hook runs, `\$AGENT_YES_CLI` expanded, a hostile prompt (`do \$(rm -rf ~); \`id\``) arrives as **one inert arg**, `ok:true`;
- failure: `502` + captured stderr, agent never starts (`set -e`);
- perms guard: world-writable config → hook ignored;
- read-only disclosure boolean flips correctly.

25 `workspaceConfig` unit tests pass (5 new for `getSpawnHook`/`hasSpawnHook`).

## Follow-ups (not here)

- Shared spawn lib so `ay spawn`/CLI applies the same hook.
- `runRemoteSpawn` POSTing `{cli,cwd,prompt}` so a **remote** host applies *its own* hook (the hook never crosses the wire).
- Web UI surfacing of `hasSpawnHook` (deferred — `lab/ui/*` has unrelated in-flight work in the shared worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)