### PR TITLE
fix(serve): detach console-spawned agents into their own session

### DIFF
--- a/ts/openBrowser.ts
+++ b/ts/openBrowser.ts
@@ -54,9 +54,7 @@ export async function offerOpenInBrowser(
   if (!resolveOpener(url)) return false;
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   try {
-    const answer = (
-      await new Promise<string>((resolve) => rl.question(prompt, resolve))
-    )
+    const answer = (await new Promise<string>((resolve) => rl.question(prompt, resolve)))
       .trim()
       .toLowerCase();
     if (answer !== "" && answer !== "y" && answer !== "yes") return false;

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1703,6 +1703,14 @@ export async function cmdServe(rest: string[]): Promise<number> {
       const agentArgv = [...ayCmd, cli, ...(prompt ? ["--", prompt] : [])];
       // don't leak our Claude Code session into the agent
       const agentEnv = freshAgentEnv();
+      // Detach the agent into its OWN session (setsid). When `ay serve` runs WITH a
+      // controlling terminal (started in a shell rather than as a headless daemon),
+      // an undetached child inherits the daemon's session + controlling tty and lands
+      // in a *background* process group. The first terminal op it makes then raises
+      // SIGTTOU/SIGTTIN → the child is STOPPED before emitting any output (console
+      // renders nothing), and the stop hits the whole group — freezing `ay serve`
+      // itself. `detached: true` (setsid) gives the agent a fresh session with no
+      // controlling terminal, immune to both. Matches the restart/openBrowser paths.
       try {
         const hook = getSpawnHook();
         if (hook) {
@@ -1723,6 +1731,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
           // after exec would), and bounds our read to the first few KB.
           const child = Bun.spawn([shell, "-c", script, "ay-spawn", ...agentArgv], {
             cwd,
+            detached: true,
             env: { ...agentEnv, AGENT_YES_CWD: cwd, AGENT_YES_CLI: cli },
             stdin: "ignore",
             stdout: "ignore",
@@ -1768,6 +1777,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
         }
         const child = Bun.spawn(agentArgv, {
           cwd,
+          detached: true,
           env: agentEnv,
           stdin: "ignore",
           stdout: "ignore",


### PR DESCRIPTION
## Problem

Spawning an agent from the web console (`POST /api/spawn`) intermittently did nothing — the new agent's terminal **rendered nothing**, and sometimes `ay serve` itself froze.

### Root cause (reproduced)

`/api/spawn` launched agents with a plain `Bun.spawn`, so they inherited the `ay serve` daemon's **session + controlling terminal**. When the daemon runs **with** a controlling terminal (started in a shell rather than headless — e.g. dev / codehost), the spawned agent lands in a **background process group**. Its first terminal op raises **SIGTTOU/SIGTTIN**, and the agent is **STOPPED (state `T`)** before emitting a byte → console renders nothing. The job-control stop hits the whole group, **freezing the daemon too**; the watchdog then restarts it, orphaning the agent as a zombie while `pids.jsonl` still says `"active"`.

Observed pre-fix:
```
PID    PGID(=daemon)  SESS  TPGID  STAT  log
67868  52791          1106  51286  Tl    0 bytes   ← stopped before any output
52791  (daemon)       1106  51286  Tl              ← daemon frozen too
```

## Fix

Add `detached: true` to **both** `/api/spawn` branches (plain + spawn-hook). `Bun.spawn` then `setsid`'s the agent into a **fresh session with no controlling terminal** — immune to SIGTTOU and unable to freeze the daemon. Matches the existing detached `restart` path (`ts/serve.ts`) and `openBrowser.ts`.

The spawn-hook early-failure handshake is unaffected: the parent still holds the child handle, `child.exited` still races the timeout, and file-backed stderr is independent of session membership.

## Verification

Reproduced + fixed against a live `ay serve`:

| | pre-fix | post-fix |
|---|---|---|
| agent state | `T` (stopped) | `Ssl` (running) |
| agent session | daemon's (`1106`) | own (`sid=pid`) |
| daemon | `Tl` (frozen) | `Sl` (healthy) |
| PTY log | 0 bytes | full banner, renders in console |

Reviewed with codex (no issues). Typecheck adds zero new errors; pre-push coverage gate passes.

> Note: the pre-commit hook (`oxlint --fix`/`oxfmt`) also reformatted one pre-existing line in `ts/openBrowser.ts` — unrelated lint drift, rode along automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)