### PR TITLE
fix(console): honor #room:pid deep-links on hashchange (open-tab navigation)

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -4746,6 +4746,33 @@
         connectAllRooms();
       }
 
+      // Deep-link navigation in an ALREADY-OPEN console. boot() only processes the
+      // hash on a full load, so pasting / navigating to #room:pid in an open tab
+      // did nothing — you kept staring at the previously-selected agent. Re-resolve
+      // on hashchange and jump to that agent. select() writes the hash via
+      // history.replaceState (which does NOT fire hashchange), so this never loops.
+      window.addEventListener("hashchange", () => {
+        const h = decodeURIComponent(location.hash.replace(/^#/, ""));
+        // Only the #room:pid agent-deep-link form (pid = digits, ≤7 — same bound
+        // boot() uses to tell a pid from a numeric token). Other forms (#room,
+        // #room:token, #k=…) are connection/auth concerns handled only on load.
+        const m = /^([A-Za-z0-9_-]+):(\d{1,7})$/.exec(h);
+        if (!m) return;
+        const [, room, pid] = m;
+        const key = room + "#" + pid;
+        const e = entries.find((x) => x._key === key);
+        if (e) {
+          if (sel !== e._key) select(e._key);
+          return;
+        }
+        // Not loaded yet: arm the deep-link (mergeRender selects it once it streams
+        // in) and connect the room from its cached token if we're not already on it.
+        autoPid = key;
+        autoPidExplicit = true;
+        const r = loadRooms()[room];
+        if (r && !sources.get(room)) connectRoom(room, r.token, r.host);
+      });
+
       // ---- activity-gated polling + auto-reload on new deploy ----------------
       // Poll the agent list while the page is actually in use; pause when the tab
       // is hidden or the user has been idle for IDLE_MS, so an unattended console


### PR DESCRIPTION
## Problem

`boot()` resolves the URL hash only on a **full page load**. Navigating an **already-open** console to a `#room:pid` deep-link (pasting it in the address bar, or an in-app link) did nothing — the previously-selected agent stayed selected while the URL claimed you were on another agent. (It also confounded debugging: re-`open`ing the same tab is a hashchange, not a load, so the deep-link silently no-op'd.)

## Fix

Add a `hashchange` listener that re-resolves the `#room:pid` form and jumps to that agent:
- already in the list → `select()` it;
- not loaded yet → arm `autoPid` + connect the room from its cached token, so `mergeRender` selects it once it streams in.

Scoped to the `#room:pid` agent form (pid = digits, ≤7 — the same bound `boot()` uses to distinguish a pid from a numeric token). `#room` / `#room:token` / `#k=…` are connection/auth concerns left to full-load handling.

**No loop:** `select()` writes the hash via `history.replaceState`, which does not fire `hashchange`.

## Verification

With two agents listed, selecting A then `location.hash = "#local:<pidB>"` moves the selection to B (driven via `rech`).

## Context

Found while investigating a "restart doesn't work" report (fixed separately in #135 — the console was swallowing restart errors). The deep-link **selection itself works on a clean full load**; this fixes the open-tab navigation gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)