### PR TITLE
feat(console): give the needs_input status dot a color (blue)

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -838,6 +838,11 @@
       .dot.stuck {
         background: var(--red);
       }
+      /* Waiting on you: alive and quiet, but parked on an unanswered prompt/menu.
+         The UI accent (blue) reads as "your turn" — distinct from idle-amber. */
+      .dot.needs_input {
+        background: var(--accent);
+      }
       .dot.stopped,
       .dot.exited {
         background: var(--muted);


### PR DESCRIPTION
Completes the console's status-dot palette. `needs_input` (agent alive but parked on an unanswered prompt/menu) had no `.dot` rule, so it rendered as a colorless circle — the same invisible-dot gap #125 fixed for `stuck`.

Adds `.dot.needs_input { background: var(--accent) }`. The UI accent (blue) reads as "your turn", distinct from active-green / idle-amber / stuck-red. Same render path verified in #125 (`class="dot ${e.status}"`).

Palette is now complete: active=green, idle=amber, needs_input=blue, stuck=red, stopped=muted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)