### PR TITLE
docs(console): fork copy says "clean — committed work only"

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -3918,7 +3918,7 @@
               return `<div class="omni-row omni-spawn${sc}" data-i="${i}">
                 <span class="dot active"></span>
                 <div class="omni-main">
-                  <div class="omni-title">⑂ Fork <b>${esc(r.srcBranch)}</b> &amp; run <span style="opacity:.55">(carries uncommitted work)</span></div>
+                  <div class="omni-title">⑂ Fork <b>${esc(r.srcBranch)}</b> &amp; run <span style="opacity:.55">(clean — committed work only)</span></div>
                   <div class="omni-sub">${esc(r.fromCwd)} &nbsp;→&nbsp; new branch <b>${esc(r.branch)}</b> &nbsp;·&nbsp; ⏎ to edit &amp; launch</div>
                 </div></div>`;
             }
@@ -4050,12 +4050,13 @@
           return;
         }
         if (row && row.kind === "fork") {
-          // Editable at launch (auto-slug is the default); carries the source's WIP.
+          // Editable at launch (auto-slug is the default). The fork is clean —
+          // committed work only, the source's uncommitted changes stay put.
           // Fork from the source PINNED on the row (row.fromCwd), not a freshly
           // re-resolved anchor — the anchor can drift as the list refreshes, but the
           // branch we fork from must be the one the row was built for.
           const branch = prompt(
-            "Fork to a new branch (carries your uncommitted work):",
+            "Fork to a new branch (clean — committed work only):",
             row.branch,
           );
           if (!branch || !branch.trim()) return; // cancelled — leave the omnibox open

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1642,9 +1642,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
         return new Response("fork requires a non-empty fromCwd and branch", { status: 400 });
       const from = typeof body.from === "string" ? body.from.trim() : "";
       if (fork) {
-        // Fork the anchor agent's branch (carrying its WIP) into a new sibling
-        // worktree via codehost/provision (git worktree off HEAD, no clone), then
-        // spawn the agent there.
+        // Fork the anchor agent's branch into a new sibling worktree via
+        // codehost/provision (git worktree off HEAD, no clone), then spawn the
+        // agent there. The fork is clean — committed work only; the source's
+        // uncommitted changes stay put (codehost forkWorktree defaults wip:false,
+        // and we don't opt in).
         let prov: {
           forkWorktree: (o: { fromCwd: string; branch: string; wsRoot?: string }) => Promise<{
             ok: boolean;


### PR DESCRIPTION
## What

The Cmd+K "⑂ Fork current branch & run" action (and the `/api/spawn` `fork` path) delegate to codehost's `forkWorktree`, which is changing to **fork clean by default** (snomiao/codehost#5) — it no longer carries the source's uncommitted work.

This updates the agent-yes-side copy to match:
- Omnibox row: `(carries uncommitted work)` → `(clean — committed work only)`
- Launch prompt: `Fork to a new branch (carries your uncommitted work):` → `(clean — committed work only)`
- `serve.ts` comment describing the fork path

## Note

`codehost` is an optional runtime dependency (`import("codehost/provision")`), so the actual clean-fork behavior lands once codehost publishes the release from snomiao/codehost#5 and the host's global `codehost` is upgraded. This PR only corrects the console's promise to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)