### PR TITLE
feat(auto-retry): gate the scheduled retry on a quiet period, not just backoff

### DIFF
--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -570,6 +570,7 @@ impl AgentContext {
                             // Forward Ctrl+C to agent — a live TUI redraws (e.g.
                             // an interrupt prompt), so treat it as a liveness poke.
                             send_ctrl_c(&writer)?;
+                            self.idle_waiter.ping();
                             self.mark_stdin_sent();
                         }
                     }

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -33,6 +33,14 @@ const RETRY_BASE_SECS: u64 = 8; // first backoff; doubles each consecutive failu
 /// screen (output → idle resets → stall clears) well within this window.
 const STALL_ESC_GRACE_SECS: u64 = 30;
 const RETRY_MAX_DELAY_SECS: u64 = 256; // cap per-retry backoff: 8,16,32,…,256 then hold
+
+/// Minimum quiet time (no PTY output, no forwarded stdin — see idle_waiter.ping()
+/// call sites) required before a scheduled auto-retry may actually fire, on top
+/// of the backoff delay above. The backoff schedule alone can elapse while the
+/// user is mid-typing into the prompt; typing "retry" + Enter over that would
+/// submit a mangled line. Deliberately short — this only debounces against
+/// active typing, not a real excuse to delay recovery.
+const RETRY_MIN_IDLE_MS: u64 = 5_000;
 const RETRY_GIVE_UP_SECS: u64 = 8 * 3600; // stop after 8h (claude's usage window is ~5h)
 
 /// What the no-output watchdog should do this tick. Pure decision so it can be
@@ -76,6 +84,13 @@ fn retry_backoff_secs(streak: u32) -> u64 {
     RETRY_BASE_SECS
         .saturating_mul(1u64 << shift)
         .min(RETRY_MAX_DELAY_SECS)
+}
+
+/// Whether a scheduled auto-retry may actually fire: the agent must be sitting
+/// idle at a ready prompt (not mid-work) AND the terminal must have been quiet
+/// for at least `min_idle_ms` — see RETRY_MIN_IDLE_MS.
+fn should_fire_retry(working: bool, ready: bool, idle_ms: u64, min_idle_ms: u64) -> bool {
+    !working && ready && idle_ms >= min_idle_ms
 }
 
 /// Agent context - centralized session state
@@ -896,11 +911,15 @@ impl AgentContext {
                 self.auto_retry_streak = 0;
             } else if now >= next_at {
                 // Re-render the screen to confirm the agent is idle at a prompt —
-                // never type "retry" while it's busy (e.g. the CLI's own retry).
+                // never type "retry" while it's busy (e.g. the CLI's own retry) —
+                // and require a few quiet seconds on top of the backoff delay, so
+                // a scheduled retry doesn't collide with a line the user is
+                // actively typing (see RETRY_MIN_IDLE_MS).
                 let screen = self.vterm.contents();
                 let working = self.cli_config.working.iter().any(|p| p.is_match(&screen));
                 let ready = self.cli_config.ready.iter().any(|p| p.is_match(&screen));
-                if working || !ready {
+                let idle_ms = self.idle_waiter.idle_time_ms();
+                if !should_fire_retry(working, ready, idle_ms, RETRY_MIN_IDLE_MS) {
                     self.auto_retry_next_at = Some(now + Duration::from_millis(500));
                 } else {
                     self.auto_retry_streak = self.auto_retry_streak.saturating_add(1);
@@ -1315,6 +1334,20 @@ mod tests {
         // capped at RETRY_MAX_DELAY_SECS, and no shift overflow for large streaks
         assert_eq!(retry_backoff_secs(6), 256);
         assert_eq!(retry_backoff_secs(50), 256);
+    }
+
+    #[test]
+    fn test_should_fire_retry_requires_ready_not_working_and_quiet() {
+        // Busy — never fire even if otherwise ready and quiet.
+        assert!(!should_fire_retry(true, true, 10_000, 5_000));
+        // Not at a recognized ready prompt — don't fire.
+        assert!(!should_fire_retry(false, false, 10_000, 5_000));
+        // Ready and idle, but the quiet window hasn't elapsed yet (user may
+        // still be mid-typing) — defer.
+        assert!(!should_fire_retry(false, true, 4_999, 5_000));
+        // Ready, idle, and past the quiet window — fire.
+        assert!(should_fire_retry(false, true, 5_000, 5_000));
+        assert!(should_fire_retry(false, true, 10_000, 5_000));
     }
 
     #[test]

--- a/ts/autoRetry.spec.ts
+++ b/ts/autoRetry.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { AUTO_RETRY_MAX_DELAY_SECS, autoRetryBackoffMs } from "./autoRetry.ts";
+import { AUTO_RETRY_MAX_DELAY_SECS, autoRetryBackoffMs, shouldFireRetry } from "./autoRetry.ts";
 
 describe("autoRetryBackoffMs", () => {
   it("doubles 8,16,32,…,256 then caps", () => {
@@ -15,5 +15,20 @@ describe("autoRetryBackoffMs", () => {
     expect(autoRetryBackoffMs(6)).toBe(AUTO_RETRY_MAX_DELAY_SECS * 1000);
     expect(autoRetryBackoffMs(50)).toBe(AUTO_RETRY_MAX_DELAY_SECS * 1000);
     expect(Number.isFinite(autoRetryBackoffMs(1000))).toBe(true);
+  });
+});
+
+describe("shouldFireRetry", () => {
+  it("requires ready + not working + past the idle window", () => {
+    // Busy — never fire even if otherwise ready and quiet.
+    expect(shouldFireRetry(true, true, 10_000, 5_000)).toBe(false);
+    // Not at a recognized ready prompt — don't fire.
+    expect(shouldFireRetry(false, false, 10_000, 5_000)).toBe(false);
+    // Ready and idle, but the quiet window hasn't elapsed yet (user may still
+    // be mid-typing) — defer.
+    expect(shouldFireRetry(false, true, 4_999, 5_000)).toBe(false);
+    // Ready, idle, and past the quiet window — fire.
+    expect(shouldFireRetry(false, true, 5_000, 5_000)).toBe(true);
+    expect(shouldFireRetry(false, true, 10_000, 5_000)).toBe(true);
   });
 });

--- a/ts/autoRetry.ts
+++ b/ts/autoRetry.ts
@@ -8,9 +8,32 @@ export const AUTO_RETRY_BASE_SECS = 8; // first backoff; doubles each consecutiv
 export const AUTO_RETRY_MAX_DELAY_SECS = 256; // cap: 8,16,32,…,256 then hold
 export const AUTO_RETRY_GIVE_UP_MS = 8 * 3600 * 1000; // stop after 8h (claude's usage window is ~5h)
 
+// Minimum quiet time (no CLI output, no forwarded stdin — see idleWaiter.ping()
+// call sites) required before a scheduled auto-retry may actually fire, on top
+// of the backoff delay above. The backoff schedule alone can elapse while the
+// user is mid-typing into the prompt; typing "retry" + Enter over that would
+// submit a mangled line. Deliberately short — this only debounces against
+// active typing, not a real excuse to delay recovery.
+export const AUTO_RETRY_MIN_IDLE_MS = 5_000;
+
 /** Backoff (ms) before the Nth consecutive auto-retry — doubles, then caps. */
 export function autoRetryBackoffMs(streak: number): number {
   const shift = Math.min(streak, 20); // guard against absurd streaks blowing up 2 ** n
   const secs = Math.min(AUTO_RETRY_BASE_SECS * 2 ** shift, AUTO_RETRY_MAX_DELAY_SECS);
   return secs * 1000;
+}
+
+/**
+ * Whether a scheduled auto-retry may actually fire: the agent must be sitting
+ * idle at a ready prompt (not mid-work) AND the terminal must have been quiet
+ * for at least `minIdleMs` — see AUTO_RETRY_MIN_IDLE_MS. Mirrors Rust's
+ * should_fire_retry in rs/src/context.rs.
+ */
+export function shouldFireRetry(
+  working: boolean,
+  ready: boolean,
+  idleMs: number,
+  minIdleMs: number,
+): boolean {
+  return !working && ready && idleMs >= minIdleMs;
 }

--- a/ts/core/messaging.ts
+++ b/ts/core/messaging.ts
@@ -32,7 +32,10 @@ export async function sendEnter(context: MessageContext, waitms = 1000) {
       context.nextStdout.wait(),
       new Promise<void>((resolve) =>
         setTimeout(() => {
-          if (!context.nextStdout.isReady) context.shell.write("\r");
+          if (!context.nextStdout.isReady) {
+            context.shell.write("\r");
+            context.idleWaiter.ping();
+          }
           resolve();
         }, ms),
       ),

--- a/ts/core/messaging.ts
+++ b/ts/core/messaging.ts
@@ -24,6 +24,7 @@ export async function sendEnter(context: MessageContext, waitms = 1000) {
   logger.debug(`sendEnter| idleWait took ${String(Date.now() - st)}ms`);
   context.nextStdout.unready();
   context.shell.write("\r");
+  context.idleWaiter.ping(); // mirrors sendMessage — a programmatic Enter is activity too
 
   // Retry Enter if no stdout received within escalating timeouts
   for (const ms of [1000, 3000]) {

--- a/ts/idleWaiter.spec.ts
+++ b/ts/idleWaiter.spec.ts
@@ -59,6 +59,18 @@ describe("IdleWaiter", () => {
     expect(result).toBe(waiter);
   });
 
+  it("idleTimeMs reflects elapsed time since the last ping", async () => {
+    const waiter = new IdleWaiter();
+    waiter.ping();
+    expect(waiter.idleTimeMs()).toBeLessThan(20);
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(waiter.idleTimeMs()).toBeGreaterThanOrEqual(50);
+
+    waiter.ping();
+    expect(waiter.idleTimeMs()).toBeLessThan(20);
+  });
+
   it("should wait until idle period has passed", async () => {
     const waiter = new IdleWaiter();
     waiter.checkInterval = 10;

--- a/ts/idleWaiter.ts
+++ b/ts/idleWaiter.ts
@@ -24,6 +24,11 @@ export class IdleWaiter {
     return this;
   }
 
+  /** Milliseconds since the last ping. */
+  idleTimeMs() {
+    return Date.now() - this.lastActivityTime;
+  }
+
   async wait(ms: number) {
     while (this.lastActivityTime >= Date.now() - ms)
       await new Promise((resolve) => setTimeout(resolve, this.checkInterval));

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1114,8 +1114,13 @@ export default async function agentYes({
       readable: xtermProxy.readable,
     })
 
-    .forEach(() => {
-      ctx.idleWaiter.ping();
+    .forEach((chunk) => {
+      // Only ping activity if there's visible content (not just ANSI/cursor
+      // control sequences) — mirrors the Rust runtime's handle_output gate.
+      // Without this, periodic control-only chatter (e.g. cursor position
+      // queries) would keep resetting the auto-retry idle clock and the
+      // scheduled retry could defer indefinitely without ever firing.
+      if (removeControlCharacters(chunk).trim()) ctx.idleWaiter.ping();
       pidStore.updateStatus(shell.pid, "active").catch(() => null);
       ctx.nextStdout.ready();
     })

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -18,7 +18,12 @@ import { logger } from "./logger.ts";
 import { createFifoStream } from "./beta/fifo.ts";
 import { PidStore } from "./pidStore.ts";
 import { sendEnter, sendMessage } from "./core/messaging.ts";
-import { AUTO_RETRY_GIVE_UP_MS, autoRetryBackoffMs } from "./autoRetry.ts";
+import {
+  AUTO_RETRY_GIVE_UP_MS,
+  AUTO_RETRY_MIN_IDLE_MS,
+  autoRetryBackoffMs,
+  shouldFireRetry,
+} from "./autoRetry.ts";
 import {
   initializeLogPaths,
   setupDebugLogging,
@@ -805,8 +810,12 @@ export default async function agentYes({
         } else if (now >= retryNextAt) {
           const working = conf.working?.some((rx: RegExp) => rx.test(autoRetryScreen)) ?? false;
           const readyNow = conf.ready?.some((rx: RegExp) => rx.test(autoRetryScreen)) ?? false;
-          if (working || !readyNow) {
-            retryNextAt = now + 500; // busy / not at prompt — re-check shortly
+          // Also require a few quiet seconds on top of the backoff delay, so a
+          // scheduled retry doesn't collide with a line the user is actively
+          // typing into the prompt (see AUTO_RETRY_MIN_IDLE_MS).
+          const idleMs = ctx.idleWaiter.idleTimeMs();
+          if (!shouldFireRetry(working, readyNow, idleMs, AUTO_RETRY_MIN_IDLE_MS)) {
+            retryNextAt = now + 500; // busy / not at prompt / still active — re-check shortly
           } else {
             retryStreak += 1;
             logger.warn(`[${cli}-yes] auto-retry: typing 'retry' (attempt ${retryStreak})`);
@@ -1096,6 +1105,10 @@ export default async function agentYes({
         write: async (data) => {
           await ctx.stdinReady.wait();
           shell.write(data);
+          // Forwarded user input counts as activity too (mirrors the Rust
+          // runtime's ping on stdin forward) — the auto-retry idle gate below
+          // must not fire while the user is actively typing.
+          ctx.idleWaiter.ping();
         },
       }),
       readable: xtermProxy.readable,

--- a/ts/removeControlCharacters.spec.ts
+++ b/ts/removeControlCharacters.spec.ts
@@ -70,4 +70,10 @@ describe("removeControlCharacters", () => {
     const expected = "TextClearLine";
     expect(removeControlCharacters(input)).toBe(expected);
   });
+
+  it("should remove OSC sequences (e.g. window title updates)", () => {
+    const input = "Before\u001b]0;window title\u0007After";
+    const expected = "BeforeAfter";
+    expect(removeControlCharacters(input)).toBe(expected);
+  });
 });

--- a/ts/removeControlCharacters.spec.ts
+++ b/ts/removeControlCharacters.spec.ts
@@ -81,4 +81,14 @@ describe("removeControlCharacters", () => {
     const input = "Before\u001b]0;titleAfter";
     expect(removeControlCharacters(input)).toBe(input);
   });
+
+  it("should remove OSC sequences terminated by ST (ESC backslash), not just BEL", () => {
+    const input = "Before\u001b]8;;https://example.com\u001b\\After";
+    expect(removeControlCharacters(input)).toBe("BeforeAfter");
+  });
+
+  it("does not let an ST-terminated OSC run on and eat real text before a later BEL", () => {
+    const input = "Before\u001b]0;t\u001b\\visible\u0007After";
+    expect(removeControlCharacters(input)).toBe("Beforevisible\u0007After");
+  });
 });

--- a/ts/removeControlCharacters.spec.ts
+++ b/ts/removeControlCharacters.spec.ts
@@ -76,4 +76,9 @@ describe("removeControlCharacters", () => {
     const expected = "BeforeAfter";
     expect(removeControlCharacters(input)).toBe(expected);
   });
+
+  it("does NOT strip trailing text when an OSC sequence is unterminated (no BEL)", () => {
+    const input = "Before\u001b]0;titleAfter";
+    expect(removeControlCharacters(input)).toBe(input);
+  });
 });

--- a/ts/removeControlCharacters.ts
+++ b/ts/removeControlCharacters.ts
@@ -7,7 +7,10 @@ const BEL = String.fromCharCode(0x07);
 // covered by the CSI pattern below — without this, e.g. a periodic title
 // update would count as "visible" content to callers that gate activity on
 // non-empty output.
-const OSC_PATTERN = new RegExp(ESC + "][^" + BEL + "]*" + BEL + "?", "g");
+// BEL is required, not optional: an unterminated ESC]... (BEL never arrives,
+// e.g. a truncated chunk boundary) must NOT strip through to end-of-string —
+// that would eat real trailing text as if it were part of the title sequence.
+const OSC_PATTERN = new RegExp(ESC + "][^" + BEL + "]*" + BEL, "g");
 
 // Matches control characters in the C0 and C1 ranges, including Delete (U+007F)
 const CSI_PATTERN = new RegExp(

--- a/ts/removeControlCharacters.ts
+++ b/ts/removeControlCharacters.ts
@@ -1,8 +1,20 @@
+const ESC = String.fromCharCode(0x1b);
+const C1 = String.fromCharCode(0x9b);
+const BEL = String.fromCharCode(0x07);
+
+// OSC sequences (window/tab title updates, hyperlinks, etc.): ESC ] ... BEL.
+// Terminated by BEL (the common case for real-world terminal apps); not
+// covered by the CSI pattern below — without this, e.g. a periodic title
+// update would count as "visible" content to callers that gate activity on
+// non-empty output.
+const OSC_PATTERN = new RegExp(ESC + "][^" + BEL + "]*" + BEL + "?", "g");
+
+// Matches control characters in the C0 and C1 ranges, including Delete (U+007F)
+const CSI_PATTERN = new RegExp(
+  "[" + ESC + C1 + "][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]",
+  "g",
+);
+
 export function removeControlCharacters(str: string): string {
-  // Matches control characters in the C0 and C1 ranges, including Delete (U+007F)
-  return str.replace(
-    // eslint-disable-next-line no-control-regex This is a control regex
-    /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
-    "",
-  );
+  return str.replace(OSC_PATTERN, "").replace(CSI_PATTERN, "");
 }

--- a/ts/removeControlCharacters.ts
+++ b/ts/removeControlCharacters.ts
@@ -1,16 +1,27 @@
 const ESC = String.fromCharCode(0x1b);
 const C1 = String.fromCharCode(0x9b);
 const BEL = String.fromCharCode(0x07);
+const BACKSLASH = String.fromCharCode(0x5c);
+// String Terminator (ESC \) as REGEX SOURCE text: a literal backslash inside a
+// regex pattern is itself an escape character, so matching one literal
+// backslash requires two backslash characters in the pattern source.
+const ST_PATTERN_SOURCE = ESC + BACKSLASH + BACKSLASH;
 
-// OSC sequences (window/tab title updates, hyperlinks, etc.): ESC ] ... BEL.
-// Terminated by BEL (the common case for real-world terminal apps); not
-// covered by the CSI pattern below — without this, e.g. a periodic title
-// update would count as "visible" content to callers that gate activity on
-// non-empty output.
-// BEL is required, not optional: an unterminated ESC]... (BEL never arrives,
-// e.g. a truncated chunk boundary) must NOT strip through to end-of-string —
-// that would eat real trailing text as if it were part of the title sequence.
-const OSC_PATTERN = new RegExp(ESC + "][^" + BEL + "]*" + BEL, "g");
+// OSC sequences (window/tab title updates, hyperlinks, etc.): ESC ] ...
+// terminated by either BEL or ST (ESC \) — both are valid per-spec and used
+// by real terminal apps. Not covered by the CSI pattern below — without this,
+// e.g. a periodic title update would count as "visible" content to callers
+// that gate activity on non-empty output.
+// The terminator is required, not optional: an unterminated ESC]... (the
+// terminator never arrives, e.g. a truncated chunk boundary) must NOT strip
+// through to end-of-string — that would eat real trailing text as if it were
+// part of the title sequence. The body excludes ESC too (not just BEL) so an
+// ST-terminated sequence can't accidentally run on and swallow real text up
+// to some unrelated, later BEL.
+const OSC_PATTERN = new RegExp(
+  ESC + "][^" + BEL + ESC + "]*(?:" + BEL + "|" + ST_PATTERN_SOURCE + ")",
+  "g",
+);
 
 // Matches control characters in the C0 and C1 ranges, including Delete (U+007F)
 const CSI_PATTERN = new RegExp(


### PR DESCRIPTION
## Summary
- The auto-retry feature (types "retry" on a recoverable overload/rate-limit error) previously fired purely on an exponential backoff timer + a working/ready screen check. That backoff timer can elapse while the user is actively typing into the prompt, so the scheduled "retry" + Enter could interleave with — or submit — a line the user was still composing.
- Added `should_fire_retry`/`shouldFireRetry` (mirrored in `rs/src/context.rs` and `ts/autoRetry.ts`): the retry now also requires the terminal to have been quiet (no CLI output, no forwarded stdin) for at least 5s (`RETRY_MIN_IDLE_MS` / `AUTO_RETRY_MIN_IDLE_MS`) on top of the existing backoff + ready-prompt check.
- The TS runtime's `idleWaiter` previously only pinged on CLI *output* (not on forwarded user input); added a matching `ping()` on the stdin-forward path so its idle clock tracks user activity the same way the Rust runtime's already did.

## Test plan
- [x] `cargo test --manifest-path rs/Cargo.toml` — 243 unit + 10 integration tests pass, including the existing `test_auto_retry_types_retry_on_overload` and the new `test_should_fire_retry_requires_ready_not_working_and_quiet`
- [x] `bunx vitest run --coverage.enabled=false` — 611 passed, 1 skipped, including the full `shared-e2e.spec.ts` (ts vs rs parity) suite and new `shouldFireRetry`/`idleTimeMs` unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)