### PR TITLE
feat(serve): opt-in spawn concurrency cap + memory floor to prevent host OOM

### DIFF
--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -62,6 +62,27 @@ if (config.tray) {
   ensureTray(); // fire-and-forget, don't await
 }
 
+// Spawn admission control — applies to a REAL agent launch only (subcommands,
+// --version, --tray already handled/exited above; --append-prompt / --version
+// below are not launches). Sits BEFORE the --rust dispatch so it gates BOTH the
+// Rust and the TypeScript runtimes. Blocks with φ-backoff until there's capacity
+// (or fails open after a timeout) so a burst of recursive `ay <cli>` spawns gets
+// spaced out instead of storming the host into the OOM-killer. No-op (instant)
+// unless maxAgents/minFreeMb is configured — see ts/spawnGate.ts.
+if (!config.showVersion && !config.appendPrompt && !config.tray) {
+  const { waitForSpawnCapacity } = await import("./spawnGate.ts");
+  await waitForSpawnCapacity({
+    onWait: (reason, waitedMs) => {
+      if (config.verbose || waitedMs === 0)
+        console.error(`[agent-yes] spawn gate: ${reason} — waiting…`);
+    },
+    onProceedAnyway: (reason, waitedMs) =>
+      console.error(
+        `[agent-yes] spawn gate: ${reason} — waited ${Math.round(waitedMs / 1000)}s, proceeding anyway`,
+      ),
+  });
+}
+
 // Handle --rust: spawn the Rust binary instead, fall back to TypeScript if unavailable
 if (config.useRust) {
   let rustBinary: string | undefined;

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -20,6 +20,7 @@ import {
   type CommonOpts,
 } from "./subcommands.ts";
 import { updateGlobalPidStatus } from "./globalPidIndex.ts";
+import { spawnRejectionReason } from "./spawnGate.ts";
 import { pgidForWrapper } from "./reaper.ts";
 import { SUPPORTED_CLIS } from "./SUPPORTED_CLIS.ts";
 import { getInstalledPackage } from "./versionChecker.ts";
@@ -1559,6 +1560,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
       if (!SUPPORTED_CLIS.includes(cli as never))
         return new Response(`unsupported cli: ${cli}`, { status: 400 });
       const prompt = String(body.prompt ?? "");
+
+      // Admission control BEFORE any provisioning (clone/worktree) so a capped
+      // request fails fast without doing expensive work. Enforces the optional
+      // concurrency cap + memory floor that keep a fan-out of agents from
+      // driving the host into the OOM-killer. 429 = back-pressure, retry later.
+      const reject = await spawnRejectionReason();
+      if (reject) return new Response(reject, { status: 429 });
 
       // Resolve the working directory. A `from` source is provisioned (clone /
       // worktree) through codehost/provision; a plain `cwd` is resolved to the

--- a/ts/spawnGate.spec.ts
+++ b/ts/spawnGate.spec.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import {
+  memAvailableMb,
+  spawnGateEnabled,
+  spawnRejectionReason,
+  waitForSpawnCapacity,
+} from "./spawnGate.ts";
+
+// Build a minimal live pid record. Using the test runner's own pid guarantees
+// `isProcessAlive` (process.kill(pid, 0)) succeeds, so the record counts as live.
+const liveRecord = (pid: number) =>
+  JSON.stringify({
+    pid,
+    cli: "claude",
+    prompt: null,
+    cwd: "/tmp",
+    log_file: null,
+    status: "active",
+    exit_code: null,
+    exit_reason: null,
+    started_at: 0,
+  });
+
+describe("spawnGate", () => {
+  let original: string | undefined;
+  let tmp: string;
+  const writePids = (lines: string[]) =>
+    writeFileSync(path.join(tmp, "pids.jsonl"), lines.join("\n") + "\n");
+
+  beforeEach(() => {
+    original = process.env.AGENT_YES_HOME;
+    tmp = mkdtempSync(path.join(tmpdir(), "ay-gate-"));
+    process.env.AGENT_YES_HOME = tmp;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = original;
+    delete process.env.AGENT_YES_MAX_AGENTS;
+    delete process.env.AGENT_YES_MIN_FREE_MB;
+    delete process.env.AGENT_YES_SPAWN_WAIT_MS;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  describe("memAvailableMb", () => {
+    it("returns a positive number on this host", async () => {
+      const mb = await memAvailableMb();
+      expect(mb).not.toBeNull();
+      expect(mb!).toBeGreaterThan(0);
+    });
+  });
+
+  describe("spawnGateEnabled", () => {
+    it("is false when nothing is configured", () => {
+      expect(spawnGateEnabled()).toBe(false);
+    });
+    it("is true when a cap or floor is set", () => {
+      process.env.AGENT_YES_MAX_AGENTS = "5";
+      expect(spawnGateEnabled()).toBe(true);
+    });
+  });
+
+  describe("spawnRejectionReason", () => {
+    it("returns null when no limits are configured", async () => {
+      expect(await spawnRejectionReason()).toBeNull();
+    });
+
+    it("rejects when live agents reach the cap", async () => {
+      writePids([liveRecord(process.pid)]);
+      process.env.AGENT_YES_MAX_AGENTS = "1";
+      expect(await spawnRejectionReason()).toMatch(/too many agents running \(1\/1\)/);
+    });
+
+    it("admits when live agents are under the cap", async () => {
+      writePids([liveRecord(process.pid)]);
+      process.env.AGENT_YES_MAX_AGENTS = "5";
+      expect(await spawnRejectionReason()).toBeNull();
+    });
+
+    it("ignores dead pids when counting live agents", async () => {
+      // pid 2^31-1 is effectively never a live process → not counted.
+      writePids([liveRecord(2147483646)]);
+      process.env.AGENT_YES_MAX_AGENTS = "1";
+      expect(await spawnRejectionReason()).toBeNull();
+    });
+
+    it("rejects when free memory is below the floor", async () => {
+      process.env.AGENT_YES_MIN_FREE_MB = String(Number.MAX_SAFE_INTEGER);
+      expect(await spawnRejectionReason()).toMatch(/host is low on memory/);
+    });
+
+    it("admits when free memory is above the floor", async () => {
+      process.env.AGENT_YES_MIN_FREE_MB = "1";
+      expect(await spawnRejectionReason()).toBeNull();
+    });
+  });
+
+  describe("waitForSpawnCapacity", () => {
+    it("returns immediately (no sleep) when the gate is disabled", async () => {
+      const sleeps: number[] = [];
+      await waitForSpawnCapacity({ sleep: async (ms) => void sleeps.push(ms) });
+      expect(sleeps).toEqual([]);
+    });
+
+    it("backs off with φ growth and fails open at the deadline", async () => {
+      writePids([liveRecord(process.pid)]);
+      process.env.AGENT_YES_MAX_AGENTS = "1"; // always over → never admits
+
+      let t = 0;
+      const sleeps: number[] = [];
+      let proceededAfter: number | null = null;
+      await waitForSpawnCapacity({
+        maxWaitMs: 5000,
+        now: () => t,
+        sleep: async (ms) => {
+          sleeps.push(ms);
+          t += ms;
+        },
+        onProceedAnyway: (_r, waited) => {
+          proceededAfter = waited;
+        },
+      });
+
+      // 1000, then ×φ (1618), then clamped to the remaining 2382ms before deadline.
+      expect(sleeps[0]).toBe(1000);
+      expect(sleeps[1]).toBe(1618);
+      expect(sleeps.reduce((a, b) => a + b, 0)).toBe(5000);
+      expect(proceededAfter).toBe(5000);
+    });
+
+    it("admits as soon as capacity frees, without proceeding-anyway", async () => {
+      writePids([liveRecord(process.pid)]);
+      process.env.AGENT_YES_MAX_AGENTS = "1";
+
+      const sleeps: number[] = [];
+      let proceeded = false;
+      await waitForSpawnCapacity({
+        maxWaitMs: 600_000,
+        sleep: async (ms) => {
+          sleeps.push(ms);
+          // free up capacity after two backoff cycles
+          if (sleeps.length >= 2) process.env.AGENT_YES_MAX_AGENTS = "10";
+        },
+        onProceedAnyway: () => {
+          proceeded = true;
+        },
+      });
+
+      expect(sleeps.length).toBe(2);
+      expect(proceeded).toBe(false);
+    });
+  });
+});

--- a/ts/spawnGate.ts
+++ b/ts/spawnGate.ts
@@ -1,0 +1,123 @@
+/**
+ * Spawn admission control — keep an unbounded fan-out of agents from exhausting
+ * host RAM and tripping the kernel OOM-killer (which, on a box with no cgroup
+ * memory limit, hangs the whole machine). Two opt-in limits:
+ *   - {@link getMaxAgents}  — max concurrently-live agents
+ *   - {@link getMinFreeMb}  — minimum free memory before admitting a spawn
+ *
+ * Two entry points share one instantaneous check ({@link spawnRejectionReason}):
+ *   - the `ay serve` daemon HARD-REJECTS (`/api/spawn` → 429) so the caller retries;
+ *   - the CLI path BLOCKS-AND-WAITS ({@link waitForSpawnCapacity}) with φ-backoff,
+ *     failing open after a timeout so recursive `ay <cli>` spawns get spaced out
+ *     (the actual cause of the burst storms) without ever deadlocking a workflow.
+ */
+import { readFile } from "fs/promises";
+import { readGlobalPids } from "./globalPidIndex.ts";
+import { getMaxAgents, getMinFreeMb, getSpawnWaitMs } from "./workspaceConfig.ts";
+
+/**
+ * System available memory in MB. Prefers Linux `/proc/meminfo` `MemAvailable`
+ * (the kernel's own estimate of what's reclaimable without swapping — far more
+ * accurate than free RAM), falling back to `os.freemem()` on other platforms or
+ * if the file can't be parsed. Returns null when nothing usable is available.
+ */
+export async function memAvailableMb(): Promise<number | null> {
+  try {
+    const txt = await readFile("/proc/meminfo", "utf-8");
+    const m = /^MemAvailable:\s+(\d+)\s*kB/m.exec(txt);
+    if (m) return Math.floor(Number(m[1]) / 1024);
+  } catch {
+    /* not Linux / unreadable — fall through */
+  }
+  try {
+    const { freemem } = await import("os");
+    return Math.floor(freemem() / (1024 * 1024));
+  } catch {
+    return null;
+  }
+}
+
+/** True when at least one spawn limit is configured (else the gate is a no-op). */
+export function spawnGateEnabled(): boolean {
+  return getMaxAgents() !== undefined || getMinFreeMb() !== undefined;
+}
+
+/**
+ * Instantaneous capacity check. Returns a human-readable reason string when a
+ * new spawn should be held back (cap reached / memory too low), or null when
+ * there's capacity. Both limits are opt-in — unset means no check.
+ *
+ * NOTE — the `maxAgents` count is BEST-EFFORT, not a hard barrier: the check is
+ * non-atomic (check here → register in `pids.jsonl` later, in another process),
+ * so a simultaneous burst can briefly overshoot the cap before the new wrappers
+ * appear in the live count. That's acceptable because (a) the CLI path's
+ * φ-backoff desynchronizes retries, spreading a burst out, and (b) `minFreeMb`
+ * is the HARD OOM guard — it's re-evaluated against live `/proc/meminfo` on every
+ * attempt, so once RAM actually drops, further spawns are held regardless of the
+ * count. Exact admission would need a cross-process reservation+lock (a TTL'd
+ * reservation file); deliberately deferred to avoid stale reservations wedging
+ * spawns, which would be worse than a transient overshoot.
+ */
+export async function spawnRejectionReason(): Promise<string | null> {
+  const maxAgents = getMaxAgents();
+  if (maxAgents !== undefined) {
+    // Live agents already running (this wrapper hasn't registered itself yet),
+    // so "live >= cap" admits exactly `maxAgents` concurrent agents.
+    const live = (await readGlobalPids({ liveOnly: true })).length;
+    if (live >= maxAgents)
+      // Phrased for the end user who clicked "Spawn" (the console shows this
+      // string verbatim), with a host-admin hint appended in parentheses.
+      return `too many agents running (${live}/${maxAgents}) — this agent wasn't started. Please wait for one to finish and try again. (host: raise "maxAgents" in ~/.agent-yes/config.json or AGENT_YES_MAX_AGENTS)`;
+  }
+  const minFreeMb = getMinFreeMb();
+  if (minFreeMb !== undefined) {
+    const avail = await memAvailableMb();
+    if (avail !== null && avail < minFreeMb)
+      return `the host is low on memory (${avail}MB free, needs ${minFreeMb}MB) — this agent wasn't started, to avoid crashing the machine. Please try again in a moment. (host: adjust "minFreeMb" in ~/.agent-yes/config.json or AGENT_YES_MIN_FREE_MB)`;
+  }
+  return null;
+}
+
+const PHI = 1.618; // golden-ratio backoff base (snomiao global pref)
+const BACKOFF_CAP_MS = 60_000;
+const BACKOFF_BASE_MS = 1_000;
+
+/**
+ * Block until there's spawn capacity, polling with φ-backoff (1s × φⁿ, capped at
+ * 60s — there is no OS event for "memory freed", so polling is unavoidable here).
+ * Fails open after {@link getSpawnWaitMs} ms (default 10 min): on timeout it logs
+ * and proceeds, so a set of mutually-waiting recursive spawns can never deadlock
+ * permanently. A no-op (returns immediately) when no limit is configured, so it
+ * adds ~zero overhead to the spawn hot path for users who haven't opted in.
+ *
+ * `sleep`/`now` are injectable for tests. `onWait` fires once per backoff cycle.
+ */
+export async function waitForSpawnCapacity(opts?: {
+  maxWaitMs?: number;
+  onWait?: (reason: string, waitedMs: number) => void;
+  onProceedAnyway?: (reason: string, waitedMs: number) => void;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}): Promise<void> {
+  if (!spawnGateEnabled()) return; // fast path: nothing configured
+  const maxWaitMs = opts?.maxWaitMs ?? getSpawnWaitMs();
+  // Monotonic clock for the deadline — `Date.now()` can step backward (NTP /
+  // suspend) and stretch the fail-open wait far past `maxWaitMs`.
+  const now = opts?.now ?? (() => performance.now());
+  const sleep = opts?.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const start = now();
+  let delay = BACKOFF_BASE_MS;
+  for (;;) {
+    const reason = await spawnRejectionReason();
+    if (!reason) return; // capacity available — admit
+    const waited = now() - start;
+    if (waited >= maxWaitMs) {
+      opts?.onProceedAnyway?.(reason, waited);
+      return; // fail open — never deadlock a workflow
+    }
+    opts?.onWait?.(reason, waited);
+    // Don't oversleep past the deadline.
+    await sleep(Math.min(delay, BACKOFF_CAP_MS, maxWaitMs - waited));
+    delay = Math.min(delay * PHI, BACKOFF_CAP_MS);
+  }
+}

--- a/ts/workspaceConfig.spec.ts
+++ b/ts/workspaceConfig.spec.ts
@@ -4,6 +4,9 @@ import { homedir, tmpdir } from "os";
 import path from "path";
 import {
   expandTilde,
+  getMaxAgents,
+  getMinFreeMb,
+  getSpawnWaitMs,
   getProvisionAllowlist,
   getProvisionRoot,
   getSpawnHook,
@@ -28,6 +31,9 @@ describe("workspaceConfig", () => {
     delete process.env.CODEHOST_WS_ROOT;
     delete process.env.CODEHOST_PROVISION_ALLOWLIST;
     delete process.env.AGENT_YES_SPAWN_HOOK;
+    delete process.env.AGENT_YES_MAX_AGENTS;
+    delete process.env.AGENT_YES_MIN_FREE_MB;
+    delete process.env.AGENT_YES_SPAWN_WAIT_MS;
     rmSync(tmp, { recursive: true, force: true });
   });
 
@@ -143,6 +149,85 @@ describe("workspaceConfig", () => {
       expect(isProvisionAllowed("acme", "widget")).toBe(true);
       expect(isProvisionAllowed("acme", "other")).toBe(false);
       expect(isProvisionAllowed("org", "anything")).toBe(true);
+    });
+  });
+
+  describe("getMaxAgents", () => {
+    it("is undefined (unlimited) when neither env nor config is set", () => {
+      expect(getMaxAgents()).toBeUndefined();
+    });
+
+    it("reads a positive integer from config", () => {
+      writeConfig({ maxAgents: 8 });
+      expect(getMaxAgents()).toBe(8);
+    });
+
+    it("env AGENT_YES_MAX_AGENTS overrides config", () => {
+      writeConfig({ maxAgents: 8 });
+      process.env.AGENT_YES_MAX_AGENTS = "3";
+      expect(getMaxAgents()).toBe(3);
+    });
+
+    it("floors a fractional value", () => {
+      process.env.AGENT_YES_MAX_AGENTS = "4.9";
+      expect(getMaxAgents()).toBe(4);
+    });
+
+    it("treats 0, negative, and garbage as unlimited (undefined)", () => {
+      writeConfig({ maxAgents: 0 });
+      expect(getMaxAgents()).toBeUndefined();
+      process.env.AGENT_YES_MAX_AGENTS = "-5";
+      expect(getMaxAgents()).toBeUndefined();
+      process.env.AGENT_YES_MAX_AGENTS = "lots";
+      expect(getMaxAgents()).toBeUndefined();
+    });
+
+    it("treats a fractional value < 1 as unlimited, not a 0 hard-cap", () => {
+      // Regression: 0.5 must NOT floor to 0 (which would reject every spawn).
+      process.env.AGENT_YES_MAX_AGENTS = "0.5";
+      expect(getMaxAgents()).toBeUndefined();
+    });
+  });
+
+  describe("getMinFreeMb", () => {
+    it("is undefined (no floor) when unset", () => {
+      expect(getMinFreeMb()).toBeUndefined();
+    });
+
+    it("reads config and lets env override", () => {
+      writeConfig({ minFreeMb: 1024 });
+      expect(getMinFreeMb()).toBe(1024);
+      process.env.AGENT_YES_MIN_FREE_MB = "2048";
+      expect(getMinFreeMb()).toBe(2048);
+    });
+
+    it("treats non-positive/garbage/sub-1 as no floor", () => {
+      process.env.AGENT_YES_MIN_FREE_MB = "0";
+      expect(getMinFreeMb()).toBeUndefined();
+      process.env.AGENT_YES_MIN_FREE_MB = "nope";
+      expect(getMinFreeMb()).toBeUndefined();
+      process.env.AGENT_YES_MIN_FREE_MB = "0.5";
+      expect(getMinFreeMb()).toBeUndefined();
+    });
+  });
+
+  describe("getSpawnWaitMs", () => {
+    it("defaults to 10 minutes when unset", () => {
+      expect(getSpawnWaitMs()).toBe(600_000);
+    });
+
+    it("reads config and lets env override; allows 0 (don't wait)", () => {
+      writeConfig({ spawnWaitMs: 5000 });
+      expect(getSpawnWaitMs()).toBe(5000);
+      process.env.AGENT_YES_SPAWN_WAIT_MS = "0";
+      expect(getSpawnWaitMs()).toBe(0);
+    });
+
+    it("falls back to the default on negative/garbage", () => {
+      process.env.AGENT_YES_SPAWN_WAIT_MS = "-1";
+      expect(getSpawnWaitMs()).toBe(600_000);
+      process.env.AGENT_YES_SPAWN_WAIT_MS = "soon";
+      expect(getSpawnWaitMs()).toBe(600_000);
     });
   });
 

--- a/ts/workspaceConfig.ts
+++ b/ts/workspaceConfig.ts
@@ -25,6 +25,24 @@ interface Config {
    * arbitrary local code that runs on every spawn.
    */
   spawnHook?: string;
+  /**
+   * Max number of concurrently-live agents the daemon will admit via
+   * `/api/spawn`. `0`/unset = unlimited (current behavior). See {@link getMaxAgents}.
+   */
+  maxAgents?: number;
+  /**
+   * Refuse a new spawn when system MemAvailable is below this many MB — a memory
+   * floor so a burst of spawns can't drive the host into the OOM-killer. `0`/unset
+   * = no floor. See {@link getMinFreeMb}.
+   */
+  minFreeMb?: number;
+  /**
+   * How long (ms) a CLI spawn will block-and-wait for capacity (φ-backoff) before
+   * failing open and proceeding anyway. Prevents a burst of recursive `ay <cli>`
+   * spawns from storming the host while never permanently deadlocking a workflow.
+   * Unset = default 10 min. See {@link getSpawnWaitMs}.
+   */
+  spawnWaitMs?: number;
 }
 
 function configPath(): string {
@@ -129,6 +147,52 @@ export function getSpawnHook(): string | null {
 /** Whether a usable {@link getSpawnHook} is configured (for read-only disclosure). */
 export function hasSpawnHook(): boolean {
   return getSpawnHook() !== null;
+}
+
+/**
+ * Cap on concurrently-live agents admitted via `/api/spawn`. Env
+ * `AGENT_YES_MAX_AGENTS` overrides the config `maxAgents`. A non-positive,
+ * missing, or unparseable value means **unlimited** (returns undefined), which
+ * preserves the historical no-cap behavior. Exists to stop an unbounded fan-out
+ * of agents from exhausting host RAM and tripping the OOM-killer.
+ */
+export function getMaxAgents(): number | undefined {
+  const raw = process.env.AGENT_YES_MAX_AGENTS?.trim();
+  const n = raw !== undefined && raw !== "" ? Number(raw) : readConfig().maxAgents;
+  // Floor BEFORE the >0 check: a fractional 0<n<1 would otherwise floor to 0 and
+  // turn "invalid/unlimited" into "reject every spawn" (live >= 0 always true).
+  const v = typeof n === "number" && Number.isFinite(n) ? Math.floor(n) : NaN;
+  return v > 0 ? v : undefined;
+}
+
+/**
+ * Minimum system MemAvailable (MB) required to admit a new spawn. Env
+ * `AGENT_YES_MIN_FREE_MB` overrides config `minFreeMb`. Non-positive/unset =
+ * no floor (undefined). Complements {@link getMaxAgents}: a count cap alone
+ * can't stop OOM when individual agents are large, so we also refuse to spawn
+ * when free memory is already low.
+ */
+export function getMinFreeMb(): number | undefined {
+  const raw = process.env.AGENT_YES_MIN_FREE_MB?.trim();
+  const n = raw !== undefined && raw !== "" ? Number(raw) : readConfig().minFreeMb;
+  // Floor before the >0 check (see getMaxAgents) so a fractional value can't
+  // collapse to a meaningless 0 floor.
+  const v = typeof n === "number" && Number.isFinite(n) ? Math.floor(n) : NaN;
+  return v > 0 ? v : undefined;
+}
+
+/**
+ * Max time (ms) a CLI spawn blocks waiting for capacity before failing open.
+ * Env `AGENT_YES_SPAWN_WAIT_MS` overrides config `spawnWaitMs`. A non-negative
+ * finite value is used as-is (0 = don't wait, check once then proceed); anything
+ * missing/garbage falls back to the 10-minute default. Bounded fail-open is
+ * deliberate: recursive spawns must never deadlock permanently on each other.
+ */
+export function getSpawnWaitMs(): number {
+  const DEFAULT = 600_000;
+  const raw = process.env.AGENT_YES_SPAWN_WAIT_MS?.trim();
+  const n = raw !== undefined && raw !== "" ? Number(raw) : readConfig().spawnWaitMs;
+  return typeof n === "number" && Number.isFinite(n) && n >= 0 ? Math.floor(n) : DEFAULT;
 }
 
 /** Persist the workspace root, tilde-expanded and resolved to an absolute path. */


### PR DESCRIPTION
## Why

The host has **no cgroup memory limit**, so an unbounded fan-out of agents (console `/api/spawn` + recursive `ay <cli>`) can exhaust RAM and trip the kernel OOM-killer, hanging the whole machine (needs a hard reset). A 6-hour memory trace showed **no leak** — the hang was a spawn **burst**, so a memory floor re-checked on every spawn is the right guard.

## What

New shared `ts/spawnGate.ts` with three **opt-in** limits (all default OFF → no behavior change until configured):

| Setting | Env | Meaning |
|---|---|---|
| `maxAgents` | `AGENT_YES_MAX_AGENTS` | max concurrent live agents |
| `minFreeMb` | `AGENT_YES_MIN_FREE_MB` | refuse spawn below this MemAvailable (hard OOM guard) |
| `spawnWaitMs` | `AGENT_YES_SPAWN_WAIT_MS` | CLI block-wait timeout (default 10 min) |

Two enforcement styles over one capacity check:
- **daemon `/api/spawn`** → HARD-REJECT **429** (frontend Spawn button shows the reason via `alert("launch failed: "+res.text)`).
- **CLI path** (`ts/cli.ts`, before the `--rust` dispatch so it covers both the Rust and TS runtimes) → BLOCK with **φ≈1.618 backoff** (1s→60s) then **fail open** after the timeout, so a burst gets spaced out without ever deadlocking a workflow.

Rejection messages are end-user-friendly (plain language first, host-admin hint in parens).

## Review notes (codex)
- elapsed time uses a **monotonic clock** (`performance.now`) so an NTP step can't stretch the fail-open deadline.
- the `maxAgents` count is **best-effort** (non-atomic check-then-register); `minFreeMb`, re-evaluated every attempt, is the hard guard. Documented; exact admission (reservation+lock) deferred to avoid stale-reservation wedging.

## Tests
`ts/spawnGate.spec.ts` (φ-backoff sequence, fail-open-at-deadline, admit-on-free, live-vs-dead-pid count, memory floor) + `ts/workspaceConfig.spec.ts` getters. **48/48 pass**; `bun run build` clean. Verified live: `POST /api/spawn` → 429 with the friendly body, no agent spawned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)