### PR TITLE
feat(console): status-flag badges matched against an agent's last screen

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -180,6 +180,22 @@ export function taskLabel(e) {
   return `${t.done}/${t.total}`;
 }
 
+// Display metadata for status flags matched server-side against an agent's
+// screen (ts/badges.ts BADGE_DEFS — matching runs server-side; the API sends
+// just the matched ids in e.badges). Keep the label/title text here in sync
+// with ts/badges.ts. An id with no entry still renders (falls back to the raw
+// id), so a newly-added server-side badge is never silently dropped.
+export const BADGE_META = {
+  "goal-active": { label: "goal", title: "A /goal Stop-hook loop is active on this agent" },
+};
+
+// Status-flag chips ("badges") matched against the agent's screen — e.g. an
+// active /goal loop. [] when e.badges is missing/empty. Returns
+// { id, label, title } objects ready for the caller to render as chips.
+export function badgesFor(e) {
+  return (e.badges || []).map((id) => ({ id, ...(BADGE_META[id] || { label: id, title: id }) }));
+}
+
 // Human age of an agent ("12s" / "5m" / "3h"). `now` is injectable so tests
 // don't depend on the wall clock; the browser calls age(e) and gets Date.now().
 export function age(e, now = Date.now()) {

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -891,6 +891,20 @@
         color: var(--green);
         border-color: #2a3a2a;
       }
+      /* Status-flag chip ("badge") matched server-side against the agent's
+         screen — e.g. an active /goal loop (ts/badges.ts). Same pill shape as
+         .tasks but accent-colored so a matched flag stands out as a distinct
+         signal, not just a counter. */
+      .flag {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        color: var(--accent);
+        white-space: nowrap;
+        flex: none;
+        padding: 0 5px;
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+      }
       /* The pending question when an agent needs_input — blue accent to match the
          needs_input dot, reading as "your turn / here's what it's asking". */
       .detail.ask {
@@ -1543,6 +1557,7 @@
         sortEntries,
         SORT_MODES,
         taskLabel,
+        badgesFor,
         hashHue,
         selFromBottom,
         parseSel,
@@ -3219,6 +3234,17 @@
         return `<span class="tasks${allDone ? " done" : ""}" title="${esc(tip)}">${esc(label)}</span>`;
       }
 
+      // Status-flag chips ("badges") matched server-side against the agent's
+      // screen (ts/badges.ts) — e.g. an active /goal loop. One small pill per
+      // matched flag; "" when none matched. CSS class is "flag" (not "badge")
+      // to avoid colliding with the existing pid pill's .badge class. See
+      // BADGE_META in console-logic.js for the id → label/title mapping.
+      function badgeChipsHtml(e) {
+        return badgesFor(e)
+          .map((b) => `<span class="flag" title="${esc(b.title)}">${esc(b.label)}</span>`)
+          .join("");
+      }
+
       // A room/peer group header row. Non-selectable; carries the same tree rails
       // as agent rows so the hierarchy reads as one tree. The room/peer layers
       // only appear here when there are ≥2 of them (single ones fold away in
@@ -3268,6 +3294,7 @@
         ${cli ? `<span class="cname">${esc(cli)}</span>` : ""}
         <span class="ctitle ${e.title ? "" : "dim"}" title="${esc(t)}">${esc(t)}</span>
         ${taskChipHtml(e)}
+        ${badgeChipsHtml(e)}
         ${gitChipHtml(e)}
         <span class="age">${age(e)}</span></div>`;
               })
@@ -3293,6 +3320,7 @@
           <span class="name">${esc(cliLabel(e) || ident(e) || "agent")}</span>
           <span class="badge">pid ${e.pid}</span>
           ${taskChipHtml(e)}
+          ${badgeChipsHtml(e)}
           ${gitChipHtml(e)}
           <span class="age">${age(e)}</span></div>
         ${e.title ? `<div class="rowtitle" title="${esc(e.title)}">${esc(e.title)}</div>` : ""}

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -24,6 +24,7 @@ import {
   sortEntries,
   SORT_MODES,
   taskLabel,
+  badgesFor,
   hashHue,
   selFromBottom,
   parseSel,
@@ -460,6 +461,32 @@ describe("taskLabel (progress badge)", () => {
     expect(taskLabel({})).toBe("");
     expect(taskLabel({ tasks: null })).toBe("");
     expect(taskLabel({ tasks: { done: 0, total: 0 } })).toBe("");
+  });
+});
+
+describe("badgesFor (status flag chips)", () => {
+  it("returns [] when e.badges is missing or empty", () => {
+    expect(badgesFor({})).toEqual([]);
+    expect(badgesFor({ badges: [] })).toEqual([]);
+  });
+
+  it("resolves a known id to its label + title", () => {
+    expect(badgesFor({ badges: ["goal-active"] })).toEqual([
+      { id: "goal-active", label: "goal", title: "A /goal Stop-hook loop is active on this agent" },
+    ]);
+  });
+
+  it("falls back to the raw id for an unknown badge (never silently dropped)", () => {
+    expect(badgesFor({ badges: ["some-future-flag"] })).toEqual([
+      { id: "some-future-flag", label: "some-future-flag", title: "some-future-flag" },
+    ]);
+  });
+
+  it("preserves order and handles multiple badges", () => {
+    expect(badgesFor({ badges: ["goal-active", "some-future-flag"] }).map((b) => b.id)).toEqual([
+      "goal-active",
+      "some-future-flag",
+    ]);
   });
 });
 

--- a/ts/badges.spec.ts
+++ b/ts/badges.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { badgeDef, BADGE_DEFS, matchBadges, type BadgeDef } from "./badges.ts";
+
+describe("matchBadges", () => {
+  it("matches goal-active when the /goal status line is on screen", () => {
+    const lines = ["some output", "/goal active (42s)", "more output"];
+    expect(matchBadges(lines)).toEqual(["goal-active"]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchBadges(["/GOAL ACTIVE (1s)"])).toEqual(["goal-active"]);
+  });
+
+  it("returns empty when nothing matches", () => {
+    expect(matchBadges(["just some regular CLI output", "nothing special here"])).toEqual([]);
+  });
+
+  it("returns empty for an empty screen", () => {
+    expect(matchBadges([])).toEqual([]);
+  });
+
+  it("matches across a join boundary between lines (pattern spans the joined text)", () => {
+    // Sanity: matchBadges joins lines with \n before testing, so a pattern that
+    // doesn't care about line boundaries still finds a hit split across two lines.
+    const defs: BadgeDef[] = [{ id: "spans", label: "x", title: "t", pattern: /foo\nbar/ }];
+    expect(matchBadges(["foo", "bar"], defs)).toEqual(["spans"]);
+  });
+
+  it("supports custom def sets independent of the built-in BADGE_DEFS", () => {
+    const defs: BadgeDef[] = [
+      { id: "custom-error", label: "err", title: "custom error banner", pattern: /FATAL: boom/ },
+    ];
+    expect(matchBadges(["FATAL: boom"], defs)).toEqual(["custom-error"]);
+    expect(matchBadges(["FATAL: boom"])).toEqual([]); // not in the default set
+  });
+
+  it("can match multiple badges at once, in def order", () => {
+    const defs: BadgeDef[] = [
+      { id: "a", label: "a", title: "a", pattern: /alpha/ },
+      { id: "b", label: "b", title: "b", pattern: /beta/ },
+    ];
+    expect(matchBadges(["alpha and beta both here"], defs)).toEqual(["a", "b"]);
+  });
+});
+
+describe("badgeDef", () => {
+  it("looks up a built-in definition by id", () => {
+    expect(badgeDef("goal-active")).toBe(BADGE_DEFS[0]);
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(badgeDef("does-not-exist")).toBeUndefined();
+  });
+});

--- a/ts/badges.ts
+++ b/ts/badges.ts
@@ -1,0 +1,42 @@
+/**
+ * Badge/flag matchers: small regex patterns run against an agent's last
+ * rendered screen (the same tail window `ay tail` shows — see
+ * extractBadges in subcommands.ts) to surface a short status chip in the
+ * web console's agent list. Extensible: add more entries to BADGE_DEFS as
+ * useful patterns turn up (a known error banner, a loop-state flag, etc.).
+ * Pure and CLI-agnostic — a definition just won't match on CLIs that never
+ * print its pattern.
+ */
+
+export interface BadgeDef {
+  /** Stable id, used as the wire value and as the key when re-deriving the label. */
+  id: string;
+  /** Short chip text, e.g. "goal". Keep it a couple of characters — the chip is tiny. */
+  label: string;
+  /** Tooltip shown on hover, explaining what the badge means. */
+  title: string;
+  /** Matched against the tail-rendered screen text (lines joined with \n). */
+  pattern: RegExp;
+}
+
+export const BADGE_DEFS: BadgeDef[] = [
+  {
+    id: "goal-active",
+    label: "goal",
+    title: "A /goal Stop-hook loop is active on this agent",
+    pattern: /\/goal active/i,
+  },
+];
+
+/**
+ * Which badge ids match the given rendered screen lines. Pure so it's
+ * unit-tested without a live PTY/log file.
+ */
+export function matchBadges(lines: string[], defs: BadgeDef[] = BADGE_DEFS): string[] {
+  const text = lines.join("\n");
+  return defs.filter((d) => d.pattern.test(text)).map((d) => d.id);
+}
+
+export function badgeDef(id: string, defs: BadgeDef[] = BADGE_DEFS): BadgeDef | undefined {
+  return defs.find((d) => d.id === id);
+}

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -9,6 +9,7 @@ import yargs from "yargs";
 import {
   controlCodeFromName,
   deriveLiveStatus,
+  extractBadges,
   extractNeedsInput,
   extractTaskCounts,
   listRecords,
@@ -935,6 +936,26 @@ export async function cmdServe(rest: string[]): Promise<number> {
     }
   };
 
+  // Per-agent status badges/flags (see badges.ts) matched against the agent's
+  // rendered screen — e.g. an active /goal Stop-hook loop. Cached per
+  // (size, mtime) exactly like logTasks. Extend BADGE_DEFS in badges.ts to
+  // surface more patterns (error banners, other flags); no server changes
+  // needed beyond that.
+  const badgeCache = new Map<string, { size: number; mtimeMs: number; badges: string[] }>();
+  const logBadges = async (logFile: string | null | undefined): Promise<string[]> => {
+    if (!logFile) return [];
+    try {
+      const { size, mtimeMs } = await stat(logFile);
+      const hit = badgeCache.get(logFile);
+      if (hit && hit.size === size && hit.mtimeMs === mtimeMs) return hit.badges;
+      const badges = await extractBadges(logFile);
+      badgeCache.set(logFile, { size, mtimeMs, badges });
+      return badges;
+    } catch {
+      return [];
+    }
+  };
+
   // Per-agent "waiting on you" detection: the agent is parked on an interactive
   // menu it did NOT auto-resolve (config `needsInput` patterns). Same source and
   // classifier as `ay ls` / `ay status`, so the console's dot matches the CLI's
@@ -1148,6 +1169,9 @@ export async function cmdServe(rest: string[]): Promise<number> {
       // Task progress from the rendered todo block (null when none detected → no
       // badge). Skipped for exited agents — their screen is no longer live.
       tasks: status === "exited" ? null : await logTasks(r.log_file),
+      // Status flags matched against the rendered screen (see badges.ts) — e.g.
+      // an active /goal loop. [] when none matched or for exited agents.
+      badges: status === "exited" ? [] : await logBadges(r.log_file),
     };
   };
 

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -18,6 +18,7 @@ import path from "path";
 import { type GlobalPidRecord, readGlobalPids, updateGlobalPidStatus } from "./globalPidIndex.ts";
 import { buildAgentForest, flattenForest } from "./agentTree.ts";
 import { parseTaskCounts, type TaskCounts } from "./todoParse.ts";
+import { matchBadges } from "./badges.ts";
 import {
   classifyNeedsInput,
   isWorkingScreen,
@@ -2126,6 +2127,17 @@ export async function extractNeedsInput(logPath: string, cli: string): Promise<N
   const lines = await renderLogTailLines(logPath, 40);
   if (!lines) return null;
   return classifyNeedsInput(lines, { needsInput: cfg.needsInput, working: cfg.working });
+}
+
+/**
+ * Which badges (see badges.ts) match an agent's current screen — the same 32 KB
+ * tail window `ay tail` renders, no CLI-specific config needed. Returns [] on
+ * any read/render error or an empty log, same failure shape as extractNeedsInput.
+ */
+export async function extractBadges(logPath: string): Promise<string[]> {
+  const lines = await renderLogTailLines(logPath, 40);
+  if (!lines) return [];
+  return matchBadges(lines);
 }
 
 /**


### PR DESCRIPTION
## Summary
Extensible pattern → badge system for the web console's sidepanel: a small regex registry (`ts/badges.ts` `BADGE_DEFS`) is matched against the same 32 KB tail window `ay tail` already renders — no full-history scan needed (last-screen matching is enough per scope). Ships with one built-in badge (`goal-active`, matching `/goal active`), designed to grow: add a `{ id, label, title, pattern }` entry to `BADGE_DEFS` (+ a matching label/title in `console-logic.js`'s `BADGE_META`) to surface any future flag or error banner as a chip — no other wiring required.

- `ts/badges.ts`: pure `matchBadges(lines) -> id[]`, unit tested.
- `ts/subcommands.ts`: `extractBadges(logPath)` reuses the same tail-render helper as `extractNeedsInput`/`extractTaskCounts`.
- `ts/serve.ts`: `withMeta` gains a `badges: string[]` field, cached per (size, mtime) exactly like the existing `tasks`/`needsInput` caches — the console already diffs the full `withMeta` JSON per agent, so this participates in `/api/ls/subscribe`'s change detection for free.
- `lab/ui/console-logic.js` + `index.html`: `badgesFor()`/`BADGE_META` (id → label + tooltip) and a small pill chip (`.flag`, distinct from the existing `.badge` pid-pill class) rendered next to the task/git chips in both compact and full row layouts.

## Test plan
- [x] `bunx vitest run --coverage.enabled=false` — 628 passed, 1 skipped (incl. 9 new `ts/badges.spec.ts` tests + 4 new `console-logic.spec.ts` `badgesFor` tests)
- [x] Live end-to-end: `extractBadges()` against a real running agent's raw log correctly returns `[]` normally, and `["goal-active"]` once the pattern is appended to a copy of the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)