### PR TITLE
feat(help): show agent self/parent identity + sub-agent guidance in ay help

### DIFF
--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -30,7 +30,7 @@ import { buildRustArgs } from "./buildRustArgs.ts";
   const isHelpFlag = rawArg === "-h" || rawArg === "--help";
   const { isSubcommand, runSubcommand, cmdHelp } = await import("./subcommands.ts");
   if (isHelpFlag && process.argv.length === 3) {
-    cmdHelp(managerCommands);
+    await cmdHelp(managerCommands);
     process.exit(0);
   }
   if (isSubcommand(rawArg, managerCommands)) {

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -179,8 +179,37 @@ describe("subcommands.cmdHelp", () => {
       expect(out).toContain(`You are agent pid ${process.pid} (claude)`);
       expect(out).toContain(`Spawned by agent pid 900001 (codex)`);
       expect(out).toContain("Spawn a sub-agent");
-      expect(out).toContain("List your sub-agents");
-      expect(out).toContain("ay ls --watch");
+      expect(out).toContain(`ay ls --cwd /work/parent/child`);
+      expect(out).toContain(`ay ls --watch --cwd /work/parent/child`);
+    } finally {
+      if (saved === undefined) delete process.env.AGENT_YES_PID;
+      else process.env.AGENT_YES_PID = saved;
+    }
+  });
+
+  it("reports a nested-but-unresolved parent distinctly from top-level", async () => {
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    const selfWrapperPid = 555004;
+    await appendGlobalPid({
+      pid: process.pid,
+      cli: "claude",
+      prompt: null,
+      cwd: process.cwd(),
+      log_file: null,
+      fifo_file: null,
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now(),
+      wrapper_pid: selfWrapperPid,
+      parent_pid: 999999999, // no record ever registered for this wrapper pid
+    });
+    const saved = process.env.AGENT_YES_PID;
+    process.env.AGENT_YES_PID = String(selfWrapperPid);
+    try {
+      const out = await capture();
+      expect(out).not.toContain("Top-level agent");
+      expect(out).toContain("Nested under a parent (wrapper pid 999999999)");
     } finally {
       if (saved === undefined) delete process.env.AGENT_YES_PID;
       else process.env.AGENT_YES_PID = saved;

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -113,25 +113,105 @@ describe("subcommands.isSubcommand", () => {
 });
 
 describe("subcommands.cmdHelp", () => {
-  it("hides the manager-only `setup` line for cli-bound aliases", async () => {
+  const capture = async (managerCommands?: boolean) => {
     const { cmdHelp } = await loadModule();
-    const capture = (managerCommands?: boolean) => {
-      let out = "";
-      const spy = vi.spyOn(process.stdout, "write").mockImplementation((s: unknown) => {
-        out += String(s);
-        return true;
-      });
-      try {
-        cmdHelp(managerCommands);
-      } finally {
-        spy.mockRestore();
-      }
-      return out;
-    };
-    expect(capture(true)).toContain("ay setup"); // manager
-    expect(capture()).toContain("ay setup"); // default = manager
-    expect(capture(false)).not.toContain("ay setup"); // cli-bound alias (cy)
-    expect(capture(false)).toContain("ay ls"); // universal commands still shown
+    let out = "";
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation((s: unknown) => {
+      out += String(s);
+      return true;
+    });
+    try {
+      await cmdHelp(managerCommands);
+    } finally {
+      spy.mockRestore();
+    }
+    return out;
+  };
+
+  it("hides the manager-only `setup` line for cli-bound aliases", async () => {
+    expect(await capture(true)).toContain("ay setup"); // manager
+    expect(await capture()).toContain("ay setup"); // default = manager
+    expect(await capture(false)).not.toContain("ay setup"); // cli-bound alias (cy)
+    expect(await capture(false)).toContain("ay ls"); // universal commands still shown
+  });
+
+  it("stays plain for a human shell (no AGENT_YES_PID)", async () => {
+    const out = await capture();
+    expect(out).not.toContain("You are running inside an agent");
+  });
+
+  it("prints self + parent identity and sub-agent guidance when nested in an agent", async () => {
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    const parentWrapperPid = 555001;
+    const selfWrapperPid = 555002;
+    await appendGlobalPid({
+      pid: 900001,
+      cli: "codex",
+      prompt: "orchestrate the migration",
+      cwd: "/work/parent",
+      log_file: null,
+      fifo_file: null,
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now(),
+      wrapper_pid: parentWrapperPid,
+    });
+    await appendGlobalPid({
+      pid: process.pid,
+      cli: "claude",
+      prompt: "fix the failing test",
+      cwd: "/work/parent/child",
+      log_file: null,
+      fifo_file: null,
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now(),
+      wrapper_pid: selfWrapperPid,
+      parent_pid: parentWrapperPid,
+    });
+    const saved = process.env.AGENT_YES_PID;
+    process.env.AGENT_YES_PID = String(selfWrapperPid);
+    try {
+      const out = await capture();
+      expect(out).toContain("You are running inside an agent");
+      expect(out).toContain(`You are agent pid ${process.pid} (claude)`);
+      expect(out).toContain(`Spawned by agent pid 900001 (codex)`);
+      expect(out).toContain("Spawn a sub-agent");
+      expect(out).toContain("List your sub-agents");
+      expect(out).toContain("ay ls --watch");
+    } finally {
+      if (saved === undefined) delete process.env.AGENT_YES_PID;
+      else process.env.AGENT_YES_PID = saved;
+    }
+  });
+
+  it("reports top-level (no parent) when parent_pid is absent", async () => {
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    const selfWrapperPid = 555003;
+    await appendGlobalPid({
+      pid: process.pid,
+      cli: "claude",
+      prompt: null,
+      cwd: process.cwd(),
+      log_file: null,
+      fifo_file: null,
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now(),
+      wrapper_pid: selfWrapperPid,
+    });
+    const saved = process.env.AGENT_YES_PID;
+    process.env.AGENT_YES_PID = String(selfWrapperPid);
+    try {
+      const out = await capture();
+      expect(out).toContain("Top-level agent");
+    } finally {
+      if (saved === undefined) delete process.env.AGENT_YES_PID;
+      else process.env.AGENT_YES_PID = saved;
+    }
   });
 });
 

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -387,14 +387,72 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
 // ay help
 // ---------------------------------------------------------------------------
 
-export function cmdHelp(managerCommands = true): number {
+/**
+ * The banner shown by `ay help` / `ay -h` when this process is itself running
+ * inside an agent (`AGENT_YES_PID` set — see resolveSender). Answers the three
+ * things a nested agent actually needs: who am I, who spawned me, and how do I
+ * drive sub-agents of my own — so it doesn't have to rediscover the fan-out
+ * primitives (spawn / ay ls forest / ay ls --watch) from scratch every session.
+ */
+async function buildAgentContextSection(self: GlobalPidRecord): Promise<string> {
+  const parent =
+    typeof self.parent_pid === "number" && self.parent_pid > 0
+      ? (
+          await listRecords(undefined, {
+            all: true,
+            active: false,
+            json: false,
+            latest: false,
+            cwdScope: null,
+          })
+        ).find((r) => r.wrapper_pid === self.parent_pid)
+      : undefined;
+
+  const whoAmI = `You are agent pid ${self.pid} (${self.cli}) in ${shortenPath(self.cwd)}.`;
+  const parentLine = parent
+    ? `Spawned by agent pid ${parent.pid} (${parent.cli}) in ${shortenPath(parent.cwd)}.`
+    : `Top-level agent — no parent (started from a human shell or scheduler).`;
+
+  return (
+    `You are running inside an agent:\n` +
+    `  ${whoAmI}\n` +
+    `  ${parentLine}\n` +
+    `\n` +
+    `As an agent, you can:\n` +
+    `  Spawn a sub-agent:\n` +
+    `    ay <cli> -- "<prompt>"                                  auto-links as your child\n` +
+    `    ay claude --model sonnet --advisor opus -- "<prompt>"   routine task\n` +
+    `    ay claude --model opus --advisor fable -- "<prompt>"    complex task\n` +
+    `    (pick --model by task complexity so easy tasks don't cost like hard ones;\n` +
+    `     --advisor is a claude-cli flag — only takes effect for claude/cy)\n` +
+    `  List your sub-agents:\n` +
+    `    ay ls                                   children render indented under your own pid\n` +
+    `    ay ls --cwd <dir>                       scope the tree to one workspace\n` +
+    `  Watch all your sub-agents at once:\n` +
+    `    ay ls --watch                           NDJSON stream of state changes across every\n` +
+    `                                              matched agent — one watcher for the whole\n` +
+    `                                              fan-out instead of N \`ay status --watch\`es\n` +
+    `  Read one sub-agent's output:\n` +
+    `    ay tail -f <pid>                        follow live output (no single command tails\n` +
+    `                                              many agents' content at once yet — loop\n` +
+    `                                              \`ay ls --json\` pids into per-pid \`ay tail\`)\n` +
+    `\n`
+  );
+}
+
+export async function cmdHelp(managerCommands = true): Promise<number> {
   // `setup` is manager-only — hide it when invoked through a cli-bound alias
   // (cy/claude-yes/…), where `cy setup` runs the agent instead of managing the host.
   const setupLine = managerCommands
     ? `  ay setup                            guided setup: pick a workspace, share to agent-yes.com\n`
     : ``;
+  // Only agents carry AGENT_YES_PID — a human shell never sets it — so this
+  // section is skipped entirely (no async work at all) for interactive use.
+  const self = process.env.AGENT_YES_PID ? await resolveSender() : null;
+  const agentSection = self ? await buildAgentContextSection(self) : "";
   process.stdout.write(
-    `ay - agent-yes CLI\n` +
+    agentSection +
+      `ay - agent-yes CLI\n` +
       `\n` +
       `Management:\n` +
       `  ay ls [keyword]                     list running agents\n` +

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -395,23 +395,29 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
  * primitives (spawn / ay ls forest / ay ls --watch) from scratch every session.
  */
 async function buildAgentContextSection(self: GlobalPidRecord): Promise<string> {
-  const parent =
-    typeof self.parent_pid === "number" && self.parent_pid > 0
-      ? (
-          await listRecords(undefined, {
-            all: true,
-            active: false,
-            json: false,
-            latest: false,
-            cwdScope: null,
-          })
-        ).find((r) => r.wrapper_pid === self.parent_pid)
-      : undefined;
+  const hasParentPid = typeof self.parent_pid === "number" && self.parent_pid > 0;
+  const parent = hasParentPid
+    ? (
+        await listRecords(undefined, {
+          all: true,
+          active: false,
+          json: false,
+          latest: false,
+          cwdScope: null,
+        })
+      ).find((r) => r.wrapper_pid === self.parent_pid)
+    : undefined;
 
   const whoAmI = `You are agent pid ${self.pid} (${self.cli}) in ${shortenPath(self.cwd)}.`;
-  const parentLine = parent
-    ? `Spawned by agent pid ${parent.pid} (${parent.cli}) in ${shortenPath(parent.cwd)}.`
-    : `Top-level agent — no parent (started from a human shell or scheduler).`;
+  // Three distinct states: no parent at all (top-level); a parent_pid whose
+  // record we can resolve; or a parent_pid we can't resolve (its record aged
+  // out / lives on a remote) — that last case is still nested, just unknown,
+  // so it must not collapse into the "top-level" line.
+  const parentLine = !hasParentPid
+    ? `Top-level agent — no parent (started from a human shell or scheduler).`
+    : parent
+      ? `Spawned by agent pid ${parent.pid} (${parent.cli}) in ${shortenPath(parent.cwd)}.`
+      : `Nested under a parent (wrapper pid ${self.parent_pid}) whose record isn't in the local registry.`;
 
   return (
     `You are running inside an agent:\n` +
@@ -425,13 +431,12 @@ async function buildAgentContextSection(self: GlobalPidRecord): Promise<string> 
     `    ay claude --model opus --advisor fable -- "<prompt>"    complex task\n` +
     `    (pick --model by task complexity so easy tasks don't cost like hard ones;\n` +
     `     --advisor is a claude-cli flag — only takes effect for claude/cy)\n` +
-    `  List your sub-agents:\n` +
-    `    ay ls                                   children render indented under your own pid\n` +
-    `    ay ls --cwd <dir>                       scope the tree to one workspace\n` +
-    `  Watch all your sub-agents at once:\n` +
-    `    ay ls --watch                           NDJSON stream of state changes across every\n` +
-    `                                              matched agent — one watcher for the whole\n` +
-    `                                              fan-out instead of N \`ay status --watch\`es\n` +
+    `  List agents (your children nest under your own pid in the tree):\n` +
+    `    ay ls --cwd ${shortenPath(self.cwd)}\n` +
+    `  Watch agent state changes, scoped to your workspace:\n` +
+    `    ay ls --watch --cwd ${shortenPath(self.cwd)}\n` +
+    `    (NDJSON stream of state changes across every matched agent — one watcher\n` +
+    `     for the whole fan-out instead of N \`ay status --watch\`es)\n` +
     `  Read one sub-agent's output:\n` +
     `    ay tail -f <pid>                        follow live output (no single command tails\n` +
     `                                              many agents' content at once yet — loop\n` +


### PR DESCRIPTION
## Summary
- `ay -h` / `ay help` now detects when it's running inside an agent (`AGENT_YES_PID` set) and prepends a banner: who you are (pid/cli/cwd), who spawned you (parent pid/cli/cwd, or "top-level agent"), and concrete guidance for spawning/listing/watching/tailing sub-agents.
- Spawn guidance recommends `--model` by task complexity (sonnet for routine sub-agent work, opus for complex tasks) and notes `--advisor` as a claude-cli-only flag (claude/cy).
- A human shell (no `AGENT_YES_PID`) sees the help output unchanged.

## Test plan
- [x] `bunx vitest run --coverage.enabled=false` — 599 passed, 1 skipped, 0 failed
- [x] Manually verified `ay -h` inside a live agent-yes session (shows real self/parent identity) and via `env -u AGENT_YES_PID ay -h` (plain output, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)