### PR TITLE
fix(console): surface restart failures instead of silently swallowing them

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2829,9 +2829,17 @@
         const who = `pid ${e.pid} ${cliLabel(e) || ident(e) || ""}`.trim();
         if (!confirm(`Restart ${who}?\nStops it (if live) and relaunches resuming the session.`))
           return;
-        txFor(e)
+        // Surface the outcome. This used to be fire-and-forget (`.catch(()=>{})`,
+        // and the resolved value — including a non-2xx {ok:false} — was ignored),
+        // so a failed restart (agent gone, host/transport error) looked identical
+        // to a no-op: "I clicked restart and nothing happened." /api/restart
+        // returns once the detached restart is kicked off; the old→new pid swap
+        // then arrives over /api/ls/subscribe.
+        const res = await txFor(e)
           .post("/api/restart", { keyword: String(e.pid) })
-          .catch(() => {});
+          .catch((err) => ({ ok: false, text: String(err?.message || err) }));
+        if (!res || !res.ok)
+          alert(`Restart failed for ${who}:\n${(res && res.text) || "request failed"}`);
       }
 
       // ---- On-screen key bar (mobile) -------------------------------------


### PR DESCRIPTION
## Symptom

"I clicked Restart on an agent and it doesn't work." Reproduced via the live web console (`rech`): clicking **↻ Restart** produces no visible result on failure — no error, no toast, nothing.

## Root cause (the certain defect)

`restartAgent()` fired `/api/restart` fire-and-forget:
```js
txFor(e).post("/api/restart", { keyword: String(e.pid) }).catch(() => {});
```
`.catch(()=>{})` swallows rejections, and the **resolved value was never checked** — so a non-2xx `{ok:false}` (e.g. a `404` when the pid no longer resolves on the host) was silently ignored. A failed restart was indistinguishable from a no-op: zero feedback.

## Fix

`restartAgent()` now awaits the result and alerts on failure with the host's error text. On success it stays silent — `/api/restart` returns as soon as the detached restart is kicked off, and the old→new pid swap arrives over `/api/ls/subscribe`. Verified: a bogus pid → host returns `404` → the console now shows "Restart failed: …" instead of nothing.

## Investigated and ruled out (server-side restart is NOT broken)

A first hypothesis was that the graceful stop fails for **Rust-runtime** agents (a stale `subcommands.ts` comment claims "Rust doesn't yet support FIFO IPC"). Verified end-to-end that this is **false**:
- `rs/src/context.rs` `run_with_fifo` forwards FIFO bytes into the agent's stdin; `rs/src/fifo.rs` keeps an `O_RDWR` reader.
- Live test: `ay restart <pid>` on a Rust claude agent stopped it gracefully (FIFO `/exit` reached claude) and relaunched `--continue` as a new pid in **~1 second**.

So the server-side restart works; the only defect was the console discarding the outcome. (Follow-up worth a separate change: correct the stale "Rust doesn't support FIFO IPC" comment in `subcommands.ts`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)