### PR TITLE
fix(restart): stop printing the launcher pid; key the hint on cwd

### DIFF
--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1520,6 +1520,23 @@ describe("subcommands.cmdRestart", () => {
     // (signal 0 throws only if the pid is gone / not signalable.)
     expect(() => process.kill(process.pid, 0)).not.toThrow();
   });
+
+  // The post-restart hint must NOT print a pid (the resumed agent's pid races and
+  // resolves to "no agent matched" — the reported "restart not working"). It must
+  // instead key `ay tail` on the cwd, which is the one stable handle at this point.
+  it("restartHintLines keys the watch hint on cwd, never a pid", async () => {
+    const mod = await loadModule();
+    const cwd = "/Users/x/ws/proj/tree/docs";
+    const { out, err } = mod.restartHintLines("claude", cwd, "restoreArgs (--continue)");
+    expect(out).toMatch(/restarted claude in/);
+    expect(out).not.toMatch(/new pid/); // the old, broken phrasing
+    // `ay tail -f <cwd>` — a substring of the agent's absolute cwd, so it resolves
+    // regardless of which pid the resume settles on.
+    expect(err).toMatch(/ay tail -f \/Users\/x\/ws\/proj\/tree\/docs/);
+    expect(err).toMatch(/ay ls/);
+    // No bare numeric pid anywhere in the hint.
+    expect(`${out}${err}`).not.toMatch(/\bpid \d+/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -2815,6 +2815,29 @@ async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
   return !isPidAlive(pid);
 }
 
+// Post-restart hint. The resumed agent's pid is NOT knowable synchronously here:
+// `proc.pid` is the `agent-yes` launcher we just spawned (a wrapper/bin shim
+// whose pid differs from the registered agent), and the resume itself bootstraps
+// through a throwaway pid that dies before the real TUI re-registers under yet
+// another pid seconds later — with a window where nothing is registered at all.
+// So any pid we print here would race and usually resolve to "no agent matched"
+// (the reported "restart not working"). The cwd is the one stable handle, and
+// `ay tail`/`ay ls` already accept a cwd substring, so we key the hint on cwd.
+export function restartHintLines(
+  cli: string,
+  cwd: string,
+  strategy: string,
+): { out: string; err: string } {
+  return {
+    out: `restarted ${cli} in ${shortenPath(cwd)} via ${strategy}\n`,
+    err:
+      `\n` +
+      `the resumed agent re-registers under a new pid a moment later — reach it by cwd:\n` +
+      `  ay tail -f ${cwd}   # follow the resumed agent\n` +
+      `  ay ls                 # list all agents\n`,
+  };
+}
+
 async function cmdRestart(rest: string[]): Promise<number> {
   const y = yargs(rest)
     .usage("Usage: ay restart <keyword> [--fresh]")
@@ -2875,20 +2898,17 @@ async function cmdRestart(rest: string[]): Promise<number> {
     prompt: record.prompt,
   });
 
-  const proc = Bun.spawn(["agent-yes", "--cli=" + record.cli, ...resumeArgs], {
+  // Detached launcher; we deliberately don't track its pid — see restartHintLines
+  // for why the resumed agent's pid isn't reportable synchronously.
+  Bun.spawn(["agent-yes", "--cli=" + record.cli, ...resumeArgs], {
     cwd: record.cwd,
     detached: true,
     stdio: ["ignore", "ignore", "ignore"],
   });
 
-  process.stdout.write(
-    `restarted ${record.cli} in ${shortenPath(record.cwd)} via ${strategy} (new pid: ${proc.pid})\n`,
-  );
-  process.stderr.write(
-    `\n` +
-      `  ay tail ${proc.pid}   # watch output\n` +
-      `  ay ls                 # list all agents\n`,
-  );
+  const { out, err } = restartHintLines(record.cli, record.cwd, strategy);
+  process.stdout.write(out);
+  process.stderr.write(err);
   return 0;
 }
 


### PR DESCRIPTION
## Problem

Reported from the web console (`agent-yes.com/w/#r223104:83014`): **\"agent restart seems not working.\"**

Investigating live: `ay restart` actually **does** resume the session correctly — but it printed a follow-up command that fails:

```
restarted claude in ~/ws/snomiao/otoji/tree/docs via restoreArgs (--continue) (new pid: 36030)
  ay tail 36030   # watch output   ← ay tail 36030 → "no agent matched"
```

`ay ls` showed the real agent under a *different* pid (`36032`). Reproduced on both otoji agents in the room:

| agent | printed pid | actual registered pid |
|---|---|---|
| `otoji/tree/docs` | 36030 | **36032** |
| `otoji/tree/main` | 38891 | **38917** |

## Root cause

`proc.pid` is the `agent-yes` **launcher** we spawn, not the resumed agent. Worse, a `--continue` resume bootstraps through a **throwaway pid that dies** before the real TUI re-registers under yet another pid seconds later — with a window where nothing is registered at all. So any pid printed at restart time races and usually resolves to "no agent matched". The session resumed fine; only the hint was wrong, which read as "restart broken."

## Fix

The pid isn't knowable synchronously, but the **cwd is a stable handle** and `ay tail`/`ay ls` already accept a cwd substring. Key the hint on cwd:

```
restarted claude in ~/ws/snomiao/otoji/tree/docs via restoreArgs (--continue)
the resumed agent re-registers under a new pid a moment later — reach it by cwd:
  ay tail -f /Users/sno/ws/snomiao/otoji/tree/docs   # follow the resumed agent
  ay ls                                              # list all agents
```

Extracts a pure `restartHintLines(cli, cwd, strategy)` builder, unit-tested to never emit a pid.

## Verification

- `bunx vitest run ts/subcommands.spec.ts` → 86 passed.
- `bun run build` clean; no new tsc errors (3 pre-existing in subcommands.ts unchanged).
- **Live**: restarted two real agents via the built dist — the printed `ay tail <cwd>` resolves to the settled agent (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)