### PR TITLE
feat(console): surface needs_input state (blue dot + pending question)

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -526,10 +526,21 @@ export function fitTransform(gridW, gridH, paneW, paneH) {
 
 // Browser-tab title: "<glyph> <selected agent title> - agent-yes", or the bare
 // console title when nothing is selected (blank/whitespace name). The leading
-// glyph mirrors the agent's status dot — ● active, ○ idle, ✗ exited — so the tab
-// shows liveness at a glance; an unknown status adds no glyph.
+// glyph mirrors the agent's status dot — ⌨ needs_input ("your turn"), ⚠ stuck,
+// ● active, ○ idle, ✗ exited — so the tab shows liveness at a glance even in a
+// background tab; an unknown status adds no glyph.
 export function statusGlyph(status) {
-  return status === "active" ? "●" : status === "idle" ? "○" : status === "exited" ? "✗" : "";
+  return status === "needs_input"
+    ? "⌨"
+    : status === "stuck"
+      ? "⚠"
+      : status === "active"
+        ? "●"
+        : status === "idle"
+          ? "○"
+          : status === "exited"
+            ? "✗"
+            : "";
 }
 export function docTitle(name, status) {
   const n = name && String(name).trim();

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -891,6 +891,11 @@
         color: var(--green);
         border-color: #2a3a2a;
       }
+      /* The pending question when an agent needs_input — blue accent to match the
+         needs_input dot, reading as "your turn / here's what it's asking". */
+      .detail.ask {
+        color: var(--accent);
+      }
       .detail {
         color: var(--muted);
         font-size: 12.5px;
@@ -3291,7 +3296,13 @@
           ${gitChipHtml(e)}
           <span class="age">${age(e)}</span></div>
         ${e.title ? `<div class="rowtitle" title="${esc(e.title)}">${esc(e.title)}</div>` : ""}
-        ${e.prompt ? `<div class="detail" title="${esc(e.prompt)}">${esc(e.prompt)}</div>` : ""}
+        ${
+          e.status === "needs_input" && e.question
+            ? `<div class="detail ask" title="${esc(e.question)}">⌨ ${esc(e.question)}</div>`
+            : e.prompt
+              ? `<div class="detail" title="${esc(e.prompt)}">${esc(e.prompt)}</div>`
+              : ""
+        }
         <div class="rowtags">${tags}</div>
       </div>`;
             })
@@ -4061,10 +4072,7 @@
           // Fork from the source PINNED on the row (row.fromCwd), not a freshly
           // re-resolved anchor — the anchor can drift as the list refreshes, but the
           // branch we fork from must be the one the row was built for.
-          const branch = prompt(
-            "Fork to a new branch (clean — committed work only):",
-            row.branch,
-          );
+          const branch = prompt("Fork to a new branch (clean — committed work only):", row.branch);
           if (!branch || !branch.trim()) return; // cancelled — leave the omnibox open
           closeOmni(false);
           await spawnAndSelect(

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -285,11 +285,15 @@ describe("gitLabel", () => {
   it("splits submodule pin-bumps (⑂) and internal dirt (⊙) out of ±", () => {
     // pin-drift only: no ± (real files) — drift can't masquerade as file changes
     expect(
-      gitLabel(agent({ git: { dirty: false, changed: 0, pins: 3, subDirty: 0, ahead: 0, behind: 0 } })),
+      gitLabel(
+        agent({ git: { dirty: false, changed: 0, pins: 3, subDirty: 0, ahead: 0, behind: 0 } }),
+      ),
     ).toBe("⑂3");
     // real files + pins + sub-dirt, in order
     expect(
-      gitLabel(agent({ git: { dirty: true, changed: 2, pins: 1, subDirty: 4, ahead: 0, behind: 0 } })),
+      gitLabel(
+        agent({ git: { dirty: true, changed: 2, pins: 1, subDirty: 4, ahead: 0, behind: 0 } }),
+      ),
     ).toBe("±2 ⑂1 ⊙4");
     // zero pins/subDirty (or absent) add nothing
     expect(gitLabel(agent({ git: { dirty: true, changed: 1, pins: 0, subDirty: 0 } }))).toBe("±1");
@@ -618,6 +622,8 @@ describe("fitTransform", () => {
 
 describe("statusGlyph", () => {
   it("maps status → glyph", () => {
+    expect(statusGlyph("needs_input")).toBe("⌨");
+    expect(statusGlyph("stuck")).toBe("⚠");
     expect(statusGlyph("active")).toBe("●");
     expect(statusGlyph("idle")).toBe("○");
     expect(statusGlyph("exited")).toBe("✗");

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -9,6 +9,7 @@ import yargs from "yargs";
 import {
   controlCodeFromName,
   deriveLiveStatus,
+  extractNeedsInput,
   extractTaskCounts,
   listRecords,
   readNotes,
@@ -172,12 +173,15 @@ function loginShellEnv(): Record<string, string> | null {
     // Delimiters fence off the env dump from any banner/prompt noise the rc files
     // print to stdout; `env -0` is NUL-separated so values with newlines survive.
     const delim = "_AY_SHELL_ENV_DELIM_";
-    const res = Bun.spawnSync([shell, "-ilc", `printf %s "${delim}"; env -0; printf %s "${delim}"`], {
-      stdin: "ignore",
-      stderr: "ignore",
-      timeout: 5_000,
-      env: process.env as Record<string, string>,
-    });
+    const res = Bun.spawnSync(
+      [shell, "-ilc", `printf %s "${delim}"; env -0; printf %s "${delim}"`],
+      {
+        stdin: "ignore",
+        stderr: "ignore",
+        timeout: 5_000,
+        env: process.env as Record<string, string>,
+      },
+    );
     const out = res.stdout?.toString() ?? "";
     const start = out.indexOf(delim);
     const end = out.lastIndexOf(delim);
@@ -930,6 +934,32 @@ export async function cmdServe(rest: string[]): Promise<number> {
     }
   };
 
+  // Per-agent "waiting on you" detection: the agent is parked on an interactive
+  // menu it did NOT auto-resolve (config `needsInput` patterns). Same source and
+  // classifier as `ay ls` / `ay status`, so the console's dot matches the CLI's
+  // needs_input. Cached per (size, mtime) exactly like logTitle/logTasks — each
+  // miss renders a log window through xterm, so the 1s list tick stays cheap on
+  // an idle fleet. Returns the pending question text (surfaced in the UI), or
+  // null when the agent isn't blocked.
+  const niCache = new Map<string, { size: number; mtimeMs: number; question: string | null }>();
+  const logNeedsInput = async (
+    logFile: string | null | undefined,
+    cli: string,
+  ): Promise<string | null> => {
+    if (!logFile) return null;
+    try {
+      const { size, mtimeMs } = await stat(logFile);
+      const hit = niCache.get(logFile);
+      if (hit && hit.size === size && hit.mtimeMs === mtimeMs) return hit.question;
+      const ni = await extractNeedsInput(logFile, cli);
+      const question = ni?.question ?? null;
+      niCache.set(logFile, { size, mtimeMs, question });
+      return question;
+    } catch {
+      return null;
+    }
+  };
+
   // Per-repo git snapshot for the list (branch + dirty/changed + ahead/behind, from
   // one `git status --porcelain=v2 --branch`). v2 (not v1) so the submodule field
   // lets us split real file changes from submodule pin-drift, which would otherwise
@@ -1095,12 +1125,23 @@ export async function cmdServe(rest: string[]): Promise<number> {
     // the LIVE status here — same liveness+log-mtime basis as `ay ls` — so the
     // console's dot (and the browser tab glyph) flips to idle in step with `ay ls`.
     const status = await deriveLiveStatus(r);
+    // "Waiting on you": alive, quiet, but parked on an unanswered menu. Checked
+    // only for live agents, and skipped when unresponsive (the Rust wedge signal
+    // wins) — mirroring deriveLiveState's precedence in `ay ls` so the console's
+    // dot and the CLI agree.
+    const question =
+      status !== "exited" && !r.unresponsive ? await logNeedsInput(r.log_file, r.cli) : null;
     return {
       ...r,
-      // The Rust supervisor's unresponsive flag is an authoritative wedge signal —
-      // surface it as `stuck` so the console's dot matches `ay ls`. (A dead agent
-      // is never unresponsive — Rust clears the flag on exit.)
-      status: status !== "exited" && r.unresponsive ? "stuck" : status,
+      // Precedence: exited stays exited; the Rust supervisor's unresponsive flag is
+      // an authoritative wedge signal (`stuck`); then a blocked menu (`needs_input`);
+      // else the base live status — so the console's dot matches `ay ls`. (A dead
+      // agent is never unresponsive — Rust clears the flag on exit.)
+      status:
+        status === "exited" ? status : r.unresponsive ? "stuck" : question ? "needs_input" : status,
+      // The pending menu/question text when needs_input, for the console to show
+      // WHAT the agent is waiting on. Null otherwise.
+      question,
       title: await logTitle(r.log_file),
       git: status === "exited" ? null : await gitStatus(r.cwd),
       // Task progress from the rendered todo block (null when none detected → no
@@ -1846,7 +1887,12 @@ export async function cmdServe(rest: string[]): Promise<number> {
           const child = Bun.spawn([shell, "-c", script, "ay-spawn", ...agentArgv], {
             cwd,
             detached: true,
-            env: { ...agentEnv, AGENT_YES_CWD: cwd, AGENT_YES_CLI: cli, AGENT_YES_AGENT_ID: agentId },
+            env: {
+              ...agentEnv,
+              AGENT_YES_CWD: cwd,
+              AGENT_YES_CLI: cli,
+              AGENT_YES_AGENT_ID: agentId,
+            },
             stdin: "ignore",
             stdout: "ignore",
             stderr: Bun.file(errPath),


### PR DESCRIPTION
## Problem

The web console (agent-yes.com/w/) never showed the **needs_input** state — even
though the CSS (`.dot.needs_input`), the attention-first sort rank, and the CLI
(`ay ls` / `ay status`) all already support it. An agent parked on an unanswered
prompt rendered as a plain green/amber dot, indistinguishable from one actively
working. Opening the live console confirmed it: `.dot` classes were only ever
`active` / `idle` / `exited`, never `needs_input` or `stuck`.

## Root cause

`serve.ts`'s `/api/ls` `withMeta` derived only `deriveLiveStatus` (active/idle/
exited) and upgraded to `stuck` on the Rust `unresponsive` flag. It never ran the
`needs_input` menu detection that `deriveLiveState` (the CLI path) uses.

## Fix

- **serve.ts** — add a cached `logNeedsInput` helper (mirrors `logTitle`/`logTasks`
  size+mtime caching so the 1s list tick stays cheap on an idle fleet) and layer
  `needs_input` into `withMeta` with `deriveLiveState`'s precedence:
  `exited > stuck (unresponsive) > needs_input > base`. The pending `question`
  text is emitted on the record.
- **index.html** — render the blue `needs_input` dot and, when parked, show the
  pending question as a `.detail.ask` line (`⌨`, accent color).
- **console-logic.js** — `statusGlyph` now maps `needs_input → ⌨` and `stuck → ⚠`
  so the browser tab reflects "your turn" for the selected agent.

## Verification

Verified live against the real console with `rechrome`:

- Before: `.dot` classes = `{active, idle, exited}` only — zero `needs_input`.
- After: three parked agents flip to blue `needs_input` dots (`rgb(9,105,218)` =
  `--accent`), sorted to the top, each showing its pending question (`⌨ …`).
- `GET /api/ls` now returns `status:"needs_input"` with the `question` field.
- `bun test` — ui-logic + needsInput + lsWatch suites pass (106 tests); added
  `statusGlyph` coverage for the new `needs_input`/`stuck` glyphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)