### PR TITLE
feat(console): split submodule pin-drift from real file changes in the git chip

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -153,14 +153,19 @@ export function tagsFor(e) {
 }
 
 // Compact git indicator from the record's `git` snapshot (server-side
-// `git status --porcelain --branch`): "±3" changed files, "↑1" ahead, "↓2"
-// behind. Returns "" when there's no git info or the tree is clean and in sync,
-// so a tidy repo adds no noise. Branch itself is shown via the path identity.
+// `git status --porcelain=v2 --branch`): "±3" real changed files, "⑂2"
+// submodule pin-bumps, "⊙1" submodule internal dirt, "↑1" ahead, "↓2" behind.
+// Pins/sub-dirt are split out of "±" so submodule drift (constant in a repo with
+// many submodules) never buries the real file edits. Returns "" when there's no
+// git info or the tree is clean and in sync, so a tidy repo adds no noise. Branch
+// itself is shown via the path identity.
 export function gitLabel(e) {
   const g = e.git;
   if (!g) return "";
   const parts = [];
   if (g.changed > 0) parts.push("±" + g.changed);
+  if (g.pins > 0) parts.push("⑂" + g.pins);
+  if (g.subDirty > 0) parts.push("⊙" + g.subDirty);
   if (g.ahead > 0) parts.push("↑" + g.ahead);
   if (g.behind > 0) parts.push("↓" + g.behind);
   return parts.join(" ");

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -3187,13 +3187,19 @@
         );
       }
 
-      // A small git chip (±changed ↑ahead ↓behind) for a row, amber when the tree
-      // is dirty. Empty for clean/in-sync repos and non-git cwds — no noise.
+      // A small git chip (±changed ⑂pins ⊙sub-dirty ↑ahead ↓behind) for a row,
+      // amber when the tree has real file changes. Submodule pin-drift shows as a
+      // muted "⑂" that never turns the chip amber, so it can't bury real edits.
+      // Empty for clean/in-sync repos and non-git cwds — no noise.
       function gitChipHtml(e) {
         const label = gitLabel(e);
         if (!label) return "";
         const g = e.git || {};
-        const tip = `git: ${g.changed || 0} changed · ${g.ahead || 0} ahead · ${g.behind || 0} behind`;
+        const tip =
+          `git: ${g.changed || 0} changed file${(g.changed || 0) === 1 ? "" : "s"}` +
+          (g.pins ? ` · ${g.pins} submodule pin-bump${g.pins === 1 ? "" : "s"}` : "") +
+          (g.subDirty ? ` · ${g.subDirty} submodule dirty` : "") +
+          ` · ${g.ahead || 0} ahead · ${g.behind || 0} behind`;
         return `<span class="git${g.dirty ? " dirty" : ""}" title="${esc(tip)}">${esc(label)}</span>`;
       }
 

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -282,6 +282,18 @@ describe("gitLabel", () => {
     );
     expect(gitLabel(agent({ git: { dirty: false, changed: 0, ahead: 5, behind: 0 } }))).toBe("↑5");
   });
+  it("splits submodule pin-bumps (⑂) and internal dirt (⊙) out of ±", () => {
+    // pin-drift only: no ± (real files) — drift can't masquerade as file changes
+    expect(
+      gitLabel(agent({ git: { dirty: false, changed: 0, pins: 3, subDirty: 0, ahead: 0, behind: 0 } })),
+    ).toBe("⑂3");
+    // real files + pins + sub-dirt, in order
+    expect(
+      gitLabel(agent({ git: { dirty: true, changed: 2, pins: 1, subDirty: 4, ahead: 0, behind: 0 } })),
+    ).toBe("±2 ⑂1 ⊙4");
+    // zero pins/subDirty (or absent) add nothing
+    expect(gitLabel(agent({ git: { dirty: true, changed: 1, pins: 0, subDirty: 0 } }))).toBe("±1");
+  });
 });
 
 describe("age", () => {

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -931,7 +931,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
   };
 
   // Per-repo git snapshot for the list (branch + dirty/changed + ahead/behind, from
-  // one `git status --porcelain --branch`). WATCHER-INVALIDATED, not polled: a read
+  // one `git status --porcelain=v2 --branch`). v2 (not v1) so the submodule field
+  // lets us split real file changes from submodule pin-drift, which would otherwise
+  // inflate `changed` — in a superproject with many submodules the constant gitlink
+  // drift buries the real edits. WATCHER-INVALIDATED, not polled: a read
   // returns the cached snapshot instantly and NEVER spawns `git status` on the
   // request path. A per-repo-root fs watcher recomputes (debounced) only when the
   // repo actually changes, so an idle fleet costs ~0 git processes. The old design
@@ -942,7 +945,9 @@ export async function cmdServe(rest: string[]): Promise<number> {
   interface GitInfo {
     branch: string | null;
     dirty: boolean;
-    changed: number;
+    changed: number; // real file changes (excludes submodule pin-bumps & internal dirt)
+    pins: number; // submodule gitlinks pointing at new commit(s) — pin-bump/drift
+    subDirty: number; // submodule has internal changes but its recorded pin is unchanged
     ahead: number;
     behind: number;
   }
@@ -964,16 +969,55 @@ export async function cmdServe(rest: string[]): Promise<number> {
     }
   };
   const parseGitStatus = (out: string): GitInfo => {
-    const lines = out.split("\n");
-    // Branch header, e.g. "## main...origin/main [ahead 1, behind 2]", "## main"
-    // (no upstream), "## HEAD (no branch)", or "## No commits yet on x".
-    const h = /^## (.+)$/.exec(lines[0] ?? "")?.[1] ?? "";
-    const unborn = /^No commits yet on (.+)$/.exec(h);
-    const branch = unborn ? unborn[1]! : /^(.+?)(?:\.\.\.|\s|$)/.exec(h)?.[1] || null;
-    const ahead = Number(/\bahead (\d+)/.exec(h)?.[1] ?? 0);
-    const behind = Number(/\bbehind (\d+)/.exec(h)?.[1] ?? 0);
-    const changed = lines.slice(1).filter((l) => l.trim().length > 0).length;
-    return { branch, dirty: changed > 0, changed, ahead, behind };
+    // porcelain=v2 --branch: "# branch.*" headers then one line per changed entry.
+    let branch: string | null = null;
+    let ahead = 0;
+    let behind = 0;
+    let changed = 0; // real file changes
+    let pins = 0; // submodule pin-bumps (gitlink → new commit)
+    let subDirty = 0; // submodule internal dirt, recorded pin unchanged
+    for (const line of out.split("\n")) {
+      if (line.length === 0) continue;
+      if (line[0] === "#") {
+        // "# branch.head <name|(detached)>" and "# branch.ab +A -B" (ab absent
+        // when there's no upstream). branch.head carries the name even on an
+        // unborn branch, so no special-casing needed.
+        const head = /^# branch\.head (.+)$/.exec(line);
+        if (head) {
+          branch = head[1] === "(detached)" ? null : head[1]!;
+          continue;
+        }
+        const ab = /^# branch\.ab \+(\d+) -(\d+)/.exec(line);
+        if (ab) {
+          ahead = Number(ab[1]);
+          behind = Number(ab[2]);
+        }
+        continue;
+      }
+      // Changed-entry lines. Untracked ("?") and unmerged ("u") are always real
+      // work; ignored ("!") never appears (we don't pass --ignored). For ordinary
+      // ("1") / renamed ("2") entries the 3rd space-delimited token is the
+      // submodule field <sub>: "N..." for a normal path, or "S<c><m><u>" for a
+      // submodule where c=C means its gitlink moved to new commit(s) (pin-bump),
+      // and m/u flag internal dirty/untracked with the recorded pin unchanged.
+      // Paths (which may contain spaces) come after token 2, so counting by token
+      // index is robust without -z.
+      const type = line[0];
+      if (type === "?") {
+        changed++;
+      } else if (type === "u") {
+        changed++;
+      } else if (type === "1" || type === "2") {
+        const sub = line.split(" ")[2] ?? "N...";
+        if (sub[0] === "S") {
+          if (sub[1] === "C") pins++;
+          else subDirty++;
+        } else {
+          changed++;
+        }
+      }
+    }
+    return { branch, dirty: changed > 0, changed, pins, subDirty, ahead, behind };
   };
   // cwd -> repo root ("" = resolved, not a repo). Resolved once per cwd via a cheap
   // `git rev-parse --show-toplevel` (no tree scan) and cached, so many agents in the
@@ -999,7 +1043,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
       if (rw.busy) return void recompute(root, rw); // re-arm if one is in flight
       rw.busy = true;
       try {
-        const out = await runGit(["status", "--porcelain", "--branch"], root);
+        const out = await runGit(["status", "--porcelain=v2", "--branch"], root);
         if (out != null) rw.val = parseGitStatus(out);
       } finally {
         rw.busy = false;


### PR DESCRIPTION
## Problem

The sidepanel git chip (`±N ↑A ↓B`) counted **every** `git status --porcelain` line as a changed file. In a superproject with many submodules, constant submodule **pin-drift** (` M <sub>`) inflated `±N` and buried the real edits. (agent-yes has no per-file list — just this count — so the drift shows as an inflated number, not a mixed list.)

Requested by the CRM agent exploring the virtual-monorepo (parent + 17 submodules) noise problem. This is "Track A" from the proposal (`tmp/submodule-sidepanel-proposal.md`).

## Change

Switch the per-repo snapshot from `--porcelain` (v1) → `--porcelain=v2 --branch`. v1 collapses pin-bump / submodule-dirty / normal-file all into ` M` — indistinguishable. v2's submodule field classifies them:

| v2 `<sub>` | meaning | field | chip |
|---|---|---|---|
| `N...` | real file change | `changed` | `±N` (amber) |
| `S` w/ `C` flag | submodule pin-bump (gitlink → new commit) | `pins` | muted `⑂N` |
| `S` w/o `C` | submodule internal dirt, pin unchanged | `subDirty` | `⊙N` |

`dirty` (the amber trigger) now reflects **real file changes only**, so pure pin-drift shows as a muted `⑂N` that never buries actual edits. Branch/ahead/behind re-parsed from v2 `# branch.*` headers.

## Verification

- Parser checked against **real** git v2 output (tracked edit + untracked + submodule pin-bump) → `{changed:2, pins:1, subDirty:0}`.
- Empirically confirmed the `<sub>` classifications (`SC..`/`S.M.`/`S..U`/`N...`).
- `ui-logic` tests extended; typecheck 0 new errors (23 pre-existing, unchanged).

## Notes

Backward-compatible (`GitInfo` only gains fields). Respects the existing perf design (counts-only over SSE, no per-agent git fan-out). A full per-file expandable panel (Track B) would use a lazy `/api/gitstatus/:id` endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)