### PR TITLE
feat(console): show a "spawn hook active" hint in the New agent form

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -4555,9 +4555,25 @@
         <button class="lfleet" id="nf-go">▷ Launch</button>
         <button class="lcancel" id="nf-cancel">cancel</button>
       </div>
+      <div id="nf-hook" class="lhint" style="display:none"></div>
       <div class="lhint">POST /api/spawn on this fleet. ${IS_MAC ? "⌘" : "Ctrl"}+Enter to launch.</div></div>`;
         $("newform").style.display = "flex";
         setTimeout(() => $("nf-prompt")?.focus(), 0);
+        // Surface whether this host runs a spawn hook (a trusted local command run
+        // before every launch — provisions env/cwd; see ~/.agent-yes/config.json).
+        // Read-only: /api/spawn-config discloses only the boolean, never the body.
+        if (target?.tx?.fetchJSON) {
+          target.tx
+            .fetchJSON("/api/spawn-config")
+            .then((c) => {
+              const el = $("nf-hook");
+              if (el && c && c.hasSpawnHook) {
+                el.textContent = "⚙ this host runs a spawn hook before launch";
+                el.style.display = "";
+              }
+            })
+            .catch(() => {});
+        }
       }
 
       async function submitNew() {


### PR DESCRIPTION
## What

Surfaces the host-local spawn hook (#126) in the web console. The **+ New agent**
form fetches `GET /api/spawn-config` and, when `{hasSpawnHook: true}`, shows:

> ⚙ this host runs a spawn hook before launch

## Why

#126 added a trusted local command run before every agent launch (provisions
env/cwd). A user spawning from the console should know that a host-side step runs
— otherwise the launch behaves "magically" differently from a bare `ay <cli>`.

## Notes

- **Read-only disclosure**: the endpoint returns only the boolean, never the hook
  body (room/token clients aren't necessarily host admins; the hook stays
  host-local with no network write — see #126).
- Works over every transport (local / ay-share / codehost) via `tx.fetchJSON`;
  silently no-ops when the endpoint is absent (older daemon) or no hook is set.
- Source edit is `lab/ui/index.html` only (cf/public is auto-synced at build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)