### PR TITLE
docs(send): drop the stale "Rust doesn't support FIFO IPC" claim

### DIFF
--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -2258,7 +2258,7 @@ async function cmdSend(rest: string[]): Promise<number> {
   const fifoPath = record.fifo_file;
   if (!fifoPath) {
     throw new Error(
-      `pid ${record.pid}: no fifo_file recorded — agent was not started with --stdpush (or was spawned by Rust which doesn't yet support FIFO IPC; see ROADMAP item 10)`,
+      `pid ${record.pid}: no fifo_file recorded — this agent didn't register a stdin FIFO (an older agent, or one not started with --stdpush). Restarting it (ay restart ${record.pid}) re-registers one.`,
     );
   }
 


### PR DESCRIPTION
The `ay send` "no fifo_file" error claimed the Rust runtime can't do FIFO IPC:

> …(or was spawned by Rust which doesn't yet support FIFO IPC; see ROADMAP item 10)

That's stale. The Rust runtime **does** forward FIFO bytes into the agent's stdin (`rs/src/context.rs` `run_with_fifo`, `rs/src/fifo.rs` `O_RDWR` reader) — verified end-to-end: `ay restart` of a Rust-runtime claude agent delivers `/exit` over the FIFO and relaunches in ~1s.

A null `fifo_file` now just means the agent didn't register one (an older agent, or one not started with `--stdpush`). The message now says that and points at `ay restart` to re-register.

(This exact stale comment sent a restart-bug investigation down the wrong path — the real defect was the console swallowing restart errors, fixed in #135.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)