### PR TITLE
fix(test): eliminate runningLock self-block wait + hermetic shared-e2e AGENT_YES_PID

### DIFF
--- a/ts/needsInput.ts
+++ b/ts/needsInput.ts
@@ -78,7 +78,7 @@ export interface MenuState {
 
 // An option row: an optional cursor glyph / bullet, then "N. " (the trailing
 // space rejects version-like "3.5GB" that isn't a menu option).
-const OPTION_LINE = /^[\s❯›>▶◉○●·*\-]*?(\d+)\.\s/;
+const OPTION_LINE = /^[\s❯›>▶◉○●·*-]*?(\d+)\.\s/;
 
 /**
  * Parse the selection menu a `needs_input` agent is parked on into a cursor

--- a/ts/runningLock.ts
+++ b/ts/runningLock.ts
@@ -171,6 +171,7 @@ async function checkLock(cwd: string, _prompt: string): Promise<LockCheckResult>
 
   // Find running tasks for this location
   const blockingTasks = lockFile.tasks.filter((task) => {
+    if (task.pid === process.pid) return false; // Never self-block on our own prior entry
     if (!isProcessRunning(task.pid)) return false; // Skip stale locks
     if (task.status !== "running") return false; // Only check running tasks
 

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -2400,7 +2400,10 @@ export async function extractMenu(logPath: string, cli: string): Promise<MenuSta
 
 /** Poll until the agent is no longer parked on a menu (selection accepted → it
  * resumed / moved on) or the deadline passes. Returns true if it cleared. */
-async function waitForNeedsInputClear(record: GlobalPidRecord, timeoutMs: number): Promise<boolean> {
+async function waitForNeedsInputClear(
+  record: GlobalPidRecord,
+  timeoutMs: number,
+): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, 250));
@@ -2627,9 +2630,7 @@ async function cmdSelect(rest: string[]): Promise<number> {
   const keyword = argv._[0] !== undefined ? String(argv._[0]) : undefined;
   const n = Number(argv._[1]);
   if (!keyword || !Number.isInteger(n) || n < 1) {
-    throw new Error(
-      "usage: ay select <keyword> <N>   (N = the 1-based option number to choose)",
-    );
+    throw new Error("usage: ay select <keyword> <N>   (N = the 1-based option number to choose)");
   }
 
   const opts: CommonOpts = {
@@ -2641,7 +2642,9 @@ async function cmdSelect(rest: string[]): Promise<number> {
   };
   const record = await resolveWritableAgent(keyword, opts);
   if (!record.log_file) {
-    throw new Error(`pid ${record.pid}: no log_file recorded — can't read the menu to select from.`);
+    throw new Error(
+      `pid ${record.pid}: no log_file recorded — can't read the menu to select from.`,
+    );
   }
   const force = Boolean(argv.force) || process.env.AGENT_YES_FORCE_SEND === "1";
   await enforceSendGuards(record, force);
@@ -2653,9 +2656,7 @@ async function cmdSelect(rest: string[]): Promise<number> {
     );
   }
   if (menu.options.length > 0 && !menu.options.includes(n)) {
-    throw new Error(
-      `option ${n} is out of range — this menu offers ${menu.options.join(", ")}.`,
-    );
+    throw new Error(`option ${n} is out of range — this menu offers ${menu.options.join(", ")}.`);
   }
 
   // Move the cursor from where it sits to option N, then confirm. Delta from the
@@ -2665,7 +2666,8 @@ async function cmdSelect(rest: string[]): Promise<number> {
   await writeKeysPaced(record.fifo_file!, byteSeqs, Math.max(0, argv.pace));
 
   const delta = n - menu.cursor;
-  const moved = delta === 0 ? "cursor already there" : `${Math.abs(delta)}× ${delta > 0 ? "down" : "up"}`;
+  const moved =
+    delta === 0 ? "cursor already there" : `${Math.abs(delta)}× ${delta > 0 ? "down" : "up"}`;
   process.stdout.write(
     `pid ${record.pid} (${record.cli}): selected option ${n} (${moved} + enter)\n`,
   );

--- a/ts/tests/shared-e2e.spec.ts
+++ b/ts/tests/shared-e2e.spec.ts
@@ -38,8 +38,14 @@ function runAgentYes(
   const { cwd = ROOT, env, timeoutMs = 15_000 } = opts;
   const args = ["bun", AGENT_YES_CLI, ...implArgs, ...cliAndArgs];
   // Force the isolated home onto whatever env the caller passed, so no run ever
-  // touches the shared global ~/.agent-yes.
+  // touches the shared global ~/.agent-yes. Also strip AGENT_YES_PID: when this
+  // suite itself runs inside a nested agent-yes session (e.g. an agent developing
+  // agent-yes), that var leaks in via process.env and makes the spawned agent
+  // think IT is nested too — triggering fork-by-default (shouldForkNested in
+  // forkNested.ts) instead of running synchronously, which breaks every
+  // assertion that expects runAgentYes to block until the child exits.
   const runEnv: NodeJS.ProcessEnv = { ...process.env, ...env, AGENT_YES_HOME: E2E_HOME };
+  delete runEnv.AGENT_YES_PID;
 
   return new Promise((resolve) => {
     const proc = spawn(args[0]!, args.slice(1), { cwd, env: runEnv });


### PR DESCRIPTION
## Summary
Benchmarked the vitest suite (`bunx vitest run --reporter=json`) to find slow/flaky spots. Found and fixed two real bugs surfaced by the timing data, both no-tradeoff correctness fixes:

- **`ts/runningLock.ts`**: `checkLock()` didn't exclude the caller's own PID from `blockingTasks`, so a second `acquireLock()` call from the same process saw its own prior lock entry as a blocker and paid a needless fixed 2000ms poll wait (`POLL_INTERVAL`) before proceeding. A process should never self-block on its own lock entry. Fix cut the "should not duplicate tasks with same PID" test from ~2.1s to ~0.1s.
- **`ts/tests/shared-e2e.spec.ts`**: `runAgentYes()` spread the outer `process.env` (including `AGENT_YES_PID`) into every spawned test subprocess. When the suite itself runs inside a nested agent-yes session — which is common for this repo, since agent-yes is used to develop agent-yes — that leaks nested-agent context into the spawned test agent. Post-#151, that now triggers fork-by-default (`shouldForkNested`) instead of running synchronously, breaking every `[rs]` assertion that expects `runAgentYes` to block until the child exits. Reproduced 5 real failures this way; fixed by stripping `AGENT_YES_PID` from the child env, making the suite hermetic regardless of the invoking shell.

## Other findings (not changed — real production tradeoffs, flagging for a follow-up decision)
- `ts/index.ts:1310-1323` (`exitAgent()`) blocks up to 5000ms waiting for a CLI to voluntarily exit before force-killing. Rust's equivalent doesn't wait. This dominates the slowest e2e tests (`[ts] exits when idle timeout` ~9.5s, `[ts] detects ready pattern` ~9.4s) because the mock CLIs deliberately never respond to `/exit`. Shortening this would speed tests but risks killing real CLIs mid-cleanup — not changing without more signal.
- `ts/index.ts:899` — TS's fallback no-EOL heartbeat poll is 800ms vs Rust's `HEARTBEAT_INTERVAL_MS = 50`ms (`rs/src/context.rs:20`). 16x coarser; adds up to 800ms latency for CLIs whose ready pattern never gets a clean `\n`. Lowering it trades a small CPU increase for faster detection — worth considering separately.

## Test plan
- [x] `bunx vitest run` — 650 passed, 1 skipped, 0 failed (verified both with and without `AGENT_YES_PID` set in the invoking shell)
- [x] Pre-push hook's full coverage gate passed locally (90.5% branches)