### PR TITLE
feat(spawn): /api/spawn returns a correlation agentId for one-step addressing

### DIFF
--- a/rs/src/pid_store.rs
+++ b/rs/src/pid_store.rs
@@ -59,9 +59,18 @@ pub struct PidRecord {
     pub agent_id: Option<String>,
 }
 
-/// Mint a short, low-collision agent id (12 hex chars from a v4 UUID). Short
-/// enough to type/reference; `matchKeyword` allows prefix lookups.
+/// The agent id for this process: adopt a caller-injected `AGENT_YES_AGENT_ID`
+/// (so `ay serve`'s /api/spawn can hand back an id that addresses this exact
+/// agent; pty_spawner strips it from the wrapped CLI's env so subagents don't
+/// inherit and collide), else mint a short low-collision id (12 hex from a v4
+/// UUID). Short enough to type/reference; `matchKeyword` allows prefix lookups.
 fn new_agent_id() -> String {
+    if let Ok(id) = std::env::var("AGENT_YES_AGENT_ID") {
+        let id = id.trim();
+        if (6..=32).contains(&id.len()) && id.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return id.to_ascii_lowercase();
+        }
+    }
     uuid::Uuid::new_v4().simple().to_string()[..12].to_string()
 }
 
@@ -432,6 +441,23 @@ pub fn is_process_alive(pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_new_agent_id_adopts_injected_env() {
+        // A valid AGENT_YES_AGENT_ID (6..=32 hex) is adopted verbatim (lowercased);
+        // anything else falls back to a freshly-minted 12-hex id. Env is process-
+        // global, so set/clear tightly around the calls.
+        std::env::set_var("AGENT_YES_AGENT_ID", "DEADBEEF0001");
+        assert_eq!(new_agent_id(), "deadbeef0001");
+        std::env::set_var("AGENT_YES_AGENT_ID", "not-hex!!");
+        let minted = new_agent_id();
+        assert_eq!(minted.len(), 12);
+        assert!(minted.bytes().all(|b| b.is_ascii_hexdigit()));
+        std::env::remove_var("AGENT_YES_AGENT_ID");
+        let fresh = new_agent_id();
+        assert_eq!(fresh.len(), 12);
+        assert!(fresh.bytes().all(|b| b.is_ascii_hexdigit()));
+    }
 
     #[test]
     fn test_register_and_read_all() {

--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -294,6 +294,13 @@ pub async fn spawn_agent(
     // tree in `ay ls` and the console. Mirrors ts/index.ts.
     cmd.env("AGENT_YES_PID", std::process::id().to_string());
 
+    // A caller-injected AGENT_YES_AGENT_ID (from `ay serve`'s /api/spawn) is for
+    // THIS agent's record only (pid_store::new_agent_id reads it from our env).
+    // Strip it from the wrapped CLI's env so the agent's subagents (a nested `ay`)
+    // don't inherit it and register under the same id — which would make that id
+    // ambiguous. Our own process env still carries it for new_agent_id().
+    cmd.env_remove("AGENT_YES_AGENT_ID");
+
     // The agent runs in a PTY (a real terminal), so advertise terminal
     // capabilities. A console/daemon-spawned agent inherits an env with no TERM/
     // COLORTERM: neither the daemon (no controlling terminal) nor the recovered

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -374,6 +374,12 @@ export default async function agentYes({
   const parentPid =
     Number.isInteger(inheritedAyPid) && inheritedAyPid > 0 ? inheritedAyPid : undefined;
   ptyEnv.AGENT_YES_PID = String(process.pid);
+  // A caller-injected AGENT_YES_AGENT_ID (from `ay serve`'s /api/spawn) is meant
+  // for THIS agent's record only — pidStore.registerProcess reads it from our own
+  // env. Strip it from the wrapped CLI's env so the agent's subagents (a nested
+  // `ay`) don't inherit it and register under the same id (which would make that
+  // id ambiguous). The wrapper's own process.env still carries it for pidStore.
+  delete ptyEnv.AGENT_YES_AGENT_ID;
   // Inject per-CLI env (e.g. glm → Z.AI endpoint). Expand ${VAR} against the
   // launching env; skip entries whose vars are unset so we never blank out an
   // inherited value (e.g. ANTHROPIC_AUTH_TOKEN when ZAI_API_KEY isn't exported).

--- a/ts/pidStore.ts
+++ b/ts/pidStore.ts
@@ -77,9 +77,15 @@ export class PidStore {
     const fifoFile = this.getFifoPath(pid);
 
     // Upsert by pid. Reuse an existing record's agent id so re-registration
-    // (e.g. status churn) keeps the id stable; mint a fresh 12-hex id otherwise.
+    // (e.g. status churn) keeps the id stable; else adopt a caller-injected
+    // AGENT_YES_AGENT_ID (so `ay serve`'s /api/spawn can hand back an id that
+    // addresses this exact agent — index.ts strips it from the wrapped CLI's env
+    // so subagents don't inherit it); else mint a fresh 12-hex id.
+    const injected = process.env.AGENT_YES_AGENT_ID;
     const existing = this.store.findOne((doc) => doc.pid === pid);
-    const agentId = existing?.agentId ?? randomBytes(6).toString("hex");
+    const agentId =
+      existing?.agentId ??
+      (injected && /^[0-9a-f]{6,32}$/i.test(injected) ? injected : randomBytes(6).toString("hex"));
 
     const record: Omit<PidRecord, "_id"> = {
       pid,

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1763,6 +1763,14 @@ export async function cmdServe(rest: string[]): Promise<number> {
       const agentArgv = [...ayCmd, cli, ...(prompt ? ["--", prompt] : [])];
       // don't leak our Claude Code session into the agent
       const agentEnv = freshAgentEnv();
+      // Correlation id: the spawn response returns the `ay` LAUNCHER pid, which is
+      // NOT the agent's registered pid — so the caller can't find the agent it just
+      // spawned. Mint a 12-hex id (the agent_id format), inject it as
+      // AGENT_YES_AGENT_ID, and return it. Both runtimes adopt it as their agent_id
+      // (instead of minting a random one) and strip it from the wrapped CLI's env so
+      // subagents don't inherit and collide. The caller can then address the agent
+      // immediately: `ay <verb> <remote>:<agentId>`.
+      const agentId = randomBytes(6).toString("hex");
       // Detach the agent into its OWN session (setsid). When `ay serve` runs WITH a
       // controlling terminal (started in a shell rather than as a headless daemon),
       // an undetached child inherits the daemon's session + controlling tty and lands
@@ -1792,7 +1800,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
           const child = Bun.spawn([shell, "-c", script, "ay-spawn", ...agentArgv], {
             cwd,
             detached: true,
-            env: { ...agentEnv, AGENT_YES_CWD: cwd, AGENT_YES_CLI: cli },
+            env: { ...agentEnv, AGENT_YES_CWD: cwd, AGENT_YES_CLI: cli, AGENT_YES_AGENT_ID: agentId },
             stdin: "ignore",
             stdout: "ignore",
             stderr: Bun.file(errPath),
@@ -1829,6 +1837,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
           return Response.json({
             ok: true,
             pid: child.pid,
+            agentId,
             cli,
             cwd,
             hook: true,
@@ -1838,7 +1847,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
         const child = Bun.spawn(agentArgv, {
           cwd,
           detached: true,
-          env: agentEnv,
+          env: { ...agentEnv, AGENT_YES_AGENT_ID: agentId },
           stdin: "ignore",
           stdout: "ignore",
           stderr: "ignore",
@@ -1847,6 +1856,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
         return Response.json({
           ok: true,
           pid: child.pid,
+          agentId,
           cli,
           cwd,
           ...(provisioned ? { provisioned } : {}),

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -897,6 +897,7 @@ async function runRemoteSpawn(
     pid: number;
     cli: string;
     cwd: string;
+    agentId?: string;
     hook?: boolean;
     provisioned?: { action: string };
   };
@@ -905,15 +906,19 @@ async function runRemoteSpawn(
       `${r.hook ? " (via spawn hook)" : ""}` +
       `${r.provisioned ? ` (${r.provisioned.action})` : ""}\n`,
   );
-  // We deliberately do NOT print the agent's own pid. `/api/spawn` returns the
-  // `ay` LAUNCHER pid, which is not the agent's registered pid (the record's
-  // pid/wrapper_pid are the runtime process, not the launcher) — and picking the
-  // freshly-registered agent by "newest" would, under a concurrent spawn,
-  // surface a sibling's (or another user's) pid. Point at the remote's list,
-  // where the new agent reliably appears, instead of guessing.
-  // (A one-step `ay tail <remote>:<pid>` would need /api/spawn to return a
-  // correlatable agent id — a server change left for a follow-up.)
-  process.stderr.write(`\n  ay ls ${hint}    # the new ${r.cli} agent appears here\n`);
+  // `/api/spawn` returns a correlation `agentId` that the agent adopts as its
+  // agent_id — so we address the EXACT agent by it (no pid guessing, no race). A
+  // webrtc:// / share-link target isn't `:keyword`-addressable, so the keyword
+  // hint is only for an alias / token@host:port. Older remotes omit agentId →
+  // fall back to pointing at `ay ls`.
+  if (r.agentId && !hint.includes("://")) {
+    process.stderr.write(
+      `\n  ay tail ${hint}:${r.agentId}            # watch its output\n` +
+        `  ay status ${hint}:${r.agentId} --wait   # block until it needs you\n`,
+    );
+  } else {
+    process.stderr.write(`\n  ay ls ${hint}    # the new ${r.cli} agent appears here\n`);
+  }
   return 0;
 }
 


### PR DESCRIPTION
## What

`/api/spawn` now returns a correlation **`agentId`** so a caller can address the exact agent it just spawned — `ay tail <remote>:<agentId>` / `ay status <remote>:<agentId> --wait`. This completes the follow-up noted in #134.

## Why

`/api/spawn` returned only the `ay` **launcher** pid, which is not the agent's registered pid (the record's pid/wrapper_pid are the runtime process). So `ay spawn <remote>` couldn't reliably point at the new agent and fell back to `ay ls`. (A "newest agent in /api/ls" heuristic was rejected in #134 — it surfaces a wrong agent under a concurrent spawn.)

## How

Mint a 12-hex id, inject it as `AGENT_YES_AGENT_ID`, return it. Both runtimes **adopt** it as their `agent_id` instead of minting a random one, and **strip** it from the wrapped CLI's env so the agent's subagents (a nested `ay`) don't inherit it and register under the same id (which would make it ambiguous).

- `ts/serve.ts` — mint + inject (both hook and direct paths) + return `agentId`.
- `rs/src/pid_store.rs` — `new_agent_id()` adopts a valid injected id else mints (+ unit test).
- `rs/src/pty_spawner.rs` — `env_remove("AGENT_YES_AGENT_ID")` on the wrapped CLI.
- `ts/pidStore.ts` — same adopt-else-mint.
- `ts/index.ts` — strip from `ptyEnv`.
- `ts/subcommands.ts` — `runRemoteSpawn` prints the `:agentId` follow-ups (alias / token@host:port; `ay ls` fallback for webrtc URLs or older remotes).

## Verification (default Rust runtime, end-to-end)

- `/api/spawn` → `{…, agentId}`;
- the spawned agent's record has `agent_id === agentId` (**adopted**);
- the wrapped CLI's env has `AGENT_YES_AGENT_ID` **stripped** (0), the runtime's env keeps it (1);
- Rust unit test for `new_agent_id` (adopt valid / mint on invalid/unset);
- `ay spawn` prints `ay tail <spec>:<agentId>`.

Backwards compatible: older remotes omit `agentId` → CLI falls back to `ay ls`. No behavior change when nobody injects the var (both runtimes still mint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)