### PR TITLE
docs(examples): spawn-notify.sh — fan-out completion detection for orchestrators

### DIFF
--- a/examples/spawn-notify.sh
+++ b/examples/spawn-notify.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# spawn-notify — fan-out completion detection for an orchestrator parent.
+#
+# Spawns an agent-yes agent FIRE-AND-FORGET (it outlives this script), then
+# BLOCKS until the agent needs attention. Launch THIS via the parent's
+# background runner (e.g. Claude Code's run_in_background): a background command
+# only notifies its parent when the PROCESS EXITS, but an agent never exits — it
+# idles at its prompt waiting for re-instruction. So we let a tiny sibling — this
+# script, blocked on `ay status --wait` — be the thing that exits. The agent
+# itself keeps living, so you can still re-instruct it with `ay send <pid> "…"`.
+#
+# Verified: a nohup+disown child survives the spawning shell's exit, so the agent
+# outlives this waiter.
+#
+# Usage:   spawn-notify <cwd> -- <task...>
+# Env:     CLI=claude          wrapped CLI (claude|codex|gemini|…)
+#          AY_FLAGS="-y"       extra flags for `ay <cli>` (e.g. -y for yolo)
+#          WAIT_MODE=--wait    --wait      → wake on idle|needs_input|stuck|stopped (recommended:
+#                                            also catches a blocked AskUserQuestion menu)
+#                              --wait-idle → wake on idle only (misses blocked menus)
+#          WAIT_TIMEOUT=6h     waiter timeout (ms() syntax: 30s, 5m, 6h)
+# Exit:    0  agent needs attention (idle / blocked-on-input / done)
+#          2  waiter timed out (agent still actively working)
+#          3  agent never registered in ~/.agent-yes/pids.jsonl
+set -uo pipefail
+
+cli="${CLI:-claude}"
+cwd="${1:?usage: spawn-notify <cwd> -- <task...>}"; shift
+[ "${1:-}" = "--" ] && shift
+task="$*"
+
+# 1) Fire-and-forget. nohup+disown so the agent outlives this waiter; agent-yes
+#    keeps its own PTY log under ~/.agent-yes, so /dev/null here loses nothing.
+mkdir -p "$cwd"
+# shellcheck disable=SC2086
+nohup ay "$cli" ${AY_FLAGS:-} --cwd "$cwd" -- "$task" >/dev/null 2>&1 &
+disown || true
+
+# 2) Resolve the agent we just spawned to an EXACT pid (newest match in this cwd),
+#    retrying until its record lands in pids.jsonl. From here on we key off the
+#    pid — exact identity, no --latest ambiguity, no sibling-collision risk.
+pid=""
+for _ in $(seq 1 30); do
+  pid=$(ay status "$cwd" --latest 2>/dev/null | sed -n 's/.*"pid":\([0-9]\{1,\}\).*/\1/p' | head -1)
+  [ -n "$pid" ] && break
+  sleep 1
+done
+[ -z "$pid" ] && { echo "spawn-notify: agent never registered under $cwd" >&2; exit 3; }
+echo "spawn-notify: agent pid=$pid cwd=$cwd — waiting (${WAIT_MODE:---wait})…" >&2
+
+# 3) Block until the ball is in the parent's court. Pid keyword = exact identity.
+ay status "$pid" "${WAIT_MODE:---wait}" --timeout "${WAIT_TIMEOUT:-6h}"
+rc=$?
+
+# 4) Surface the structured envelope (if the agent ran `ay result set '{...}'`) so
+#    it rides along in the parent's notification payload. Non-fatal if absent.
+ay result "$pid" 2>/dev/null || true
+exit $rc


### PR DESCRIPTION
## What

`examples/spawn-notify.sh` — a parent-orchestrator helper that solves the
fan-out completion-detection gap.

## Why

A parent that spawns `ay <cli>` in the background never learns when the task is
done: the agent doesn't exit (it idles at its prompt for re-instruction), and a
background runner (e.g. Claude Code's `run_in_background`) only notifies on
process **EXIT**. So the parent can't distinguish "finished" from "still working".

## How

Pair each spawn with a short-lived waiter:
1. fire the agent **detached** (`nohup`+`disown`) so it outlives the waiter;
2. resolve it to an exact pid (newest match in the cwd, retry until it registers);
3. **block on `ay status <pid> --wait`** — wakes on `idle｜needs_input｜stuck｜stopped`
   (`--wait`, not `--wait-idle`, so a blocked menu is caught too);
4. emit any `ay result` envelope so commit/result rides along in the notification.

Launched via the parent's background runner, the **waiter's exit** is the
completion signal — while the agent stays alive and re-instructable via
`ay send <pid> "…"`.

Pure composition of existing verbs (`status --wait`, `result`); **no new CLI
surface, no runtime changes**. A future `ay spawn-notify` subcommand could fold
this in cross-platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)