### PR TITLE
feat(console): sort button beside the compact-view toggle (state/created/identity)

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -305,6 +305,54 @@ function agentForestNodes(list) {
   return roots;
 }
 
+// ---- display sort order -----------------------------------------------------
+// The console cycles a button through these; the chosen comparator runs over the
+// flat entry list BEFORE layeredRows builds the room/peer/agent tree (which keeps
+// the given order for siblings and first-seen order for room/peer groups). So
+// sorting reorders roots and siblings without breaking the nesting.
+export const SORT_MODES = ["state", "created", "identity"];
+
+// Attention-first state ranking: someone scanning the fleet wants the agents that
+// need them (needs_input) up top, then the wedged ones (stuck), then live work,
+// then quiet/idle, then finished. Unknown states sort last.
+const STATE_RANK = {
+  needs_input: 0,
+  stuck: 1,
+  active: 2,
+  running: 2,
+  idle: 3,
+  stopped: 4,
+  exited: 4,
+};
+function stateRank(e) {
+  const r = STATE_RANK[e.status];
+  return r === undefined ? 5 : r;
+}
+
+// Git "busyness" for the state mode's secondary key: a dirty / ahead / behind
+// repo outranks a clean one, and more outstanding changes rank higher. The +0.5
+// for `dirty` breaks a 0-count tie toward the dirty tree.
+function gitWeight(e) {
+  const g = e.git || {};
+  return (g.changed || 0) + (g.ahead || 0) + (g.behind || 0) + (g.dirty ? 0.5 : 0);
+}
+
+// Return a NEW array sorted for display per `mode` (default "state"):
+//   - "state":    attention-first state, then git busyness, then newest.
+//   - "created":  newest first (started_at desc).
+//   - "identity": user@host:owner/repo/branch (alphabetical).
+// Every comparator falls back to newest-first so order is total & deterministic.
+export function sortEntries(entries, mode = "state") {
+  const byNewest = (a, b) => (b.started_at || 0) - (a.started_at || 0);
+  const cmp =
+    mode === "created"
+      ? byNewest
+      : mode === "identity"
+        ? (a, b) => fullIdent(a).localeCompare(fullIdent(b)) || byNewest(a, b)
+        : (a, b) => stateRank(a) - stateRank(b) || gitWeight(b) - gitWeight(a) || byNewest(a, b);
+  return entries.slice().sort(cmp);
+}
+
 // Order entries as agent>subagent forests so a nested `ay` (one agent spawning
 // another) renders indented under its parent. SCOPED PER HOST. Returns a NEW
 // array in depth-first order; each entry is shallow-copied with `_branch` (a

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1351,6 +1351,7 @@
           <div class="meta">
             <span id="count"></span>
             <span class="metaright">
+              <button id="sortbtn" class="viewbtn" title="cycle sort order">⇅ state</button>
               <button id="viewbtn" class="viewbtn" title="toggle compact list">☰</button>
               <button id="newbtn" class="newbtn" title="spawn a new agent on this fleet">
                 + New agent
@@ -1534,6 +1535,8 @@
         hasIdent,
         deviceCount,
         layeredRows,
+        sortEntries,
+        SORT_MODES,
         taskLabel,
         hashHue,
         selFromBottom,
@@ -3160,6 +3163,22 @@
       // Compact list: one line per agent (dot + cli + title), persisted per device.
       let compactList = localStorage.getItem("ay.compactList") === "1";
 
+      // Display sort order, cycled by the sort button and persisted per device.
+      // Default "state" (attention-first state, then git busyness). Guard against
+      // a stale/garbage stored value so we never start in an unknown mode.
+      let sortMode = localStorage.getItem("ay.sortMode") || "state";
+      if (!SORT_MODES.includes(sortMode)) sortMode = "state";
+
+      // The filtered + sorted entry list, in the SAME order the left panel renders
+      // and the keyboard nav steps. Sorting runs before layeredRows builds the
+      // room/peer/agent tree, so it reorders roots/siblings without breaking nesting.
+      function orderedEntries(toks) {
+        return sortEntries(
+          entries.filter((e) => matches(e, toks)),
+          sortMode,
+        );
+      }
+
       // A small git chip (±changed ↑ahead ↓behind) for a row, amber when the tree
       // is dirty. Empty for clean/in-sync repos and non-git cwds — no noise.
       function gitChipHtml(e) {
@@ -3200,10 +3219,14 @@
         const toks = $("q").value.trim().split(/\s+/).filter(Boolean);
         // Build the full signalling-server > rooms > peers > agents > subagents
         // tree. Single-node room/peer layers fold away; ≥2 become ├ └ │ branches.
-        const rows = layeredRows(entries.filter((e) => matches(e, toks)));
+        const rows = layeredRows(orderedEntries(toks));
         const agentRows = rows.filter((r) => r.kind === "agent");
         $("count").textContent = `${agentRows.length} / ${entries.length} agents`;
         $("viewbtn").classList.toggle("on", compactList);
+        // Show the active sort mode on the button so it's self-documenting; the
+        // default ("state") is also highlighted to hint it's the implicit order.
+        $("sortbtn").textContent = `⇅ ${sortMode}`;
+        $("sortbtn").classList.toggle("on", sortMode !== "state");
         // identContext blanks any field uniform across the shown list (so a
         // single-device fleet shows no device); multiDevice gates the detailed
         // host tag so it only appears when machines are actually mixed.
@@ -3663,6 +3686,12 @@
         localStorage.setItem("ay.compactList", compactList ? "1" : "0");
         renderList();
       });
+      // Cycle the sort order: state → created → identity → state.
+      $("sortbtn").addEventListener("click", () => {
+        sortMode = SORT_MODES[(SORT_MODES.indexOf(sortMode) + 1) % SORT_MODES.length];
+        localStorage.setItem("ay.sortMode", sortMode);
+        renderList();
+      });
       window.addEventListener("resize", () => {
         // Resizing our window is strong intent → re-fit to our pane (we become the
         // size driver; the push rides term.onResize). applyCanvasScale then clears
@@ -3700,7 +3729,7 @@
       function stepSelection(dir) {
         const toks = $("q").value.trim().split(/\s+/).filter(Boolean);
         // Must match renderList's order; step only over agent rows (skip headers).
-        const shown = layeredRows(entries.filter((e) => matches(e, toks)))
+        const shown = layeredRows(orderedEntries(toks))
           .filter((r) => r.kind === "agent")
           .map((r) => r.entry);
         if (!shown.length) return;

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -21,6 +21,8 @@ import {
   deviceCount,
   forestOrder,
   layeredRows,
+  sortEntries,
+  SORT_MODES,
   taskLabel,
   hashHue,
   selFromBottom,
@@ -656,5 +658,69 @@ describe("omniScore", () => {
     expect(omniScore(e({ title: "abc" }), "xyz")).toBe(0);
     expect(omniScore(e({ title: "abc" }), "")).toBe(0);
     expect(omniScore(e({ title: "abc" }), "   ")).toBe(0);
+  });
+});
+
+describe("sortEntries", () => {
+  const a = (over = {}) => agent({ started_at: 1000, ...over });
+  const keys = (arr, k = "_k") => arr.map((e) => e[k]);
+
+  it("SORT_MODES is the documented cycle", () => {
+    expect(SORT_MODES).toEqual(["state", "created", "identity"]);
+  });
+
+  it("returns a new array and does not mutate the input", () => {
+    const input = [a({ _k: "x" }), a({ _k: "y" })];
+    const out = sortEntries(input, "created");
+    expect(out).not.toBe(input);
+    expect(keys(input)).toEqual(["x", "y"]); // original order untouched
+  });
+
+  it("state mode: attention-first state order (needs_input < stuck < active < idle < stopped)", () => {
+    const list = [
+      a({ _k: "idle", status: "idle" }),
+      a({ _k: "stopped", status: "stopped" }),
+      a({ _k: "needs", status: "needs_input" }),
+      a({ _k: "active", status: "active" }),
+      a({ _k: "stuck", status: "stuck" }),
+    ];
+    expect(keys(sortEntries(list, "state"))).toEqual([
+      "needs",
+      "stuck",
+      "active",
+      "idle",
+      "stopped",
+    ]);
+  });
+
+  it("state mode: within the same state, a busier git tree ranks higher", () => {
+    const list = [
+      a({ _k: "clean", status: "active", git: { changed: 0 } }),
+      a({ _k: "dirty", status: "active", git: { changed: 3, dirty: true } }),
+      a({ _k: "ahead", status: "active", git: { ahead: 1 } }),
+    ];
+    expect(keys(sortEntries(list, "state"))).toEqual(["dirty", "ahead", "clean"]);
+  });
+
+  it("state is the default mode", () => {
+    const list = [a({ _k: "idle", status: "idle" }), a({ _k: "needs", status: "needs_input" })];
+    expect(keys(sortEntries(list))).toEqual(["needs", "idle"]);
+  });
+
+  it("created mode: newest started_at first", () => {
+    const list = [
+      a({ _k: "old", started_at: 100 }),
+      a({ _k: "new", started_at: 900 }),
+      a({ _k: "mid", started_at: 500 }),
+    ];
+    expect(keys(sortEntries(list, "created"))).toEqual(["new", "mid", "old"]);
+  });
+
+  it("identity mode: alphabetical by full identity (user@host:owner/repo/branch)", () => {
+    const list = [
+      a({ _k: "zed", cwd: "/x/zoe/repo/tree/main" }),
+      a({ _k: "amy", cwd: "/x/amy/repo/tree/main" }),
+    ];
+    expect(keys(sortEntries(list, "identity"))).toEqual(["amy", "zed"]);
   });
 });


### PR DESCRIPTION
The console's agent list rendered in arrival order with no way to reorder it. Adds a **sort button beside the compact-view button** that cycles three orders (persisted per device via `localStorage` `ay.sortMode`):

- **state** (default): attention-first state (`needs_input` > `stuck` > `active` > `idle` > `stopped`), then git busyness (dirty / ±changes), then newest.
- **created**: newest `started_at` first.
- **identity**: alphabetical by `user@host:owner/repo/branch`.

## Design
- Pure, testable `sortEntries(entries, mode)` (+ `SORT_MODES`) in `console-logic.js`.
- `index.html` sorts the filtered entries through one `orderedEntries()` helper used by **both** the renderer and the keyboard-nav stepper, so their order stays in lockstep.
- Sort runs **before** `layeredRows` builds the room/peer/agent tree — it reorders roots/siblings without breaking nesting.
- The button shows the active mode (`⇅ state` / `⇅ created` / `⇅ identity`).

## Verification
- 7 new `sortEntries` unit tests (state order, git secondary key, created, identity, no-mutation, default); ui-logic suite **88 passed**.
- Served console HTML carries the button + import + wiring (confirmed against a live test server).
- `oxfmt --check` clean on changed JS/TS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)